### PR TITLE
Make a few minor tweaks

### DIFF
--- a/generate/resources/couchbase-server/scripts/couchbase-start
+++ b/generate/resources/couchbase-server/scripts/couchbase-start
@@ -4,7 +4,7 @@
 
 set -e
 
-if [ "$1" = 'couchbase' ]
+if [ "$1" = 'couchbase-server' ]
 then
 
     if [ "$(id -u)" != "0" ]; then
@@ -22,9 +22,9 @@ then
         var/lib/moxi
     chown -R couchbase:couchbase var
 
-    # Start couchbase, pass -noinput so it doesn't drop us in the erlang shell
+    # Start couchbase
     echo "Starting Couchbase Server -- Web UI available at http://<ip>:8091"
-    exec gosu couchbase /opt/couchbase/bin/couchbase-server -- -noinput
+    exec gosu couchbase "$@"
 fi
 
 exec "$@"

--- a/generate/templates/couchbase-server/Dockerfile.template
+++ b/generate/templates/couchbase-server/Dockerfile.template
@@ -1,18 +1,10 @@
-FROM centos:centos6.6
+FROM centos:6
 
 MAINTAINER Couchbase Docker Team <docker@couchbase.com>
-
-ENV CB_VERSION={{ .CB_VERSION }} \
-    CB_RELEASE_URL=http://packages.couchbase.com/releases \
-    CB_PACKAGE={{ .CB_PACKAGE }} \
-    PATH=$PATH:/opt/couchbase/bin:/opt/couchbase/bin/tools:/opt/couchbase/bin/install
 
 # Install yum dependencies
 RUN yum install -y tar \
     && yum clean all
-
-# Install couchbase
-RUN rpm --install $CB_RELEASE_URL/$CB_VERSION/$CB_PACKAGE
 
 # Install gosu for startup script
 RUN gpg --keyserver ha.pool.sks-keyservers.net --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4 \
@@ -22,9 +14,18 @@ RUN gpg --keyserver ha.pool.sks-keyservers.net --recv-keys B42F6819007F00F88E364
     && rm /usr/local/bin/gosu.asc \
     && chmod +x /usr/local/bin/gosu
 
+ENV CB_VERSION={{ .CB_VERSION }} \
+    CB_RELEASE_URL=http://packages.couchbase.com/releases \
+    CB_PACKAGE={{ .CB_PACKAGE }} \
+    PATH=$PATH:/opt/couchbase/bin:/opt/couchbase/bin/tools:/opt/couchbase/bin/install
+
+# Install couchbase
+RUN rpm --install $CB_RELEASE_URL/$CB_VERSION/$CB_PACKAGE
+
 COPY scripts/couchbase-start /usr/local/bin/
-ENTRYPOINT ["/usr/local/bin/couchbase-start"]
-CMD ["couchbase"]
+ENTRYPOINT ["couchbase-start"]
+CMD ["couchbase-server", "--", "-noinput"]
+# pass -noinput so it doesn't drop us in the erlang shell
 
 EXPOSE 8091 8092 11207 11210 11211 18091 18092
-VOLUME /opt/couchbase/lib
+VOLUME /opt/couchbase/var


### PR DESCRIPTION
- use the more broad `centos:6` base so that CentOS updates are applied appropriately and transparently without a bump to the `Dockerfile`s here
- rearrange `Dockerfile` for improved cache overlap (and improved repeat cache in general)
- change the "default command" to actually be the `couchbase-server` invocation, and have the `couchbase-start` script just execute what's passed in directly, adding `gosu` appropriately if it's `couchbase-server` we're trying to run (this also allows users who enjoy the Erlang console to avoid `-noinput` by just doing `docker run -it <image> couchbase-server`)
- adjust `VOLUME` to apply to the actual mutable bits (where the data gets stored) so that recreations can be as simple as `docker stop old-container`, `docker run --volumes-from old-container --name new-container couchbase`, `docker rm old-container` (as one benefit -- another is that it's now clear to the user that if they want to bind-mount a directory from the host, it goes at `/opt/couchbase/var/lib/couchbase`)