### PR TITLE
4.0.0-beta needs to install CentOS 6 RPM not CentOS 7

### DIFF
--- a/enterprise/couchbase-server/4.0.0-beta/Dockerfile
+++ b/enterprise/couchbase-server/4.0.0-beta/Dockerfile
@@ -16,7 +16,7 @@ RUN gpg --keyserver ha.pool.sks-keyservers.net --recv-keys B42F6819007F00F88E364
 
 ENV CB_VERSION=4.0.0-beta \
     CB_RELEASE_URL=http://packages.couchbase.com/releases \
-    CB_PACKAGE=couchbase-server-enterprise-4.0.0-beta-centos7.x86_64.rpm \
+    CB_PACKAGE=couchbase-server-enterprise-4.0.0-beta-centos6.x86_64.rpm \
     PATH=$PATH:/opt/couchbase/bin:/opt/couchbase/bin/tools:/opt/couchbase/bin/install
 
 # Install couchbase


### PR DESCRIPTION
The 4.0.0-beta version was installing the wrong RPM