### PR TITLE
Changed ubuntu version

### DIFF
--- a/community/couchbase-server/4.0.0/Dockerfile
+++ b/community/couchbase-server/4.0.0/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:12.04
+FROM ubuntu:14.04
 
 MAINTAINER Couchbase Docker Team <docker@couchbase.com>
 


### PR DESCRIPTION
Changed base ubuntu version from LTS 12.04 to LTS 14.04.
This change is need to use libc6 > 2.17 which is needed to use the couchbase driver with nodejs