### PR TITLE
Expose port 9110 for FTS. Also add comments documenting ports.

### DIFF
--- a/community/couchbase-server/2.2.0/Dockerfile
+++ b/community/couchbase-server/2.2.0/Dockerfile
@@ -32,5 +32,14 @@ COPY scripts/entrypoint.sh /
 ENTRYPOINT ["/entrypoint.sh"]
 CMD ["couchbase-server"]
 
-EXPOSE 8091 8092 8093 11207 11210 11211 18091 18092
+# 8091: Couchbase Web console, REST/HTTP interface
+# 8092: Views, queries, XDCR
+# 8093: Query services (4.0+)
+# 9110: Full-text Serarch (4.5 DP; will be 8094 in 4.5+)
+# 11207: Smart client library data node access (SSL)
+# 11210: Smart client library/moxi data node access
+# 11211: Legacy non-smart client library data node access
+# 18091: Couchbase Web console, REST/HTTP interface (SSL)
+# 18092: Views, query, XDCR (SSL)
+EXPOSE 8091 8092 8093 9110 11207 11210 11211 18091 18092
 VOLUME /opt/couchbase/var

--- a/community/couchbase-server/3.0.1/Dockerfile
+++ b/community/couchbase-server/3.0.1/Dockerfile
@@ -32,5 +32,14 @@ COPY scripts/entrypoint.sh /
 ENTRYPOINT ["/entrypoint.sh"]
 CMD ["couchbase-server"]
 
-EXPOSE 8091 8092 8093 11207 11210 11211 18091 18092
+# 8091: Couchbase Web console, REST/HTTP interface
+# 8092: Views, queries, XDCR
+# 8093: Query services (4.0+)
+# 9110: Full-text Serarch (4.5 DP; will be 8094 in 4.5+)
+# 11207: Smart client library data node access (SSL)
+# 11210: Smart client library/moxi data node access
+# 11211: Legacy non-smart client library data node access
+# 18091: Couchbase Web console, REST/HTTP interface (SSL)
+# 18092: Views, query, XDCR (SSL)
+EXPOSE 8091 8092 8093 9110 11207 11210 11211 18091 18092
 VOLUME /opt/couchbase/var

--- a/community/couchbase-server/4.0.0/Dockerfile
+++ b/community/couchbase-server/4.0.0/Dockerfile
@@ -32,5 +32,14 @@ COPY scripts/entrypoint.sh /
 ENTRYPOINT ["/entrypoint.sh"]
 CMD ["couchbase-server"]
 
-EXPOSE 8091 8092 8093 11207 11210 11211 18091 18092
+# 8091: Couchbase Web console, REST/HTTP interface
+# 8092: Views, queries, XDCR
+# 8093: Query services (4.0+)
+# 9110: Full-text Serarch (4.5 DP; will be 8094 in 4.5+)
+# 11207: Smart client library data node access (SSL)
+# 11210: Smart client library/moxi data node access
+# 11211: Legacy non-smart client library data node access
+# 18091: Couchbase Web console, REST/HTTP interface (SSL)
+# 18092: Views, query, XDCR (SSL)
+EXPOSE 8091 8092 8093 9110 11207 11210 11211 18091 18092
 VOLUME /opt/couchbase/var

--- a/enterprise/couchbase-server/2.5.2/Dockerfile
+++ b/enterprise/couchbase-server/2.5.2/Dockerfile
@@ -32,5 +32,14 @@ COPY scripts/entrypoint.sh /
 ENTRYPOINT ["/entrypoint.sh"]
 CMD ["couchbase-server"]
 
-EXPOSE 8091 8092 8093 11207 11210 11211 18091 18092
+# 8091: Couchbase Web console, REST/HTTP interface
+# 8092: Views, queries, XDCR
+# 8093: Query services (4.0+)
+# 9110: Full-text Serarch (4.5 DP; will be 8094 in 4.5+)
+# 11207: Smart client library data node access (SSL)
+# 11210: Smart client library/moxi data node access
+# 11211: Legacy non-smart client library data node access
+# 18091: Couchbase Web console, REST/HTTP interface (SSL)
+# 18092: Views, query, XDCR (SSL)
+EXPOSE 8091 8092 8093 9110 11207 11210 11211 18091 18092
 VOLUME /opt/couchbase/var

--- a/enterprise/couchbase-server/3.0.2/Dockerfile
+++ b/enterprise/couchbase-server/3.0.2/Dockerfile
@@ -32,5 +32,14 @@ COPY scripts/entrypoint.sh /
 ENTRYPOINT ["/entrypoint.sh"]
 CMD ["couchbase-server"]
 
-EXPOSE 8091 8092 8093 11207 11210 11211 18091 18092
+# 8091: Couchbase Web console, REST/HTTP interface
+# 8092: Views, queries, XDCR
+# 8093: Query services (4.0+)
+# 9110: Full-text Serarch (4.5 DP; will be 8094 in 4.5+)
+# 11207: Smart client library data node access (SSL)
+# 11210: Smart client library/moxi data node access
+# 11211: Legacy non-smart client library data node access
+# 18091: Couchbase Web console, REST/HTTP interface (SSL)
+# 18092: Views, query, XDCR (SSL)
+EXPOSE 8091 8092 8093 9110 11207 11210 11211 18091 18092
 VOLUME /opt/couchbase/var

--- a/enterprise/couchbase-server/3.0.3/Dockerfile
+++ b/enterprise/couchbase-server/3.0.3/Dockerfile
@@ -32,5 +32,14 @@ COPY scripts/entrypoint.sh /
 ENTRYPOINT ["/entrypoint.sh"]
 CMD ["couchbase-server"]
 
-EXPOSE 8091 8092 8093 11207 11210 11211 18091 18092
+# 8091: Couchbase Web console, REST/HTTP interface
+# 8092: Views, queries, XDCR
+# 8093: Query services (4.0+)
+# 9110: Full-text Serarch (4.5 DP; will be 8094 in 4.5+)
+# 11207: Smart client library data node access (SSL)
+# 11210: Smart client library/moxi data node access
+# 11211: Legacy non-smart client library data node access
+# 18091: Couchbase Web console, REST/HTTP interface (SSL)
+# 18092: Views, query, XDCR (SSL)
+EXPOSE 8091 8092 8093 9110 11207 11210 11211 18091 18092
 VOLUME /opt/couchbase/var

--- a/enterprise/couchbase-server/3.1.0/Dockerfile
+++ b/enterprise/couchbase-server/3.1.0/Dockerfile
@@ -32,5 +32,14 @@ COPY scripts/entrypoint.sh /
 ENTRYPOINT ["/entrypoint.sh"]
 CMD ["couchbase-server"]
 
-EXPOSE 8091 8092 8093 11207 11210 11211 18091 18092
+# 8091: Couchbase Web console, REST/HTTP interface
+# 8092: Views, queries, XDCR
+# 8093: Query services (4.0+)
+# 9110: Full-text Serarch (4.5 DP; will be 8094 in 4.5+)
+# 11207: Smart client library data node access (SSL)
+# 11210: Smart client library/moxi data node access
+# 11211: Legacy non-smart client library data node access
+# 18091: Couchbase Web console, REST/HTTP interface (SSL)
+# 18092: Views, query, XDCR (SSL)
+EXPOSE 8091 8092 8093 9110 11207 11210 11211 18091 18092
 VOLUME /opt/couchbase/var

--- a/enterprise/couchbase-server/4.0.0-beta/Dockerfile
+++ b/enterprise/couchbase-server/4.0.0-beta/Dockerfile
@@ -32,5 +32,14 @@ COPY scripts/entrypoint.sh /
 ENTRYPOINT ["/entrypoint.sh"]
 CMD ["couchbase-server"]
 
-EXPOSE 8091 8092 8093 11207 11210 11211 18091 18092
+# 8091: Couchbase Web console, REST/HTTP interface
+# 8092: Views, queries, XDCR
+# 8093: Query services (4.0+)
+# 9110: Full-text Serarch (4.5 DP; will be 8094 in 4.5+)
+# 11207: Smart client library data node access (SSL)
+# 11210: Smart client library/moxi data node access
+# 11211: Legacy non-smart client library data node access
+# 18091: Couchbase Web console, REST/HTTP interface (SSL)
+# 18092: Views, query, XDCR (SSL)
+EXPOSE 8091 8092 8093 9110 11207 11210 11211 18091 18092
 VOLUME /opt/couchbase/var

--- a/enterprise/couchbase-server/4.0.0-dp/Dockerfile
+++ b/enterprise/couchbase-server/4.0.0-dp/Dockerfile
@@ -32,5 +32,14 @@ COPY scripts/entrypoint.sh /
 ENTRYPOINT ["/entrypoint.sh"]
 CMD ["couchbase-server"]
 
-EXPOSE 8091 8092 8093 11207 11210 11211 18091 18092
+# 8091: Couchbase Web console, REST/HTTP interface
+# 8092: Views, queries, XDCR
+# 8093: Query services (4.0+)
+# 9110: Full-text Serarch (4.5 DP; will be 8094 in 4.5+)
+# 11207: Smart client library data node access (SSL)
+# 11210: Smart client library/moxi data node access
+# 11211: Legacy non-smart client library data node access
+# 18091: Couchbase Web console, REST/HTTP interface (SSL)
+# 18092: Views, query, XDCR (SSL)
+EXPOSE 8091 8092 8093 9110 11207 11210 11211 18091 18092
 VOLUME /opt/couchbase/var

--- a/enterprise/couchbase-server/4.0.0-rc0/Dockerfile
+++ b/enterprise/couchbase-server/4.0.0-rc0/Dockerfile
@@ -32,5 +32,14 @@ COPY scripts/entrypoint.sh /
 ENTRYPOINT ["/entrypoint.sh"]
 CMD ["couchbase-server"]
 
-EXPOSE 8091 8092 8093 11207 11210 11211 18091 18092
+# 8091: Couchbase Web console, REST/HTTP interface
+# 8092: Views, queries, XDCR
+# 8093: Query services (4.0+)
+# 9110: Full-text Serarch (4.5 DP; will be 8094 in 4.5+)
+# 11207: Smart client library data node access (SSL)
+# 11210: Smart client library/moxi data node access
+# 11211: Legacy non-smart client library data node access
+# 18091: Couchbase Web console, REST/HTTP interface (SSL)
+# 18092: Views, query, XDCR (SSL)
+EXPOSE 8091 8092 8093 9110 11207 11210 11211 18091 18092
 VOLUME /opt/couchbase/var

--- a/enterprise/couchbase-server/4.0.0/Dockerfile
+++ b/enterprise/couchbase-server/4.0.0/Dockerfile
@@ -32,5 +32,14 @@ COPY scripts/entrypoint.sh /
 ENTRYPOINT ["/entrypoint.sh"]
 CMD ["couchbase-server"]
 
-EXPOSE 8091 8092 8093 11207 11210 11211 18091 18092
+# 8091: Couchbase Web console, REST/HTTP interface
+# 8092: Views, queries, XDCR
+# 8093: Query services (4.0+)
+# 9110: Full-text Serarch (4.5 DP; will be 8094 in 4.5+)
+# 11207: Smart client library data node access (SSL)
+# 11210: Smart client library/moxi data node access
+# 11211: Legacy non-smart client library data node access
+# 18091: Couchbase Web console, REST/HTTP interface (SSL)
+# 18092: Views, query, XDCR (SSL)
+EXPOSE 8091 8092 8093 9110 11207 11210 11211 18091 18092
 VOLUME /opt/couchbase/var

--- a/enterprise/couchbase-server/4.1.0/Dockerfile
+++ b/enterprise/couchbase-server/4.1.0/Dockerfile
@@ -32,5 +32,14 @@ COPY scripts/entrypoint.sh /
 ENTRYPOINT ["/entrypoint.sh"]
 CMD ["couchbase-server"]
 
-EXPOSE 8091 8092 8093 11207 11210 11211 18091 18092
+# 8091: Couchbase Web console, REST/HTTP interface
+# 8092: Views, queries, XDCR
+# 8093: Query services (4.0+)
+# 9110: Full-text Serarch (4.5 DP; will be 8094 in 4.5+)
+# 11207: Smart client library data node access (SSL)
+# 11210: Smart client library/moxi data node access
+# 11211: Legacy non-smart client library data node access
+# 18091: Couchbase Web console, REST/HTTP interface (SSL)
+# 18092: Views, query, XDCR (SSL)
+EXPOSE 8091 8092 8093 9110 11207 11210 11211 18091 18092
 VOLUME /opt/couchbase/var

--- a/enterprise/couchbase-server/4.5.0-DP1/Dockerfile
+++ b/enterprise/couchbase-server/4.5.0-DP1/Dockerfile
@@ -32,5 +32,14 @@ COPY scripts/entrypoint.sh /
 ENTRYPOINT ["/entrypoint.sh"]
 CMD ["couchbase-server"]
 
-EXPOSE 8091 8092 8093 11207 11210 11211 18091 18092
+# 8091: Couchbase Web console, REST/HTTP interface
+# 8092: Views, queries, XDCR
+# 8093: Query services (4.0+)
+# 9110: Full-text Serarch (4.5 DP; will be 8094 in 4.5+)
+# 11207: Smart client library data node access (SSL)
+# 11210: Smart client library/moxi data node access
+# 11211: Legacy non-smart client library data node access
+# 18091: Couchbase Web console, REST/HTTP interface (SSL)
+# 18092: Views, query, XDCR (SSL)
+EXPOSE 8091 8092 8093 9110 11207 11210 11211 18091 18092
 VOLUME /opt/couchbase/var

--- a/generate/templates/couchbase-server/Dockerfile.template
+++ b/generate/templates/couchbase-server/Dockerfile.template
@@ -32,5 +32,14 @@ COPY scripts/entrypoint.sh /
 ENTRYPOINT ["/entrypoint.sh"]
 CMD ["couchbase-server"]
 
-EXPOSE 8091 8092 8093 11207 11210 11211 18091 18092
+# 8091: Couchbase Web console, REST/HTTP interface
+# 8092: Views, queries, XDCR
+# 8093: Query services (4.0+)
+# 9110: Full-text Serarch (4.5 DP; will be 8094 in 4.5+)
+# 11207: Smart client library data node access (SSL)
+# 11210: Smart client library/moxi data node access
+# 11211: Legacy non-smart client library data node access
+# 18091: Couchbase Web console, REST/HTTP interface (SSL)
+# 18092: Views, query, XDCR (SSL)
+EXPOSE 8091 8092 8093 9110 11207 11210 11211 18091 18092
 VOLUME /opt/couchbase/var


### PR DESCRIPTION
As mentioned on #30 .

Please check my doc comments for accuracy; I summarized them from http://developer.couchbase.com/documentation/server/4.1/install/install-ports.html .

Anyone know if there is an SSL query port, which I assume would be at 18093?