### PR TITLE
Ubuntu version in Dockerfile

### DIFF
--- a/community/couchbase-server/4.0.0/Dockerfile
+++ b/community/couchbase-server/4.0.0/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:14.04
+FROM ubuntu:16.04
 
 MAINTAINER Couchbase Docker Team <docker@couchbase.com>
 


### PR DESCRIPTION
I realized the docker hub container was still running on 12.04 (precise) and after comparing:

https://hub.docker.com/r/couchbase/server/~/dockerfile/
vs
https://github.com/couchbase/docker/blob/master/community/couchbase-server/4.0.0/Dockerfile

... it seems the package on the docker hub has not been updated in a long while with this newer Dockerfile...
At the same time, it would be a good idea to switch to 16.04 to be good for a while and skip 14.04 since everyone will be moving to 16.04 now.

Cheers!