### PR TITLE
sync-gateway community 1.2.1 docker configuration

### DIFF
--- a/community/sync-gateway/1.2.1/Dockerfile
+++ b/community/sync-gateway/1.2.1/Dockerfile
@@ -1,0 +1,47 @@
+FROM centos:centos7
+
+MAINTAINER Couchbase Docker Team <docker@couchbase.com>
+
+ENV GOPATH /opt/go
+ENV SGROOT /opt/sync_gateway
+ENV GOROOT /usr/local/go
+ENV PATH $PATH:$GOPATH/bin:$GOROOT/bin
+
+# Get dependencies
+RUN yum -y update && \
+    yum groupinstall -y development && \
+    yum install -y \
+    bc \
+    curl \
+    emacs-nox \
+    git \
+    mercurial \
+    wget 
+
+# Download and install Go
+RUN wget http://golang.org/dl/go1.5.2.linux-amd64.tar.gz && \
+    tar -C /usr/local -xzf go1.5.2.linux-amd64.tar.gz && \
+    rm go1.5.2.linux-amd64.tar.gz
+
+# install common go packages
+RUN go get github.com/tools/godep && \
+    go get github.com/nsf/gocode && \
+    go get golang.org/x/tools/cmd/goimports && \
+    go get github.com/golang/lint/golint && \
+    go get github.com/rogpeppe/godef
+
+# Build Sync Gateway
+RUN mkdir -p $GOPATH && \
+    cd /opt && \ 
+    git clone https://github.com/couchbase/sync_gateway.git && \
+    cd $SGROOT && \
+    git checkout 1.2.1 && \	
+    git submodule update --init --recursive && \
+    ./build.sh && \
+    cp bin/sync_gateway /usr/local/bin && \
+    mkdir -p $SGROOT/data
+
+ENTRYPOINT ["/usr/local/bin/sync_gateway"]
+
+# Expose ports
+EXPOSE 4984 4985

--- a/community/sync-gateway/1.2.1/README.md
+++ b/community/sync-gateway/1.2.1/README.md
@@ -1,0 +1,10 @@
+
+Docker container for [Couchbase Sync Gateway](https://github.com/couchbase/sync_gateway).
+
+## Quickstart
+
+To run the latest release of Sync Gateway with a configuration file hosted in a github gist:
+
+```
+$ docker run -p 4984:4984 -p 4985:4985 couchbase/sync-gateway http://git.io/vfQpe
+```


### PR DESCRIPTION
As suggested here... https://github.com/couchbase/sync_gateway/issues/1366#issuecomment-165535857

I added config for 1.2.1. But the docker file does not work right now, I think because the 1.2.1 release has not been tagged on the sync-gateway repo.

`Step 10 : RUN mkdir -p $GOPATH &&     cd /opt &&     git clone https://github.com/couchbase/sync_gateway.git &&     cd $SGROOT &&     git checkout 1.2.1 &&     git submodule update --init --recursive &&     ./build.sh &&     cp bin/sync_gateway /usr/local/bin &&     mkdir -p $SGROOT/data
 ---> Running in c54bac290718
Cloning into 'sync_gateway'...
error: pathspec '1.2.1' did not match any file(s) known to git.`