### PR TITLE
Tell users where to look for logs

### DIFF
--- a/generate/resources/couchbase-server/scripts/entrypoint.sh
+++ b/generate/resources/couchbase-server/scripts/entrypoint.sh
@@ -2,7 +2,7 @@
 set -e
 
 [[ "$1" == "couchbase-server" ]] && {
-    echo "Starting Couchbase Server -- Web UI available at http://<ip>:8091"
+    echo "Starting Couchbase Server -- Web UI available at http://<ip>:8091 and logs available in /opt/couchbase/var/lib/couchbase/logs"
     exec /usr/sbin/runsvdir-start
 }
 


### PR DESCRIPTION
Users might be expecting logs to appear directly in the `docker logs` output, but Couchbase Server writes directly to log files.  This will let users know where to look.