### PR TITLE
Use ARG rather than ENV for build config values.

### DIFF
--- a/community/couchbase-server/3.0.1/Dockerfile
+++ b/community/couchbase-server/3.0.1/Dockerfile
@@ -19,11 +19,12 @@ RUN apt-get update && \
     apt-get autoremove && apt-get clean && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
-ENV CB_VERSION=3.0.1 \
-    CB_RELEASE_URL=http://packages.couchbase.com/releases \
-    CB_PACKAGE=couchbase-server-community_3.0.1-ubuntu12.04_amd64.deb \
-    CB_SHA256=59efbd8924969f71c9a6b438afea94d974db51607464c55d7a2d527368026150 \
-    PATH=$PATH:/opt/couchbase/bin:/opt/couchbase/bin/tools:/opt/couchbase/bin/install
+ARG CB_VERSION=3.0.1
+ARG CB_RELEASE_URL=http://packages.couchbase.com/releases
+ARG CB_PACKAGE=couchbase-server-community_3.0.1-ubuntu12.04_amd64.deb
+ARG CB_SHA256=59efbd8924969f71c9a6b438afea94d974db51607464c55d7a2d527368026150
+
+ENV PATH=$PATH:/opt/couchbase/bin:/opt/couchbase/bin/tools:/opt/couchbase/bin/install
 
 # Create Couchbase user with UID 1000 (necessary to match default
 # boot2docker UID)

--- a/community/couchbase-server/3.1.3/Dockerfile
+++ b/community/couchbase-server/3.1.3/Dockerfile
@@ -19,11 +19,12 @@ RUN apt-get update && \
     apt-get autoremove && apt-get clean && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
-ENV CB_VERSION=3.1.3 \
-    CB_RELEASE_URL=http://packages.couchbase.com/releases \
-    CB_PACKAGE=couchbase-server-community_3.1.3-ubuntu12.04_amd64.deb \
-    CB_SHA256=dc919f78a74ae1f627b9bee26e3da70a33ceb1b3fd3259f2ed85b0754e6fcd41 \
-    PATH=$PATH:/opt/couchbase/bin:/opt/couchbase/bin/tools:/opt/couchbase/bin/install
+ARG CB_VERSION=3.1.3
+ARG CB_RELEASE_URL=http://packages.couchbase.com/releases
+ARG CB_PACKAGE=couchbase-server-community_3.1.3-ubuntu12.04_amd64.deb
+ARG CB_SHA256=dc919f78a74ae1f627b9bee26e3da70a33ceb1b3fd3259f2ed85b0754e6fcd41
+
+ENV PATH=$PATH:/opt/couchbase/bin:/opt/couchbase/bin/tools:/opt/couchbase/bin/install
 
 # Create Couchbase user with UID 1000 (necessary to match default
 # boot2docker UID)

--- a/community/couchbase-server/4.0.0/Dockerfile
+++ b/community/couchbase-server/4.0.0/Dockerfile
@@ -19,11 +19,12 @@ RUN apt-get update && \
     apt-get autoremove && apt-get clean && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
-ENV CB_VERSION=4.0.0 \
-    CB_RELEASE_URL=http://packages.couchbase.com/releases \
-    CB_PACKAGE=couchbase-server-community_4.0.0-ubuntu14.04_amd64.deb \
-    CB_SHA256=e275717da0c22efb846b397a1ffeaf63a21ec91e4e481efe3b59de0a0d530982 \
-    PATH=$PATH:/opt/couchbase/bin:/opt/couchbase/bin/tools:/opt/couchbase/bin/install
+ARG CB_VERSION=4.0.0
+ARG CB_RELEASE_URL=http://packages.couchbase.com/releases
+ARG CB_PACKAGE=couchbase-server-community_4.0.0-ubuntu14.04_amd64.deb
+ARG CB_SHA256=e275717da0c22efb846b397a1ffeaf63a21ec91e4e481efe3b59de0a0d530982
+
+ENV PATH=$PATH:/opt/couchbase/bin:/opt/couchbase/bin/tools:/opt/couchbase/bin/install
 
 # Create Couchbase user with UID 1000 (necessary to match default
 # boot2docker UID)

--- a/community/couchbase-server/4.1.0/Dockerfile
+++ b/community/couchbase-server/4.1.0/Dockerfile
@@ -19,11 +19,12 @@ RUN apt-get update && \
     apt-get autoremove && apt-get clean && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
-ENV CB_VERSION=4.1.0 \
-    CB_RELEASE_URL=http://packages.couchbase.com/releases \
-    CB_PACKAGE=couchbase-server-community_4.1.0-ubuntu14.04_amd64.deb \
-    CB_SHA256=400263bd03e32b69259ec9b821bf58922030ba9e2a266e2ef4a0d4ac162188ea \
-    PATH=$PATH:/opt/couchbase/bin:/opt/couchbase/bin/tools:/opt/couchbase/bin/install
+ARG CB_VERSION=4.1.0
+ARG CB_RELEASE_URL=http://packages.couchbase.com/releases
+ARG CB_PACKAGE=couchbase-server-community_4.1.0-ubuntu14.04_amd64.deb
+ARG CB_SHA256=400263bd03e32b69259ec9b821bf58922030ba9e2a266e2ef4a0d4ac162188ea
+
+ENV PATH=$PATH:/opt/couchbase/bin:/opt/couchbase/bin/tools:/opt/couchbase/bin/install
 
 # Create Couchbase user with UID 1000 (necessary to match default
 # boot2docker UID)

--- a/enterprise/couchbase-server/2.5.2/Dockerfile
+++ b/enterprise/couchbase-server/2.5.2/Dockerfile
@@ -19,11 +19,12 @@ RUN apt-get update && \
     apt-get autoremove && apt-get clean && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
-ENV CB_VERSION=2.5.2 \
-    CB_RELEASE_URL=http://packages.couchbase.com/releases \
-    CB_PACKAGE=couchbase-server-enterprise_2.5.2_x86_64.deb \
-    CB_SHA256=27a79a65758023c34ed900e8ef8c54bab4a65f4c84b7c94359cba910800a4b19 \
-    PATH=$PATH:/opt/couchbase/bin:/opt/couchbase/bin/tools:/opt/couchbase/bin/install
+ARG CB_VERSION=2.5.2
+ARG CB_RELEASE_URL=http://packages.couchbase.com/releases
+ARG CB_PACKAGE=couchbase-server-enterprise_2.5.2_x86_64.deb
+ARG CB_SHA256=27a79a65758023c34ed900e8ef8c54bab4a65f4c84b7c94359cba910800a4b19
+
+ENV PATH=$PATH:/opt/couchbase/bin:/opt/couchbase/bin/tools:/opt/couchbase/bin/install
 
 # Create Couchbase user with UID 1000 (necessary to match default
 # boot2docker UID)

--- a/enterprise/couchbase-server/3.0.2/Dockerfile
+++ b/enterprise/couchbase-server/3.0.2/Dockerfile
@@ -19,11 +19,12 @@ RUN apt-get update && \
     apt-get autoremove && apt-get clean && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
-ENV CB_VERSION=3.0.2 \
-    CB_RELEASE_URL=http://packages.couchbase.com/releases \
-    CB_PACKAGE=couchbase-server-enterprise_3.0.2-ubuntu12.04_amd64.deb \
-    CB_SHA256=29490c49f4ba5e25fe68db9abe7a78f884a0ea47c7825813b50fd5b9c2bf691c \
-    PATH=$PATH:/opt/couchbase/bin:/opt/couchbase/bin/tools:/opt/couchbase/bin/install
+ARG CB_VERSION=3.0.2
+ARG CB_RELEASE_URL=http://packages.couchbase.com/releases
+ARG CB_PACKAGE=couchbase-server-enterprise_3.0.2-ubuntu12.04_amd64.deb
+ARG CB_SHA256=29490c49f4ba5e25fe68db9abe7a78f884a0ea47c7825813b50fd5b9c2bf691c
+
+ENV PATH=$PATH:/opt/couchbase/bin:/opt/couchbase/bin/tools:/opt/couchbase/bin/install
 
 # Create Couchbase user with UID 1000 (necessary to match default
 # boot2docker UID)

--- a/enterprise/couchbase-server/3.0.3/Dockerfile
+++ b/enterprise/couchbase-server/3.0.3/Dockerfile
@@ -19,11 +19,12 @@ RUN apt-get update && \
     apt-get autoremove && apt-get clean && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
-ENV CB_VERSION=3.0.3 \
-    CB_RELEASE_URL=http://packages.couchbase.com/releases \
-    CB_PACKAGE=couchbase-server-enterprise_3.0.3-ubuntu12.04_amd64.deb \
-    CB_SHA256=13e925fa8b806aecd09751bdb7be1f8cfa188ad894e266108e8c44785c08e474 \
-    PATH=$PATH:/opt/couchbase/bin:/opt/couchbase/bin/tools:/opt/couchbase/bin/install
+ARG CB_VERSION=3.0.3
+ARG CB_RELEASE_URL=http://packages.couchbase.com/releases
+ARG CB_PACKAGE=couchbase-server-enterprise_3.0.3-ubuntu12.04_amd64.deb
+ARG CB_SHA256=13e925fa8b806aecd09751bdb7be1f8cfa188ad894e266108e8c44785c08e474
+
+ENV PATH=$PATH:/opt/couchbase/bin:/opt/couchbase/bin/tools:/opt/couchbase/bin/install
 
 # Create Couchbase user with UID 1000 (necessary to match default
 # boot2docker UID)

--- a/enterprise/couchbase-server/3.1.0/Dockerfile
+++ b/enterprise/couchbase-server/3.1.0/Dockerfile
@@ -19,11 +19,12 @@ RUN apt-get update && \
     apt-get autoremove && apt-get clean && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
-ENV CB_VERSION=3.1.0 \
-    CB_RELEASE_URL=http://packages.couchbase.com/releases \
-    CB_PACKAGE=couchbase-server-enterprise_3.1.0-ubuntu12.04_amd64.deb \
-    CB_SHA256=8eed4c768816ac22f6627d05516fa8a6975571b32b354c4f16185d8654f5bc1c \
-    PATH=$PATH:/opt/couchbase/bin:/opt/couchbase/bin/tools:/opt/couchbase/bin/install
+ARG CB_VERSION=3.1.0
+ARG CB_RELEASE_URL=http://packages.couchbase.com/releases
+ARG CB_PACKAGE=couchbase-server-enterprise_3.1.0-ubuntu12.04_amd64.deb
+ARG CB_SHA256=8eed4c768816ac22f6627d05516fa8a6975571b32b354c4f16185d8654f5bc1c
+
+ENV PATH=$PATH:/opt/couchbase/bin:/opt/couchbase/bin/tools:/opt/couchbase/bin/install
 
 # Create Couchbase user with UID 1000 (necessary to match default
 # boot2docker UID)

--- a/enterprise/couchbase-server/3.1.3/Dockerfile
+++ b/enterprise/couchbase-server/3.1.3/Dockerfile
@@ -19,11 +19,12 @@ RUN apt-get update && \
     apt-get autoremove && apt-get clean && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
-ENV CB_VERSION=3.1.3 \
-    CB_RELEASE_URL=http://packages.couchbase.com/releases \
-    CB_PACKAGE=couchbase-server-enterprise_3.1.3-ubuntu12.04_amd64.deb \
-    CB_SHA256=3c48f279c8ac1634a881fa75def771b6a7362ed811e5b44e3cc4b6f9597376c2 \
-    PATH=$PATH:/opt/couchbase/bin:/opt/couchbase/bin/tools:/opt/couchbase/bin/install
+ARG CB_VERSION=3.1.3
+ARG CB_RELEASE_URL=http://packages.couchbase.com/releases
+ARG CB_PACKAGE=couchbase-server-enterprise_3.1.3-ubuntu12.04_amd64.deb
+ARG CB_SHA256=3c48f279c8ac1634a881fa75def771b6a7362ed811e5b44e3cc4b6f9597376c2
+
+ENV PATH=$PATH:/opt/couchbase/bin:/opt/couchbase/bin/tools:/opt/couchbase/bin/install
 
 # Create Couchbase user with UID 1000 (necessary to match default
 # boot2docker UID)

--- a/enterprise/couchbase-server/3.1.5/Dockerfile
+++ b/enterprise/couchbase-server/3.1.5/Dockerfile
@@ -19,11 +19,12 @@ RUN apt-get update && \
     apt-get autoremove && apt-get clean && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
-ENV CB_VERSION=3.1.5 \
-    CB_RELEASE_URL=http://packages.couchbase.com/releases \
-    CB_PACKAGE=couchbase-server-enterprise_3.1.5-ubuntu12.04_amd64.deb \
-    CB_SHA256=b4a7cbbe8a891debd9f95f165247d783c035d939b3ddedadc73a9cb4563f4fc3 \
-    PATH=$PATH:/opt/couchbase/bin:/opt/couchbase/bin/tools:/opt/couchbase/bin/install
+ARG CB_VERSION=3.1.5
+ARG CB_RELEASE_URL=http://packages.couchbase.com/releases
+ARG CB_PACKAGE=couchbase-server-enterprise_3.1.5-ubuntu12.04_amd64.deb
+ARG CB_SHA256=b4a7cbbe8a891debd9f95f165247d783c035d939b3ddedadc73a9cb4563f4fc3
+
+ENV PATH=$PATH:/opt/couchbase/bin:/opt/couchbase/bin/tools:/opt/couchbase/bin/install
 
 # Create Couchbase user with UID 1000 (necessary to match default
 # boot2docker UID)

--- a/enterprise/couchbase-server/3.1.6/Dockerfile
+++ b/enterprise/couchbase-server/3.1.6/Dockerfile
@@ -19,11 +19,12 @@ RUN apt-get update && \
     apt-get autoremove && apt-get clean && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
-ENV CB_VERSION=3.1.6 \
-    CB_RELEASE_URL=http://packages.couchbase.com/releases \
-    CB_PACKAGE=couchbase-server-enterprise_3.1.6-ubuntu12.04_amd64.deb \
-    CB_SHA256=b13964639f2effcf7026834f0c023b43b22f44d12d7567712b5760bd1829ad6b \
-    PATH=$PATH:/opt/couchbase/bin:/opt/couchbase/bin/tools:/opt/couchbase/bin/install
+ARG CB_VERSION=3.1.6
+ARG CB_RELEASE_URL=http://packages.couchbase.com/releases
+ARG CB_PACKAGE=couchbase-server-enterprise_3.1.6-ubuntu12.04_amd64.deb
+ARG CB_SHA256=b13964639f2effcf7026834f0c023b43b22f44d12d7567712b5760bd1829ad6b
+
+ENV PATH=$PATH:/opt/couchbase/bin:/opt/couchbase/bin/tools:/opt/couchbase/bin/install
 
 # Create Couchbase user with UID 1000 (necessary to match default
 # boot2docker UID)

--- a/enterprise/couchbase-server/4.0.0/Dockerfile
+++ b/enterprise/couchbase-server/4.0.0/Dockerfile
@@ -19,11 +19,12 @@ RUN apt-get update && \
     apt-get autoremove && apt-get clean && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
-ENV CB_VERSION=4.0.0 \
-    CB_RELEASE_URL=http://packages.couchbase.com/releases \
-    CB_PACKAGE=couchbase-server-enterprise_4.0.0-ubuntu14.04_amd64.deb \
-    CB_SHA256=c4fad00fe6006a31a82aa4879e7ae502cb9d397339e6d28f352312a0a5be9edd \
-    PATH=$PATH:/opt/couchbase/bin:/opt/couchbase/bin/tools:/opt/couchbase/bin/install
+ARG CB_VERSION=4.0.0
+ARG CB_RELEASE_URL=http://packages.couchbase.com/releases
+ARG CB_PACKAGE=couchbase-server-enterprise_4.0.0-ubuntu14.04_amd64.deb
+ARG CB_SHA256=c4fad00fe6006a31a82aa4879e7ae502cb9d397339e6d28f352312a0a5be9edd
+
+ENV PATH=$PATH:/opt/couchbase/bin:/opt/couchbase/bin/tools:/opt/couchbase/bin/install
 
 # Create Couchbase user with UID 1000 (necessary to match default
 # boot2docker UID)

--- a/enterprise/couchbase-server/4.1.0/Dockerfile
+++ b/enterprise/couchbase-server/4.1.0/Dockerfile
@@ -19,11 +19,12 @@ RUN apt-get update && \
     apt-get autoremove && apt-get clean && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
-ENV CB_VERSION=4.1.0 \
-    CB_RELEASE_URL=http://packages.couchbase.com/releases \
-    CB_PACKAGE=couchbase-server-enterprise_4.1.0-ubuntu14.04_amd64.deb \
-    CB_SHA256=beb4ee31b5fea2bfa47c51132d3b29a12e6e2c537b7e5e8dca5d0d50558e4c53 \
-    PATH=$PATH:/opt/couchbase/bin:/opt/couchbase/bin/tools:/opt/couchbase/bin/install
+ARG CB_VERSION=4.1.0
+ARG CB_RELEASE_URL=http://packages.couchbase.com/releases
+ARG CB_PACKAGE=couchbase-server-enterprise_4.1.0-ubuntu14.04_amd64.deb
+ARG CB_SHA256=beb4ee31b5fea2bfa47c51132d3b29a12e6e2c537b7e5e8dca5d0d50558e4c53
+
+ENV PATH=$PATH:/opt/couchbase/bin:/opt/couchbase/bin/tools:/opt/couchbase/bin/install
 
 # Create Couchbase user with UID 1000 (necessary to match default
 # boot2docker UID)

--- a/enterprise/couchbase-server/4.1.1/Dockerfile
+++ b/enterprise/couchbase-server/4.1.1/Dockerfile
@@ -19,11 +19,12 @@ RUN apt-get update && \
     apt-get autoremove && apt-get clean && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
-ENV CB_VERSION=4.1.1 \
-    CB_RELEASE_URL=http://packages.couchbase.com/releases \
-    CB_PACKAGE=couchbase-server-enterprise_4.1.1-ubuntu14.04_amd64.deb \
-    CB_SHA256=65c0ee37f0e6d816257b32a36207ec9b8e81c84112beb657c851f9aacb9b4382 \
-    PATH=$PATH:/opt/couchbase/bin:/opt/couchbase/bin/tools:/opt/couchbase/bin/install
+ARG CB_VERSION=4.1.1
+ARG CB_RELEASE_URL=http://packages.couchbase.com/releases
+ARG CB_PACKAGE=couchbase-server-enterprise_4.1.1-ubuntu14.04_amd64.deb
+ARG CB_SHA256=65c0ee37f0e6d816257b32a36207ec9b8e81c84112beb657c851f9aacb9b4382
+
+ENV PATH=$PATH:/opt/couchbase/bin:/opt/couchbase/bin/tools:/opt/couchbase/bin/install
 
 # Create Couchbase user with UID 1000 (necessary to match default
 # boot2docker UID)

--- a/enterprise/couchbase-server/4.1.2/Dockerfile
+++ b/enterprise/couchbase-server/4.1.2/Dockerfile
@@ -19,11 +19,12 @@ RUN apt-get update && \
     apt-get autoremove && apt-get clean && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
-ENV CB_VERSION=4.1.2 \
-    CB_RELEASE_URL=http://packages.couchbase.com/releases \
-    CB_PACKAGE=couchbase-server-enterprise_4.1.2-ubuntu14.04_amd64.deb \
-    CB_SHA256=a9fa03e40700e77f0ee447cc8507c5ad80a767fc0f2796e0e506e32064e86e8f \
-    PATH=$PATH:/opt/couchbase/bin:/opt/couchbase/bin/tools:/opt/couchbase/bin/install
+ARG CB_VERSION=4.1.2
+ARG CB_RELEASE_URL=http://packages.couchbase.com/releases
+ARG CB_PACKAGE=couchbase-server-enterprise_4.1.2-ubuntu14.04_amd64.deb
+ARG CB_SHA256=a9fa03e40700e77f0ee447cc8507c5ad80a767fc0f2796e0e506e32064e86e8f
+
+ENV PATH=$PATH:/opt/couchbase/bin:/opt/couchbase/bin/tools:/opt/couchbase/bin/install
 
 # Create Couchbase user with UID 1000 (necessary to match default
 # boot2docker UID)

--- a/enterprise/couchbase-server/4.5.0/Dockerfile
+++ b/enterprise/couchbase-server/4.5.0/Dockerfile
@@ -19,11 +19,12 @@ RUN apt-get update && \
     apt-get autoremove && apt-get clean && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
-ENV CB_VERSION=4.5.0 \
-    CB_RELEASE_URL=http://packages.couchbase.com/releases \
-    CB_PACKAGE=couchbase-server-enterprise_4.5.0-ubuntu14.04_amd64.deb \
-    CB_SHA256=441398302210c0d73f27bdab741b471fc9da116bf45f521b314345f04560716e \
-    PATH=$PATH:/opt/couchbase/bin:/opt/couchbase/bin/tools:/opt/couchbase/bin/install
+ARG CB_VERSION=4.5.0
+ARG CB_RELEASE_URL=http://packages.couchbase.com/releases
+ARG CB_PACKAGE=couchbase-server-enterprise_4.5.0-ubuntu14.04_amd64.deb
+ARG CB_SHA256=441398302210c0d73f27bdab741b471fc9da116bf45f521b314345f04560716e
+
+ENV PATH=$PATH:/opt/couchbase/bin:/opt/couchbase/bin/tools:/opt/couchbase/bin/install
 
 # Create Couchbase user with UID 1000 (necessary to match default
 # boot2docker UID)

--- a/enterprise/couchbase-server/4.5.1/Dockerfile
+++ b/enterprise/couchbase-server/4.5.1/Dockerfile
@@ -19,11 +19,12 @@ RUN apt-get update && \
     apt-get autoremove && apt-get clean && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
-ENV CB_VERSION=4.5.1 \
-    CB_RELEASE_URL=http://packages.couchbase.com/releases \
-    CB_PACKAGE=couchbase-server-enterprise_4.5.1-ubuntu14.04_amd64.deb \
-    CB_SHA256=4e9075643a46c015acd2dbb5c7d6c047904b21c1934f4c53fbd1dd5d73c74c82 \
-    PATH=$PATH:/opt/couchbase/bin:/opt/couchbase/bin/tools:/opt/couchbase/bin/install
+ARG CB_VERSION=4.5.1
+ARG CB_RELEASE_URL=http://packages.couchbase.com/releases
+ARG CB_PACKAGE=couchbase-server-enterprise_4.5.1-ubuntu14.04_amd64.deb
+ARG CB_SHA256=4e9075643a46c015acd2dbb5c7d6c047904b21c1934f4c53fbd1dd5d73c74c82
+
+ENV PATH=$PATH:/opt/couchbase/bin:/opt/couchbase/bin/tools:/opt/couchbase/bin/install
 
 # Create Couchbase user with UID 1000 (necessary to match default
 # boot2docker UID)

--- a/enterprise/couchbase-server/4.7.0/Dockerfile
+++ b/enterprise/couchbase-server/4.7.0/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:12.04
+FROM ubuntu:14.04
 
 MAINTAINER Couchbase Docker Team <docker@couchbase.com>
 
@@ -15,14 +15,14 @@ MAINTAINER Couchbase Docker Team <docker@couchbase.com>
 #  numactl: numactl
 RUN apt-get update && \
     apt-get install -yq runit wget python-httplib2 chrpath \
-    lsof lshw sysstat net-tools numactl librtmp0 && \
+    lsof lshw sysstat net-tools numactl  && \
     apt-get autoremove && apt-get clean && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
-ARG CB_VERSION=2.2.0
+ARG CB_VERSION=4.7.0
 ARG CB_RELEASE_URL=http://packages.couchbase.com/releases
-ARG CB_PACKAGE=couchbase-server-community_2.2.0_x86_64.deb
-ARG CB_SHA256=051b0905e13241de19fbd9efb1e22a421f33429a1db3e4b5e3ae8756b9e4d6a2
+ARG CB_PACKAGE=couchbase-server-enterprise_4.7.0-ubuntu14.04_amd64.deb
+ARG CB_SHA256=<?xml
 
 ENV PATH=$PATH:/opt/couchbase/bin:/opt/couchbase/bin/tools:/opt/couchbase/bin/install
 

--- a/enterprise/couchbase-server/4.7.0/README.md
+++ b/enterprise/couchbase-server/4.7.0/README.md
@@ -1,0 +1,155 @@
+
+This README will guide you through running Couchbase Server with Docker Containers.
+
+[Couchbase Server](http://www.couchbase.com/nosql-databases/couchbase-server) is a NoSQL document database with a distributed architecture for performance, scalability, and availability. It enables developers to build applications easier and faster by leveraging the power of SQL with the flexibility of JSON.
+
+For additional questions and feedback, please visit the [Couchbase Forums](https://forums.couchbase.com/) or [Stack Overflow](http://stackoverflow.com/questions/tagged/couchbase).
+
+# QuickStart with Couchbase Server and Docker
+
+Here is how to get a single node Couchbase Server cluster running on Docker containers:
+
+**Step - 1 :** Run Couchbase Server docker container
+
+`docker run -d --name db -p 8091-8094:8091-8094 -p 11210:11210 couchbase`
+
+**Step - 2 :** Next, visit `http://localhost:8091` on the host machine to see the Web Console to start Couchbase Server setup.
+
+![setup splash screen](https://raw.githubusercontent.com/cihanb/docker/master/generate/resources/couchbase-server/images/setup-initial.jpg)
+
+Walk through the Setup wizard and accept the default values.
+
+-	Note: You may need to lower the RAM allocated to various services to fit within the bounds of the resource of the containers.
+-	Enable the beer-sample bucket to load some sample data.
+
+![setup step-1 screen](https://raw.githubusercontent.com/cihanb/docker/master/generate/resources/couchbase-server/images/setup-step1.jpg)
+
+**Note :** For detailed information on configuring the Server, see [Initial Couchbase Server Setup](http://developer.couchbase.com/documentation/server/4.5/install/init-setup.html).
+
+## Running A N1QL Query on the Couchbase Server Cluster
+
+N1QL is the SQL based query language for Couchbase Server. Simply switch to the Query tab on the Web Console at `http://localhost:8091` and run the following N1QL Query in the query window:
+
+```SELECT name FROM `beer-sample` WHERE brewery_id ="mishawaka_brewing";```
+
+You can also execute N1QL queries from the commandline. To run a query from command line query tool, run the interactive shell on the container:
+
+`docker exec -it db sh`
+
+Then, navigate to the `bin` directory under Couchbase Server installation and run cbq command line tool and execute the N1QL Query on `beer-sample` bucket
+
+`/opt/couchbase/bin/cbq`
+
+```cbq> SELECT name FROM `beer-sample` WHERE brewery_id ="mishawaka_brewing";```
+
+For more query samples, refer to the [Running your first N1QL query](http://developer.couchbase.com/documentation/server/4.5/getting-started/first-n1ql-query.html) guide.
+
+## Connect to the Couchbase Server Cluster via Applications and SDKs
+Couchbase Server SDKs comes in many languages: C SDK 2.4/2.5 Go, Java, .NET, Node.js, PHP, Python. Simply run your application through the Couchbase Server SDK of your choice on the host, and point it to http://localhost:8091/pools to connect to the container.
+
+For running a sample application, refer to the [Running a sample Web app](http://developer.couchbase.com/documentation/server/4.5/travel-app/index.html) guide.
+
+# Requirements and Best Practices
+
+## Container Requirements
+
+Official Couchbase Server containers on Docker Hub are based on Ubuntu 14.04.
+
+**Docker Container Resource Requirements :** For minimum container requirements, you can follow [Couchbase Server minimum HW recommendations](http://developer.couchbase.com/documentation/server/current/install/pre-install.html) for development, test and production environments.
+
+## Best Practices
+
+**Avoid a Single Point of Failure :** Couchbase Server's resilience and high-availability are achieved through creating a cluster of independent nodes and replicating data between them so that any individual node failure doesn't lead to loss of access to your data. In a containerized environment, if you were to run multiple nodes on the same piece of physical hardware, you can inadvertently re-introduce a single point of failure. In environments where you control VM placement, we advise ensuring each Couchbase Server node runs on a different piece of physical hardware.
+
+**Sizing your containers :** Physical hardware performance characteristics are well understood. Even though containers insert a lightweight layer between Couchbase Server and the underlying OS, there is still a small overhead in running Couchbase Server in containers. For stability and better performance predictability, It is recommended to have at least 2 cores dedicated to the container in development environments and 4 cores dedicated to the container rather than shared across multiple containers for Couchbase Server instances running in production. With an over-committed environment you can end up with containers competing with each other causing unpredictable performance and sometimes stability issues.
+
+**Map Couchbase Node Specific Data to a Local Folder :** A Couchbase Server Docker container will write all persistent and node-specific data under the directory /opt/couchbase/var by default. It is recommended to map this directory to a directory on the host file system using the `-v` option to `docker run` to get persistence and performance.
+
+-	Persistence: Storing `/opt/couchbase/var` outside the container with the `-v` option allows you to delete the container and recreate it later without losing the data in Couchbase Server. You can even update to a container running a later release/version of Couchbase Server without losing your data.
+-	Performance: In a standard Docker environment using a union file system, leaving /opt/couchbase/var inside the container results in some amount of performance degradation.
+
+> NOTE for SELinux : If you have SELinux enabled, mounting the host volumes in a container requires an extra step. Assuming you are mounting the `~/couchbase` directory on the host file system, you need to run the following command once before running your first container on that host:
+>
+> `mkdir ~/couchbase && chcon -Rt svirt_sandbox_file_t ~/couchbase`
+
+**Increase ULIMIT in Production Deployments :** Couchbase Server normally expects the following changes to ulimits:
+
+```console
+ulimit -n 40960        # nofile: max number of open files
+ulimit -c unlimited    # core: max core file size
+ulimit -l unlimited    # memlock: maximum locked-in-memory address space
+```
+
+These ulimit settings are necessary when running under heavy load. If you are just doing light testing and development, you can omit these settings, and everything will still work.
+
+To set the ulimits in your container, you will need to run Couchbase Docker containers with the following additional --ulimit flags:
+
+`docker run -d --ulimit nofile=40960:40960 --ulimit core=100000000:100000000 --ulimit memlock=100000000:100000000 --name db -p 8091-8094:8091-8094 -p 11210:11210 couchbase`
+
+Since "unlimited" is not supported as a value, it sets the core and memlock values to 100 GB. If your system has more than 100 GB RAM, you will want to increase this value to match the available RAM on the system.
+
+> Note:The --ulimit flags only work on Docker 1.6 or later.
+
+**Network Configuration and Ports :** Couchbase Server communicates on many different ports (see the [Couchbase Server documentation](http://docs.couchbase.com/admin/admin/Install/install-networkPorts.html)). Also, it is generally not supported that the cluster nodes be placed behind any NAT. For these reasons, Docker's default networking configuration is not ideally suited to Couchbase Server deployments. For production deployments it is recomended to use `--net=host` setting to avoid performance and reliability issues.
+
+# Multi Node Couchbase Server Cluster Deployment Topologies
+
+With multi node Couchbase Server clusters, there are 2 popular topologies.
+
+## All Couchbase Server containers on one physical machine
+
+This model is commonly used for scale-minimized deployments simulating production deployments for development and test purposes. Placing all containers on a single physical machine means all containers will compete for the same resources. Placing all containers on a single physical machine also eliminates the built-in protection against Couchbase Server node failures with replication when the single physical machine fail, all containers experience unavailability at the same time loosing all replicas. These restrictions may be acceptable for test systems, however it isn’t recommended for applications in production.
+
+You can find more details on setting up Couchbase Server in this topology in Couchbase Server [documentation](http://developer.couchbase.com/documentation/server/4.5/install/docker-deploy-multi-node-cluster.html).
+
+	┌──────────────────────────────────────────────────────────┐
+	│                     Host OS (Linux)                      │
+	│                                                          │
+	│  ┌───────────────┐ ┌───────────────┐  ┌───────────────┐  │
+	│  │ Container OS  │ │ Container OS  │  │ Container OS  │  │
+	│  │   (Ubuntu)    │ │   (Ubuntu)    │  │   (Ubuntu)    │  │
+	│  │ ┌───────────┐ │ │ ┌───────────┐ │  │ ┌───────────┐ │  │
+	│  │ │ Couchbase │ │ │ │ Couchbase │ │  │ │ Couchbase │ │  │
+	│  │ │  Server   │ │ │ │  Server   │ │  │ │  Server   │ │  │
+	│  │ └───────────┘ │ │ └───────────┘ │  │ └───────────┘ │  │
+	│  └───────────────┘ └───────────────┘  └───────────────┘  │
+	└──────────────────────────────────────────────────────────┘
+
+
+## Each Couchbase Server container on its own machine
+
+This model is commonly used for production deployments. It prevents Couchbase Server nodes from stepping over each other and gives you better performance predictability. This is the supported topology in production with Couchbase Server 4.5 and higher.
+
+You can find more details on setting up Couchbase Server in this topology in Couchbase Server [documentation](http://developer.couchbase.com/documentation/server/4.5/install/docker-deploy-multi-node-cluster.html).
+
+	┌───────────────────────┐  ┌───────────────────────┐  ┌───────────────────────┐
+	│   Host OS (Linux)     │  │   Host OS (Linux)     │  │   Host OS (Linux)     │
+	│  ┌─────────────────┐  │  │  ┌─────────────────┐  │  │  ┌─────────────────┐  │
+	│  │  Container OS   │  │  │  │  Container OS   │  │  │  │  Container OS   │  │
+	│  │    (Ubuntu)     │  │  │  │    (Ubuntu)     │  │  │  │    (Ubuntu)     │  │
+	│  │  ┌───────────┐  │  │  │  │  ┌───────────┐  │  │  │  │  ┌───────────┐  │  │
+	│  │  │ Couchbase │  │  │  │  │  │ Couchbase │  │  │  │  │  │ Couchbase │  │  │
+	│  │  │  Server   │  │  │  │  │  │  Server   │  │  │  │  │  │  Server   │  │  │
+	│  │  └───────────┘  │  │  │  │  └───────────┘  │  │  │  │  └───────────┘  │  │
+	│  └─────────────────┘  │  │  └─────────────────┘  │  │  └─────────────────┘  │
+	└───────────────────────┘  └───────────────────────┘  └───────────────────────┘
+
+# Additional References
+
+-	[Couchbase Server and Containers](http://www.couchbase.com/containers)
+-	[Getting Started with Couchbbase Server and Docker](http://developer.couchbase.com/documentation/server/4.5/install/getting-started-docker.html)
+-	Detailed Walk-through for [Deploying Couchbase Server on Docker Containers](http://developer.couchbase.com/documentation/server/4.5/install/deploy-with-docker-hub.html)
+
+# Licensing
+
+Couchbase Server comes in 2 Editions: Enterprise Edition and Community Edition. You can find details on the differences between the 2 and licensing details on the [Couchbase Server Editions](http://developer.couchbase.com/documentation/server/4.5/introduction/editions.html) page.
+
+-	Enterprise Edition -- free for development, testing and POCs. Requires a paid subscription for production deployment. Please refer to the [subscribe](http://www.couchbase.com/subscriptions-and-support) page for details on enterprise edition agreements.
+
+-	Community Edition -- free for unrestricted use for community users.
+
+By default, the `latest` Docker tag points to the latest Enterprise Edition. If you want the Community Edition instead, you should add the appropriate tag, such as
+
+```console
+docker run couchbase:community-4.0.0
+```

--- a/enterprise/couchbase-server/4.7.0/scripts/dummy.sh
+++ b/enterprise/couchbase-server/4.7.0/scripts/dummy.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+echo "Running in Docker container - $0 not available"
+

--- a/enterprise/couchbase-server/4.7.0/scripts/entrypoint.sh
+++ b/enterprise/couchbase-server/4.7.0/scripts/entrypoint.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+set -e
+
+[[ "$1" == "couchbase-server" ]] && {
+    echo "Starting Couchbase Server -- Web UI available at http://<ip>:8091 and logs available in /opt/couchbase/var/lib/couchbase/logs"
+    exec /usr/sbin/runsvdir-start
+}
+
+exec "$@"

--- a/enterprise/couchbase-server/4.7.0/scripts/run
+++ b/enterprise/couchbase-server/4.7.0/scripts/run
@@ -1,0 +1,15 @@
+#!/bin/sh
+
+exec 2>&1
+
+# Create directories where couchbase stores its data
+cd /opt/couchbase
+mkdir -p var/lib/couchbase \
+         var/lib/couchbase/config \
+         var/lib/couchbase/data \
+         var/lib/couchbase/stats \
+         var/lib/couchbase/logs \
+         var/lib/moxi
+
+chown -R couchbase:couchbase var
+exec chpst -ucouchbase  /opt/couchbase/bin/couchbase-server -- -kernel global_enable_tracing false -noinput

--- a/generate/templates/couchbase-server/Dockerfile.template
+++ b/generate/templates/couchbase-server/Dockerfile.template
@@ -19,11 +19,12 @@ RUN apt-get update && \
     apt-get autoremove && apt-get clean && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
-ENV CB_VERSION={{ .CB_VERSION }} \
-    CB_RELEASE_URL=http://packages.couchbase.com/releases \
-    CB_PACKAGE={{ .CB_PACKAGE }} \
-    CB_SHA256={{ .CB_SHA256 }} \
-    PATH=$PATH:/opt/couchbase/bin:/opt/couchbase/bin/tools:/opt/couchbase/bin/install
+ARG CB_VERSION={{ .CB_VERSION }}
+ARG CB_RELEASE_URL=http://packages.couchbase.com/releases
+ARG CB_PACKAGE={{ .CB_PACKAGE }}
+ARG CB_SHA256={{ .CB_SHA256 }}
+
+ENV PATH=$PATH:/opt/couchbase/bin:/opt/couchbase/bin/tools:/opt/couchbase/bin/install
 
 # Create Couchbase user with UID 1000 (necessary to match default
 # boot2docker UID)


### PR DESCRIPTION
This allows us to override those values for local builds, and avoids
persisting the values in the image environment unnecessarily.

Also, add a 4.7.0 directory for upcoming release.