### PR TITLE
Ensure bash scripts have LF line endings on Windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+* text=auto
+
+*.sh text eol=lf
+run text eol=lf


### PR DESCRIPTION
Motivation
----------
If bash scripts are checked out on Windows, they'll have CR/LF line
endings by default.  If you then build a Docker image, the image will
not work because bash requires LF line endings.

Modifications
-------------
Ensure that Bash scripts in this repo always get LF line endings, even
if checked out on Windows.

Results
-------
Docker image builds for Couchbase on Linux will now work if built from a
Windows machine.