### PR TITLE
Expose FTS SSL port 18094 for 5.0.0 couchbase-server image

### DIFF
--- a/community/couchbase-server/5.0.0/Dockerfile
+++ b/community/couchbase-server/5.0.0/Dockerfile
@@ -64,6 +64,7 @@ CMD ["couchbase-server"]
 # 18091: Couchbase Web console, REST/HTTP interface (SSL)
 # 18092: Views, query, XDCR (SSL)
 # 18093: Query services (SSL) (4.0+)
-EXPOSE 8091 8092 8093 8094 11207 11210 11211 18091 18092 18093
+# 18094: Full-text Search (SSL) (4.5+)
+EXPOSE 8091 8092 8093 8094 11207 11210 11211 18091 18092 18093 18094
 VOLUME /opt/couchbase/var
 

--- a/enterprise/couchbase-server/5.0.0/Dockerfile
+++ b/enterprise/couchbase-server/5.0.0/Dockerfile
@@ -64,6 +64,7 @@ CMD ["couchbase-server"]
 # 18091: Couchbase Web console, REST/HTTP interface (SSL)
 # 18092: Views, query, XDCR (SSL)
 # 18093: Query services (SSL) (4.0+)
-EXPOSE 8091 8092 8093 8094 11207 11210 11211 18091 18092 18093
+# 18094: Full-text Search (SSL) (4.5+)
+EXPOSE 8091 8092 8093 8094 11207 11210 11211 18091 18092 18093 18094
 VOLUME /opt/couchbase/var
 


### PR DESCRIPTION
Motivation
----------
In addition to the already exposed FTS port 8094, it can also run over
SSL using port 18094.

Modifications
-------------
Expose port 18094 in the Dockerfile for 5.0.0.

Results
-------
It is now more obvious to image users which ports may need to be mapped
for complete functionality.