### PR TITLE
Allow ports to be overridden

### DIFF
--- a/generate/resources/couchbase-server/scripts/entrypoint.sh
+++ b/generate/resources/couchbase-server/scripts/entrypoint.sh
@@ -1,8 +1,46 @@
 #!/bin/bash
 set -e
 
+staticConfigFile=/opt/couchbase/etc/couchbase/static_config
+restPortValue=8091
+
+# see https://developer.couchbase.com/documentation/server/current/install/install-ports.html
+function overridePort() {
+    portName=$1
+    portNameUpper=$(echo $portName | awk '{print toupper($0)}')
+    portValue=${!portNameUpper}
+
+    # only override port if value available AND not already contained in static_config
+    if [ "$portValue" != "" ]; then
+        if grep -Fq "{${portName}," ${staticConfigFile}
+        then
+            echo "Don't override port ${portName} because already available in $staticConfigFile"
+        else
+            echo "Override port '$portName' with value '$portValue'"
+            echo "{$portName, $portValue}." >> ${staticConfigFile}
+
+            if [ ${portName} == "rest_port" ]; then
+                restPortValue=${portValue}
+            fi
+        fi
+    fi
+}
+
+overridePort "rest_port"
+overridePort "mccouch_port"
+overridePort "memcached_port"
+overridePort "query_port"
+overridePort "ssl_query_port"
+overridePort "fts_http_port"
+overridePort "moxi_port"
+overridePort "ssl_rest_port"
+overridePort "ssl_capi_port"
+overridePort "ssl_proxy_downstream_port"
+overridePort "ssl_proxy_upstream_port"
+
+
 [[ "$1" == "couchbase-server" ]] && {
-    echo "Starting Couchbase Server -- Web UI available at http://<ip>:8091 and logs available in /opt/couchbase/var/lib/couchbase/logs"
+    echo "Starting Couchbase Server -- Web UI available at http://<ip>:$restPortValue and logs available in /opt/couchbase/var/lib/couchbase/logs"
     exec /usr/sbin/runsvdir-start
 }
 


### PR DESCRIPTION
When ports are specified as environment variable, they override their
default ports in the `static_config`.

So to override e.g. `rest_port`, just the environment-var `REST_PORT=1234`
must be defined. The statement is valid to say, why not doing this via 
docker port bindings. True, for rest_port this would work but for other ports
like the `query_port` it wouldn't.