### PR TITLE
Add entrypoint.sh for sync_gateway and tee to logfiles for sgcollect_info

### DIFF
--- a/community/sync-gateway/1.0.4/Dockerfile
+++ b/community/sync-gateway/1.0.4/Dockerfile
@@ -22,8 +22,9 @@ RUN mkdir /opt/couchbase-sync-gateway/data
 # copy the default config into the container
 COPY config/sync_gateway_config.json /etc/sync_gateway/config.json
 
-# Invoke the sync_gateway executable by default
-ENTRYPOINT ["sync_gateway"]
+# Add bootstrap script
+COPY scripts/entrypoint.sh /
+ENTRYPOINT ["/entrypoint.sh"]
 
 # If user doesn't specify any args, use the default config
 CMD ["/etc/sync_gateway/config.json"]
@@ -31,4 +32,3 @@ CMD ["/etc/sync_gateway/config.json"]
 # Expose ports
 #  port 4984: public port
 EXPOSE 4984
-

--- a/community/sync-gateway/1.0.4/scripts/entrypoint.sh
+++ b/community/sync-gateway/1.0.4/scripts/entrypoint.sh
@@ -1,11 +1,12 @@
 #!/bin/bash
 set -e
 
-# Set up symlinks to log into a 'normal' location.
-mkdir -p /var/log/sync_gateway
-ln -sf /stdout.log /var/log/sync_gateway/sync_gateway_access.log
-ln -sf /stderr.log /var/log/sync_gateway/sync_gateway_error.log
+LOGFILE_DIR=/var/log/sync_gateway
+mkdir -p $LOGFILE_DIR
+
+LOGFILE_ACCESS=$LOGFILE_DIR/sync_gateway_access.log
+LOGFILE_ERROR=$LOGFILE_DIR/sync_gateway_error.log
 
 # Run SG and use tee to append stdout and stderr to separate logfiles
 # Process substitution described here: https://stackoverflow.com/a/692407
-exec sync_gateway "$@" > >(tee -a /stdout.log) 2> >(tee -a /stderr.log >&2)
+exec sync_gateway "$@" > >(tee -a $LOGFILE_ACCESS) 2> >(tee -a $LOGFILE_ERROR >&2)

--- a/community/sync-gateway/1.0.4/scripts/entrypoint.sh
+++ b/community/sync-gateway/1.0.4/scripts/entrypoint.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+set -e
+
+# Set up symlinks to log into a 'normal' location.
+mkdir -p /var/log/sync_gateway
+ln -sf /stdout.log /var/log/sync_gateway/sync_gateway_access.log
+ln -sf /stderr.log /var/log/sync_gateway/sync_gateway_error.log
+
+# Run SG and use tee to append stdout and stderr to separate logfiles
+# Process substitution described here: https://stackoverflow.com/a/692407
+exec sync_gateway "$@" > >(tee -a /stdout.log) 2> >(tee -a /stderr.log >&2)

--- a/community/sync-gateway/1.1.0-forestdb_bucket/Dockerfile
+++ b/community/sync-gateway/1.1.0-forestdb_bucket/Dockerfile
@@ -22,8 +22,9 @@ RUN mkdir /opt/couchbase-sync-gateway/data
 # copy the default config into the container
 COPY config/sync_gateway_config.json /etc/sync_gateway/config.json
 
-# Invoke the sync_gateway executable by default
-ENTRYPOINT ["sync_gateway"]
+# Add bootstrap script
+COPY scripts/entrypoint.sh /
+ENTRYPOINT ["/entrypoint.sh"]
 
 # If user doesn't specify any args, use the default config
 CMD ["/etc/sync_gateway/config.json"]
@@ -31,4 +32,3 @@ CMD ["/etc/sync_gateway/config.json"]
 # Expose ports
 #  port 4984: public port
 EXPOSE 4984
-

--- a/community/sync-gateway/1.1.0-forestdb_bucket/scripts/entrypoint.sh
+++ b/community/sync-gateway/1.1.0-forestdb_bucket/scripts/entrypoint.sh
@@ -1,11 +1,12 @@
 #!/bin/bash
 set -e
 
-# Set up symlinks to log into a 'normal' location.
-mkdir -p /var/log/sync_gateway
-ln -sf /stdout.log /var/log/sync_gateway/sync_gateway_access.log
-ln -sf /stderr.log /var/log/sync_gateway/sync_gateway_error.log
+LOGFILE_DIR=/var/log/sync_gateway
+mkdir -p $LOGFILE_DIR
+
+LOGFILE_ACCESS=$LOGFILE_DIR/sync_gateway_access.log
+LOGFILE_ERROR=$LOGFILE_DIR/sync_gateway_error.log
 
 # Run SG and use tee to append stdout and stderr to separate logfiles
 # Process substitution described here: https://stackoverflow.com/a/692407
-exec sync_gateway "$@" > >(tee -a /stdout.log) 2> >(tee -a /stderr.log >&2)
+exec sync_gateway "$@" > >(tee -a $LOGFILE_ACCESS) 2> >(tee -a $LOGFILE_ERROR >&2)

--- a/community/sync-gateway/1.1.0-forestdb_bucket/scripts/entrypoint.sh
+++ b/community/sync-gateway/1.1.0-forestdb_bucket/scripts/entrypoint.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+set -e
+
+# Set up symlinks to log into a 'normal' location.
+mkdir -p /var/log/sync_gateway
+ln -sf /stdout.log /var/log/sync_gateway/sync_gateway_access.log
+ln -sf /stderr.log /var/log/sync_gateway/sync_gateway_error.log
+
+# Run SG and use tee to append stdout and stderr to separate logfiles
+# Process substitution described here: https://stackoverflow.com/a/692407
+exec sync_gateway "$@" > >(tee -a /stdout.log) 2> >(tee -a /stderr.log >&2)

--- a/community/sync-gateway/1.1.0/Dockerfile
+++ b/community/sync-gateway/1.1.0/Dockerfile
@@ -22,8 +22,9 @@ RUN mkdir /opt/couchbase-sync-gateway/data
 # copy the default config into the container
 COPY config/sync_gateway_config.json /etc/sync_gateway/config.json
 
-# Invoke the sync_gateway executable by default
-ENTRYPOINT ["sync_gateway"]
+# Add bootstrap script
+COPY scripts/entrypoint.sh /
+ENTRYPOINT ["/entrypoint.sh"]
 
 # If user doesn't specify any args, use the default config
 CMD ["/etc/sync_gateway/config.json"]
@@ -31,4 +32,3 @@ CMD ["/etc/sync_gateway/config.json"]
 # Expose ports
 #  port 4984: public port
 EXPOSE 4984
-

--- a/community/sync-gateway/1.1.0/scripts/entrypoint.sh
+++ b/community/sync-gateway/1.1.0/scripts/entrypoint.sh
@@ -1,11 +1,12 @@
 #!/bin/bash
 set -e
 
-# Set up symlinks to log into a 'normal' location.
-mkdir -p /var/log/sync_gateway
-ln -sf /stdout.log /var/log/sync_gateway/sync_gateway_access.log
-ln -sf /stderr.log /var/log/sync_gateway/sync_gateway_error.log
+LOGFILE_DIR=/var/log/sync_gateway
+mkdir -p $LOGFILE_DIR
+
+LOGFILE_ACCESS=$LOGFILE_DIR/sync_gateway_access.log
+LOGFILE_ERROR=$LOGFILE_DIR/sync_gateway_error.log
 
 # Run SG and use tee to append stdout and stderr to separate logfiles
 # Process substitution described here: https://stackoverflow.com/a/692407
-exec sync_gateway "$@" > >(tee -a /stdout.log) 2> >(tee -a /stderr.log >&2)
+exec sync_gateway "$@" > >(tee -a $LOGFILE_ACCESS) 2> >(tee -a $LOGFILE_ERROR >&2)

--- a/community/sync-gateway/1.1.0/scripts/entrypoint.sh
+++ b/community/sync-gateway/1.1.0/scripts/entrypoint.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+set -e
+
+# Set up symlinks to log into a 'normal' location.
+mkdir -p /var/log/sync_gateway
+ln -sf /stdout.log /var/log/sync_gateway/sync_gateway_access.log
+ln -sf /stderr.log /var/log/sync_gateway/sync_gateway_error.log
+
+# Run SG and use tee to append stdout and stderr to separate logfiles
+# Process substitution described here: https://stackoverflow.com/a/692407
+exec sync_gateway "$@" > >(tee -a /stdout.log) 2> >(tee -a /stderr.log >&2)

--- a/community/sync-gateway/1.1.1/Dockerfile
+++ b/community/sync-gateway/1.1.1/Dockerfile
@@ -22,8 +22,9 @@ RUN mkdir /opt/couchbase-sync-gateway/data
 # copy the default config into the container
 COPY config/sync_gateway_config.json /etc/sync_gateway/config.json
 
-# Invoke the sync_gateway executable by default
-ENTRYPOINT ["sync_gateway"]
+# Add bootstrap script
+COPY scripts/entrypoint.sh /
+ENTRYPOINT ["/entrypoint.sh"]
 
 # If user doesn't specify any args, use the default config
 CMD ["/etc/sync_gateway/config.json"]
@@ -31,4 +32,3 @@ CMD ["/etc/sync_gateway/config.json"]
 # Expose ports
 #  port 4984: public port
 EXPOSE 4984
-

--- a/community/sync-gateway/1.1.1/scripts/entrypoint.sh
+++ b/community/sync-gateway/1.1.1/scripts/entrypoint.sh
@@ -1,11 +1,12 @@
 #!/bin/bash
 set -e
 
-# Set up symlinks to log into a 'normal' location.
-mkdir -p /var/log/sync_gateway
-ln -sf /stdout.log /var/log/sync_gateway/sync_gateway_access.log
-ln -sf /stderr.log /var/log/sync_gateway/sync_gateway_error.log
+LOGFILE_DIR=/var/log/sync_gateway
+mkdir -p $LOGFILE_DIR
+
+LOGFILE_ACCESS=$LOGFILE_DIR/sync_gateway_access.log
+LOGFILE_ERROR=$LOGFILE_DIR/sync_gateway_error.log
 
 # Run SG and use tee to append stdout and stderr to separate logfiles
 # Process substitution described here: https://stackoverflow.com/a/692407
-exec sync_gateway "$@" > >(tee -a /stdout.log) 2> >(tee -a /stderr.log >&2)
+exec sync_gateway "$@" > >(tee -a $LOGFILE_ACCESS) 2> >(tee -a $LOGFILE_ERROR >&2)

--- a/community/sync-gateway/1.1.1/scripts/entrypoint.sh
+++ b/community/sync-gateway/1.1.1/scripts/entrypoint.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+set -e
+
+# Set up symlinks to log into a 'normal' location.
+mkdir -p /var/log/sync_gateway
+ln -sf /stdout.log /var/log/sync_gateway/sync_gateway_access.log
+ln -sf /stderr.log /var/log/sync_gateway/sync_gateway_error.log
+
+# Run SG and use tee to append stdout and stderr to separate logfiles
+# Process substitution described here: https://stackoverflow.com/a/692407
+exec sync_gateway "$@" > >(tee -a /stdout.log) 2> >(tee -a /stderr.log >&2)

--- a/community/sync-gateway/1.2.0-rc0/Dockerfile
+++ b/community/sync-gateway/1.2.0-rc0/Dockerfile
@@ -22,8 +22,9 @@ RUN mkdir /opt/couchbase-sync-gateway/data
 # copy the default config into the container
 COPY config/sync_gateway_config.json /etc/sync_gateway/config.json
 
-# Invoke the sync_gateway executable by default
-ENTRYPOINT ["sync_gateway"]
+# Add bootstrap script
+COPY scripts/entrypoint.sh /
+ENTRYPOINT ["/entrypoint.sh"]
 
 # If user doesn't specify any args, use the default config
 CMD ["/etc/sync_gateway/config.json"]
@@ -31,4 +32,3 @@ CMD ["/etc/sync_gateway/config.json"]
 # Expose ports
 #  port 4984: public port
 EXPOSE 4984
-

--- a/community/sync-gateway/1.2.0-rc0/scripts/entrypoint.sh
+++ b/community/sync-gateway/1.2.0-rc0/scripts/entrypoint.sh
@@ -1,11 +1,12 @@
 #!/bin/bash
 set -e
 
-# Set up symlinks to log into a 'normal' location.
-mkdir -p /var/log/sync_gateway
-ln -sf /stdout.log /var/log/sync_gateway/sync_gateway_access.log
-ln -sf /stderr.log /var/log/sync_gateway/sync_gateway_error.log
+LOGFILE_DIR=/var/log/sync_gateway
+mkdir -p $LOGFILE_DIR
+
+LOGFILE_ACCESS=$LOGFILE_DIR/sync_gateway_access.log
+LOGFILE_ERROR=$LOGFILE_DIR/sync_gateway_error.log
 
 # Run SG and use tee to append stdout and stderr to separate logfiles
 # Process substitution described here: https://stackoverflow.com/a/692407
-exec sync_gateway "$@" > >(tee -a /stdout.log) 2> >(tee -a /stderr.log >&2)
+exec sync_gateway "$@" > >(tee -a $LOGFILE_ACCESS) 2> >(tee -a $LOGFILE_ERROR >&2)

--- a/community/sync-gateway/1.2.0-rc0/scripts/entrypoint.sh
+++ b/community/sync-gateway/1.2.0-rc0/scripts/entrypoint.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+set -e
+
+# Set up symlinks to log into a 'normal' location.
+mkdir -p /var/log/sync_gateway
+ln -sf /stdout.log /var/log/sync_gateway/sync_gateway_access.log
+ln -sf /stderr.log /var/log/sync_gateway/sync_gateway_error.log
+
+# Run SG and use tee to append stdout and stderr to separate logfiles
+# Process substitution described here: https://stackoverflow.com/a/692407
+exec sync_gateway "$@" > >(tee -a /stdout.log) 2> >(tee -a /stderr.log >&2)

--- a/community/sync-gateway/1.2.0-rc1/Dockerfile
+++ b/community/sync-gateway/1.2.0-rc1/Dockerfile
@@ -22,8 +22,9 @@ RUN mkdir /opt/couchbase-sync-gateway/data
 # copy the default config into the container
 COPY config/sync_gateway_config.json /etc/sync_gateway/config.json
 
-# Invoke the sync_gateway executable by default
-ENTRYPOINT ["sync_gateway"]
+# Add bootstrap script
+COPY scripts/entrypoint.sh /
+ENTRYPOINT ["/entrypoint.sh"]
 
 # If user doesn't specify any args, use the default config
 CMD ["/etc/sync_gateway/config.json"]
@@ -31,4 +32,3 @@ CMD ["/etc/sync_gateway/config.json"]
 # Expose ports
 #  port 4984: public port
 EXPOSE 4984
-

--- a/community/sync-gateway/1.2.0-rc1/scripts/entrypoint.sh
+++ b/community/sync-gateway/1.2.0-rc1/scripts/entrypoint.sh
@@ -1,11 +1,12 @@
 #!/bin/bash
 set -e
 
-# Set up symlinks to log into a 'normal' location.
-mkdir -p /var/log/sync_gateway
-ln -sf /stdout.log /var/log/sync_gateway/sync_gateway_access.log
-ln -sf /stderr.log /var/log/sync_gateway/sync_gateway_error.log
+LOGFILE_DIR=/var/log/sync_gateway
+mkdir -p $LOGFILE_DIR
+
+LOGFILE_ACCESS=$LOGFILE_DIR/sync_gateway_access.log
+LOGFILE_ERROR=$LOGFILE_DIR/sync_gateway_error.log
 
 # Run SG and use tee to append stdout and stderr to separate logfiles
 # Process substitution described here: https://stackoverflow.com/a/692407
-exec sync_gateway "$@" > >(tee -a /stdout.log) 2> >(tee -a /stderr.log >&2)
+exec sync_gateway "$@" > >(tee -a $LOGFILE_ACCESS) 2> >(tee -a $LOGFILE_ERROR >&2)

--- a/community/sync-gateway/1.2.0-rc1/scripts/entrypoint.sh
+++ b/community/sync-gateway/1.2.0-rc1/scripts/entrypoint.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+set -e
+
+# Set up symlinks to log into a 'normal' location.
+mkdir -p /var/log/sync_gateway
+ln -sf /stdout.log /var/log/sync_gateway/sync_gateway_access.log
+ln -sf /stderr.log /var/log/sync_gateway/sync_gateway_error.log
+
+# Run SG and use tee to append stdout and stderr to separate logfiles
+# Process substitution described here: https://stackoverflow.com/a/692407
+exec sync_gateway "$@" > >(tee -a /stdout.log) 2> >(tee -a /stderr.log >&2)

--- a/community/sync-gateway/1.2.0/Dockerfile
+++ b/community/sync-gateway/1.2.0/Dockerfile
@@ -22,8 +22,9 @@ RUN mkdir /opt/couchbase-sync-gateway/data
 # copy the default config into the container
 COPY config/sync_gateway_config.json /etc/sync_gateway/config.json
 
-# Invoke the sync_gateway executable by default
-ENTRYPOINT ["sync_gateway"]
+# Add bootstrap script
+COPY scripts/entrypoint.sh /
+ENTRYPOINT ["/entrypoint.sh"]
 
 # If user doesn't specify any args, use the default config
 CMD ["/etc/sync_gateway/config.json"]
@@ -31,4 +32,3 @@ CMD ["/etc/sync_gateway/config.json"]
 # Expose ports
 #  port 4984: public port
 EXPOSE 4984
-

--- a/community/sync-gateway/1.2.0/scripts/entrypoint.sh
+++ b/community/sync-gateway/1.2.0/scripts/entrypoint.sh
@@ -1,11 +1,12 @@
 #!/bin/bash
 set -e
 
-# Set up symlinks to log into a 'normal' location.
-mkdir -p /var/log/sync_gateway
-ln -sf /stdout.log /var/log/sync_gateway/sync_gateway_access.log
-ln -sf /stderr.log /var/log/sync_gateway/sync_gateway_error.log
+LOGFILE_DIR=/var/log/sync_gateway
+mkdir -p $LOGFILE_DIR
+
+LOGFILE_ACCESS=$LOGFILE_DIR/sync_gateway_access.log
+LOGFILE_ERROR=$LOGFILE_DIR/sync_gateway_error.log
 
 # Run SG and use tee to append stdout and stderr to separate logfiles
 # Process substitution described here: https://stackoverflow.com/a/692407
-exec sync_gateway "$@" > >(tee -a /stdout.log) 2> >(tee -a /stderr.log >&2)
+exec sync_gateway "$@" > >(tee -a $LOGFILE_ACCESS) 2> >(tee -a $LOGFILE_ERROR >&2)

--- a/community/sync-gateway/1.2.0/scripts/entrypoint.sh
+++ b/community/sync-gateway/1.2.0/scripts/entrypoint.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+set -e
+
+# Set up symlinks to log into a 'normal' location.
+mkdir -p /var/log/sync_gateway
+ln -sf /stdout.log /var/log/sync_gateway/sync_gateway_access.log
+ln -sf /stderr.log /var/log/sync_gateway/sync_gateway_error.log
+
+# Run SG and use tee to append stdout and stderr to separate logfiles
+# Process substitution described here: https://stackoverflow.com/a/692407
+exec sync_gateway "$@" > >(tee -a /stdout.log) 2> >(tee -a /stderr.log >&2)

--- a/community/sync-gateway/1.2.1/Dockerfile
+++ b/community/sync-gateway/1.2.1/Dockerfile
@@ -22,8 +22,9 @@ RUN mkdir /opt/couchbase-sync-gateway/data
 # copy the default config into the container
 COPY config/sync_gateway_config.json /etc/sync_gateway/config.json
 
-# Invoke the sync_gateway executable by default
-ENTRYPOINT ["sync_gateway"]
+# Add bootstrap script
+COPY scripts/entrypoint.sh /
+ENTRYPOINT ["/entrypoint.sh"]
 
 # If user doesn't specify any args, use the default config
 CMD ["/etc/sync_gateway/config.json"]
@@ -31,4 +32,3 @@ CMD ["/etc/sync_gateway/config.json"]
 # Expose ports
 #  port 4984: public port
 EXPOSE 4984
-

--- a/community/sync-gateway/1.2.1/scripts/entrypoint.sh
+++ b/community/sync-gateway/1.2.1/scripts/entrypoint.sh
@@ -1,11 +1,12 @@
 #!/bin/bash
 set -e
 
-# Set up symlinks to log into a 'normal' location.
-mkdir -p /var/log/sync_gateway
-ln -sf /stdout.log /var/log/sync_gateway/sync_gateway_access.log
-ln -sf /stderr.log /var/log/sync_gateway/sync_gateway_error.log
+LOGFILE_DIR=/var/log/sync_gateway
+mkdir -p $LOGFILE_DIR
+
+LOGFILE_ACCESS=$LOGFILE_DIR/sync_gateway_access.log
+LOGFILE_ERROR=$LOGFILE_DIR/sync_gateway_error.log
 
 # Run SG and use tee to append stdout and stderr to separate logfiles
 # Process substitution described here: https://stackoverflow.com/a/692407
-exec sync_gateway "$@" > >(tee -a /stdout.log) 2> >(tee -a /stderr.log >&2)
+exec sync_gateway "$@" > >(tee -a $LOGFILE_ACCESS) 2> >(tee -a $LOGFILE_ERROR >&2)

--- a/community/sync-gateway/1.2.1/scripts/entrypoint.sh
+++ b/community/sync-gateway/1.2.1/scripts/entrypoint.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+set -e
+
+# Set up symlinks to log into a 'normal' location.
+mkdir -p /var/log/sync_gateway
+ln -sf /stdout.log /var/log/sync_gateway/sync_gateway_access.log
+ln -sf /stderr.log /var/log/sync_gateway/sync_gateway_error.log
+
+# Run SG and use tee to append stdout and stderr to separate logfiles
+# Process substitution described here: https://stackoverflow.com/a/692407
+exec sync_gateway "$@" > >(tee -a /stdout.log) 2> >(tee -a /stderr.log >&2)

--- a/community/sync-gateway/1.3.0-274/Dockerfile
+++ b/community/sync-gateway/1.3.0-274/Dockerfile
@@ -22,8 +22,9 @@ RUN mkdir /opt/couchbase-sync-gateway/data
 # copy the default config into the container
 COPY config/sync_gateway_config.json /etc/sync_gateway/config.json
 
-# Invoke the sync_gateway executable by default
-ENTRYPOINT ["sync_gateway"]
+# Add bootstrap script
+COPY scripts/entrypoint.sh /
+ENTRYPOINT ["/entrypoint.sh"]
 
 # If user doesn't specify any args, use the default config
 CMD ["/etc/sync_gateway/config.json"]
@@ -31,4 +32,3 @@ CMD ["/etc/sync_gateway/config.json"]
 # Expose ports
 #  port 4984: public port
 EXPOSE 4984
-

--- a/community/sync-gateway/1.3.0-274/scripts/entrypoint.sh
+++ b/community/sync-gateway/1.3.0-274/scripts/entrypoint.sh
@@ -1,11 +1,12 @@
 #!/bin/bash
 set -e
 
-# Set up symlinks to log into a 'normal' location.
-mkdir -p /var/log/sync_gateway
-ln -sf /stdout.log /var/log/sync_gateway/sync_gateway_access.log
-ln -sf /stderr.log /var/log/sync_gateway/sync_gateway_error.log
+LOGFILE_DIR=/var/log/sync_gateway
+mkdir -p $LOGFILE_DIR
+
+LOGFILE_ACCESS=$LOGFILE_DIR/sync_gateway_access.log
+LOGFILE_ERROR=$LOGFILE_DIR/sync_gateway_error.log
 
 # Run SG and use tee to append stdout and stderr to separate logfiles
 # Process substitution described here: https://stackoverflow.com/a/692407
-exec sync_gateway "$@" > >(tee -a /stdout.log) 2> >(tee -a /stderr.log >&2)
+exec sync_gateway "$@" > >(tee -a $LOGFILE_ACCESS) 2> >(tee -a $LOGFILE_ERROR >&2)

--- a/community/sync-gateway/1.3.0-274/scripts/entrypoint.sh
+++ b/community/sync-gateway/1.3.0-274/scripts/entrypoint.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+set -e
+
+# Set up symlinks to log into a 'normal' location.
+mkdir -p /var/log/sync_gateway
+ln -sf /stdout.log /var/log/sync_gateway/sync_gateway_access.log
+ln -sf /stderr.log /var/log/sync_gateway/sync_gateway_error.log
+
+# Run SG and use tee to append stdout and stderr to separate logfiles
+# Process substitution described here: https://stackoverflow.com/a/692407
+exec sync_gateway "$@" > >(tee -a /stdout.log) 2> >(tee -a /stderr.log >&2)

--- a/community/sync-gateway/1.3.1-16/Dockerfile
+++ b/community/sync-gateway/1.3.1-16/Dockerfile
@@ -22,8 +22,9 @@ RUN mkdir /opt/couchbase-sync-gateway/data
 # copy the default config into the container
 COPY config/sync_gateway_config.json /etc/sync_gateway/config.json
 
-# Invoke the sync_gateway executable by default
-ENTRYPOINT ["sync_gateway"]
+# Add bootstrap script
+COPY scripts/entrypoint.sh /
+ENTRYPOINT ["/entrypoint.sh"]
 
 # If user doesn't specify any args, use the default config
 CMD ["/etc/sync_gateway/config.json"]
@@ -31,4 +32,3 @@ CMD ["/etc/sync_gateway/config.json"]
 # Expose ports
 #  port 4984: public port
 EXPOSE 4984
-

--- a/community/sync-gateway/1.3.1-16/scripts/entrypoint.sh
+++ b/community/sync-gateway/1.3.1-16/scripts/entrypoint.sh
@@ -1,11 +1,12 @@
 #!/bin/bash
 set -e
 
-# Set up symlinks to log into a 'normal' location.
-mkdir -p /var/log/sync_gateway
-ln -sf /stdout.log /var/log/sync_gateway/sync_gateway_access.log
-ln -sf /stderr.log /var/log/sync_gateway/sync_gateway_error.log
+LOGFILE_DIR=/var/log/sync_gateway
+mkdir -p $LOGFILE_DIR
+
+LOGFILE_ACCESS=$LOGFILE_DIR/sync_gateway_access.log
+LOGFILE_ERROR=$LOGFILE_DIR/sync_gateway_error.log
 
 # Run SG and use tee to append stdout and stderr to separate logfiles
 # Process substitution described here: https://stackoverflow.com/a/692407
-exec sync_gateway "$@" > >(tee -a /stdout.log) 2> >(tee -a /stderr.log >&2)
+exec sync_gateway "$@" > >(tee -a $LOGFILE_ACCESS) 2> >(tee -a $LOGFILE_ERROR >&2)

--- a/community/sync-gateway/1.3.1-16/scripts/entrypoint.sh
+++ b/community/sync-gateway/1.3.1-16/scripts/entrypoint.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+set -e
+
+# Set up symlinks to log into a 'normal' location.
+mkdir -p /var/log/sync_gateway
+ln -sf /stdout.log /var/log/sync_gateway/sync_gateway_access.log
+ln -sf /stderr.log /var/log/sync_gateway/sync_gateway_error.log
+
+# Run SG and use tee to append stdout and stderr to separate logfiles
+# Process substitution described here: https://stackoverflow.com/a/692407
+exec sync_gateway "$@" > >(tee -a /stdout.log) 2> >(tee -a /stderr.log >&2)

--- a/community/sync-gateway/1.4.0-2/Dockerfile
+++ b/community/sync-gateway/1.4.0-2/Dockerfile
@@ -22,8 +22,9 @@ RUN mkdir /opt/couchbase-sync-gateway/data
 # copy the default config into the container
 COPY config/sync_gateway_config.json /etc/sync_gateway/config.json
 
-# Invoke the sync_gateway executable by default
-ENTRYPOINT ["sync_gateway"]
+# Add bootstrap script
+COPY scripts/entrypoint.sh /
+ENTRYPOINT ["/entrypoint.sh"]
 
 # If user doesn't specify any args, use the default config
 CMD ["/etc/sync_gateway/config.json"]
@@ -31,4 +32,3 @@ CMD ["/etc/sync_gateway/config.json"]
 # Expose ports
 #  port 4984: public port
 EXPOSE 4984
-

--- a/community/sync-gateway/1.4.0-2/scripts/entrypoint.sh
+++ b/community/sync-gateway/1.4.0-2/scripts/entrypoint.sh
@@ -1,11 +1,12 @@
 #!/bin/bash
 set -e
 
-# Set up symlinks to log into a 'normal' location.
-mkdir -p /var/log/sync_gateway
-ln -sf /stdout.log /var/log/sync_gateway/sync_gateway_access.log
-ln -sf /stderr.log /var/log/sync_gateway/sync_gateway_error.log
+LOGFILE_DIR=/var/log/sync_gateway
+mkdir -p $LOGFILE_DIR
+
+LOGFILE_ACCESS=$LOGFILE_DIR/sync_gateway_access.log
+LOGFILE_ERROR=$LOGFILE_DIR/sync_gateway_error.log
 
 # Run SG and use tee to append stdout and stderr to separate logfiles
 # Process substitution described here: https://stackoverflow.com/a/692407
-exec sync_gateway "$@" > >(tee -a /stdout.log) 2> >(tee -a /stderr.log >&2)
+exec sync_gateway "$@" > >(tee -a $LOGFILE_ACCESS) 2> >(tee -a $LOGFILE_ERROR >&2)

--- a/community/sync-gateway/1.4.0-2/scripts/entrypoint.sh
+++ b/community/sync-gateway/1.4.0-2/scripts/entrypoint.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+set -e
+
+# Set up symlinks to log into a 'normal' location.
+mkdir -p /var/log/sync_gateway
+ln -sf /stdout.log /var/log/sync_gateway/sync_gateway_access.log
+ln -sf /stderr.log /var/log/sync_gateway/sync_gateway_error.log
+
+# Run SG and use tee to append stdout and stderr to separate logfiles
+# Process substitution described here: https://stackoverflow.com/a/692407
+exec sync_gateway "$@" > >(tee -a /stdout.log) 2> >(tee -a /stderr.log >&2)

--- a/community/sync-gateway/1.4.1-3/Dockerfile
+++ b/community/sync-gateway/1.4.1-3/Dockerfile
@@ -22,8 +22,9 @@ RUN mkdir /opt/couchbase-sync-gateway/data
 # copy the default config into the container
 COPY config/sync_gateway_config.json /etc/sync_gateway/config.json
 
-# Invoke the sync_gateway executable by default
-ENTRYPOINT ["sync_gateway"]
+# Add bootstrap script
+COPY scripts/entrypoint.sh /
+ENTRYPOINT ["/entrypoint.sh"]
 
 # If user doesn't specify any args, use the default config
 CMD ["/etc/sync_gateway/config.json"]
@@ -31,4 +32,3 @@ CMD ["/etc/sync_gateway/config.json"]
 # Expose ports
 #  port 4984: public port
 EXPOSE 4984
-

--- a/community/sync-gateway/1.4.1-3/scripts/entrypoint.sh
+++ b/community/sync-gateway/1.4.1-3/scripts/entrypoint.sh
@@ -1,11 +1,12 @@
 #!/bin/bash
 set -e
 
-# Set up symlinks to log into a 'normal' location.
-mkdir -p /var/log/sync_gateway
-ln -sf /stdout.log /var/log/sync_gateway/sync_gateway_access.log
-ln -sf /stderr.log /var/log/sync_gateway/sync_gateway_error.log
+LOGFILE_DIR=/var/log/sync_gateway
+mkdir -p $LOGFILE_DIR
+
+LOGFILE_ACCESS=$LOGFILE_DIR/sync_gateway_access.log
+LOGFILE_ERROR=$LOGFILE_DIR/sync_gateway_error.log
 
 # Run SG and use tee to append stdout and stderr to separate logfiles
 # Process substitution described here: https://stackoverflow.com/a/692407
-exec sync_gateway "$@" > >(tee -a /stdout.log) 2> >(tee -a /stderr.log >&2)
+exec sync_gateway "$@" > >(tee -a $LOGFILE_ACCESS) 2> >(tee -a $LOGFILE_ERROR >&2)

--- a/community/sync-gateway/1.4.1-3/scripts/entrypoint.sh
+++ b/community/sync-gateway/1.4.1-3/scripts/entrypoint.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+set -e
+
+# Set up symlinks to log into a 'normal' location.
+mkdir -p /var/log/sync_gateway
+ln -sf /stdout.log /var/log/sync_gateway/sync_gateway_access.log
+ln -sf /stderr.log /var/log/sync_gateway/sync_gateway_error.log
+
+# Run SG and use tee to append stdout and stderr to separate logfiles
+# Process substitution described here: https://stackoverflow.com/a/692407
+exec sync_gateway "$@" > >(tee -a /stdout.log) 2> >(tee -a /stderr.log >&2)

--- a/community/sync-gateway/1.5.0-377/Dockerfile
+++ b/community/sync-gateway/1.5.0-377/Dockerfile
@@ -22,8 +22,9 @@ RUN mkdir /opt/couchbase-sync-gateway/data
 # copy the default config into the container
 COPY config/sync_gateway_config.json /etc/sync_gateway/config.json
 
-# Invoke the sync_gateway executable by default
-ENTRYPOINT ["sync_gateway"]
+# Add bootstrap script
+COPY scripts/entrypoint.sh /
+ENTRYPOINT ["/entrypoint.sh"]
 
 # If user doesn't specify any args, use the default config
 CMD ["/etc/sync_gateway/config.json"]
@@ -31,4 +32,3 @@ CMD ["/etc/sync_gateway/config.json"]
 # Expose ports
 #  port 4984: public port
 EXPOSE 4984
-

--- a/community/sync-gateway/1.5.0-377/scripts/entrypoint.sh
+++ b/community/sync-gateway/1.5.0-377/scripts/entrypoint.sh
@@ -1,11 +1,12 @@
 #!/bin/bash
 set -e
 
-# Set up symlinks to log into a 'normal' location.
-mkdir -p /var/log/sync_gateway
-ln -sf /stdout.log /var/log/sync_gateway/sync_gateway_access.log
-ln -sf /stderr.log /var/log/sync_gateway/sync_gateway_error.log
+LOGFILE_DIR=/var/log/sync_gateway
+mkdir -p $LOGFILE_DIR
+
+LOGFILE_ACCESS=$LOGFILE_DIR/sync_gateway_access.log
+LOGFILE_ERROR=$LOGFILE_DIR/sync_gateway_error.log
 
 # Run SG and use tee to append stdout and stderr to separate logfiles
 # Process substitution described here: https://stackoverflow.com/a/692407
-exec sync_gateway "$@" > >(tee -a /stdout.log) 2> >(tee -a /stderr.log >&2)
+exec sync_gateway "$@" > >(tee -a $LOGFILE_ACCESS) 2> >(tee -a $LOGFILE_ERROR >&2)

--- a/community/sync-gateway/1.5.0-377/scripts/entrypoint.sh
+++ b/community/sync-gateway/1.5.0-377/scripts/entrypoint.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+set -e
+
+# Set up symlinks to log into a 'normal' location.
+mkdir -p /var/log/sync_gateway
+ln -sf /stdout.log /var/log/sync_gateway/sync_gateway_access.log
+ln -sf /stderr.log /var/log/sync_gateway/sync_gateway_error.log
+
+# Run SG and use tee to append stdout and stderr to separate logfiles
+# Process substitution described here: https://stackoverflow.com/a/692407
+exec sync_gateway "$@" > >(tee -a /stdout.log) 2> >(tee -a /stderr.log >&2)

--- a/community/sync-gateway/1.5.1/Dockerfile
+++ b/community/sync-gateway/1.5.1/Dockerfile
@@ -22,8 +22,9 @@ RUN mkdir /opt/couchbase-sync-gateway/data
 # copy the default config into the container
 COPY config/sync_gateway_config.json /etc/sync_gateway/config.json
 
-# Invoke the sync_gateway executable by default
-ENTRYPOINT ["sync_gateway"]
+# Add bootstrap script
+COPY scripts/entrypoint.sh /
+ENTRYPOINT ["/entrypoint.sh"]
 
 # If user doesn't specify any args, use the default config
 CMD ["/etc/sync_gateway/config.json"]
@@ -31,4 +32,3 @@ CMD ["/etc/sync_gateway/config.json"]
 # Expose ports
 #  port 4984: public port
 EXPOSE 4984
-

--- a/community/sync-gateway/1.5.1/scripts/entrypoint.sh
+++ b/community/sync-gateway/1.5.1/scripts/entrypoint.sh
@@ -1,11 +1,12 @@
 #!/bin/bash
 set -e
 
-# Set up symlinks to log into a 'normal' location.
-mkdir -p /var/log/sync_gateway
-ln -sf /stdout.log /var/log/sync_gateway/sync_gateway_access.log
-ln -sf /stderr.log /var/log/sync_gateway/sync_gateway_error.log
+LOGFILE_DIR=/var/log/sync_gateway
+mkdir -p $LOGFILE_DIR
+
+LOGFILE_ACCESS=$LOGFILE_DIR/sync_gateway_access.log
+LOGFILE_ERROR=$LOGFILE_DIR/sync_gateway_error.log
 
 # Run SG and use tee to append stdout and stderr to separate logfiles
 # Process substitution described here: https://stackoverflow.com/a/692407
-exec sync_gateway "$@" > >(tee -a /stdout.log) 2> >(tee -a /stderr.log >&2)
+exec sync_gateway "$@" > >(tee -a $LOGFILE_ACCESS) 2> >(tee -a $LOGFILE_ERROR >&2)

--- a/community/sync-gateway/1.5.1/scripts/entrypoint.sh
+++ b/community/sync-gateway/1.5.1/scripts/entrypoint.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+set -e
+
+# Set up symlinks to log into a 'normal' location.
+mkdir -p /var/log/sync_gateway
+ln -sf /stdout.log /var/log/sync_gateway/sync_gateway_access.log
+ln -sf /stderr.log /var/log/sync_gateway/sync_gateway_error.log
+
+# Run SG and use tee to append stdout and stderr to separate logfiles
+# Process substitution described here: https://stackoverflow.com/a/692407
+exec sync_gateway "$@" > >(tee -a /stdout.log) 2> >(tee -a /stderr.log >&2)

--- a/community/sync-gateway/2.0.0-devbuild/Dockerfile
+++ b/community/sync-gateway/2.0.0-devbuild/Dockerfile
@@ -22,8 +22,9 @@ RUN mkdir /opt/couchbase-sync-gateway/data
 # copy the default config into the container
 COPY config/sync_gateway_config.json /etc/sync_gateway/config.json
 
-# Invoke the sync_gateway executable by default
-ENTRYPOINT ["sync_gateway"]
+# Add bootstrap script
+COPY scripts/entrypoint.sh /
+ENTRYPOINT ["/entrypoint.sh"]
 
 # If user doesn't specify any args, use the default config
 CMD ["/etc/sync_gateway/config.json"]
@@ -31,4 +32,3 @@ CMD ["/etc/sync_gateway/config.json"]
 # Expose ports
 #  port 4984: public port
 EXPOSE 4984
-

--- a/community/sync-gateway/2.0.0-devbuild/scripts/entrypoint.sh
+++ b/community/sync-gateway/2.0.0-devbuild/scripts/entrypoint.sh
@@ -1,11 +1,12 @@
 #!/bin/bash
 set -e
 
-# Set up symlinks to log into a 'normal' location.
-mkdir -p /var/log/sync_gateway
-ln -sf /stdout.log /var/log/sync_gateway/sync_gateway_access.log
-ln -sf /stderr.log /var/log/sync_gateway/sync_gateway_error.log
+LOGFILE_DIR=/var/log/sync_gateway
+mkdir -p $LOGFILE_DIR
+
+LOGFILE_ACCESS=$LOGFILE_DIR/sync_gateway_access.log
+LOGFILE_ERROR=$LOGFILE_DIR/sync_gateway_error.log
 
 # Run SG and use tee to append stdout and stderr to separate logfiles
 # Process substitution described here: https://stackoverflow.com/a/692407
-exec sync_gateway "$@" > >(tee -a /stdout.log) 2> >(tee -a /stderr.log >&2)
+exec sync_gateway "$@" > >(tee -a $LOGFILE_ACCESS) 2> >(tee -a $LOGFILE_ERROR >&2)

--- a/community/sync-gateway/2.0.0-devbuild/scripts/entrypoint.sh
+++ b/community/sync-gateway/2.0.0-devbuild/scripts/entrypoint.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+set -e
+
+# Set up symlinks to log into a 'normal' location.
+mkdir -p /var/log/sync_gateway
+ln -sf /stdout.log /var/log/sync_gateway/sync_gateway_access.log
+ln -sf /stderr.log /var/log/sync_gateway/sync_gateway_error.log
+
+# Run SG and use tee to append stdout and stderr to separate logfiles
+# Process substitution described here: https://stackoverflow.com/a/692407
+exec sync_gateway "$@" > >(tee -a /stdout.log) 2> >(tee -a /stderr.log >&2)

--- a/enterprise/sync-gateway/1.3.0-274/Dockerfile
+++ b/enterprise/sync-gateway/1.3.0-274/Dockerfile
@@ -22,8 +22,9 @@ RUN mkdir /opt/couchbase-sync-gateway/data
 # copy the default config into the container
 COPY config/sync_gateway_config.json /etc/sync_gateway/config.json
 
-# Invoke the sync_gateway executable by default
-ENTRYPOINT ["sync_gateway"]
+# Add bootstrap script
+COPY scripts/entrypoint.sh /
+ENTRYPOINT ["/entrypoint.sh"]
 
 # If user doesn't specify any args, use the default config
 CMD ["/etc/sync_gateway/config.json"]
@@ -31,4 +32,3 @@ CMD ["/etc/sync_gateway/config.json"]
 # Expose ports
 #  port 4984: public port
 EXPOSE 4984
-

--- a/enterprise/sync-gateway/1.3.0-274/scripts/entrypoint.sh
+++ b/enterprise/sync-gateway/1.3.0-274/scripts/entrypoint.sh
@@ -1,11 +1,12 @@
 #!/bin/bash
 set -e
 
-# Set up symlinks to log into a 'normal' location.
-mkdir -p /var/log/sync_gateway
-ln -sf /stdout.log /var/log/sync_gateway/sync_gateway_access.log
-ln -sf /stderr.log /var/log/sync_gateway/sync_gateway_error.log
+LOGFILE_DIR=/var/log/sync_gateway
+mkdir -p $LOGFILE_DIR
+
+LOGFILE_ACCESS=$LOGFILE_DIR/sync_gateway_access.log
+LOGFILE_ERROR=$LOGFILE_DIR/sync_gateway_error.log
 
 # Run SG and use tee to append stdout and stderr to separate logfiles
 # Process substitution described here: https://stackoverflow.com/a/692407
-exec sync_gateway "$@" > >(tee -a /stdout.log) 2> >(tee -a /stderr.log >&2)
+exec sync_gateway "$@" > >(tee -a $LOGFILE_ACCESS) 2> >(tee -a $LOGFILE_ERROR >&2)

--- a/enterprise/sync-gateway/1.3.0-274/scripts/entrypoint.sh
+++ b/enterprise/sync-gateway/1.3.0-274/scripts/entrypoint.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+set -e
+
+# Set up symlinks to log into a 'normal' location.
+mkdir -p /var/log/sync_gateway
+ln -sf /stdout.log /var/log/sync_gateway/sync_gateway_access.log
+ln -sf /stderr.log /var/log/sync_gateway/sync_gateway_error.log
+
+# Run SG and use tee to append stdout and stderr to separate logfiles
+# Process substitution described here: https://stackoverflow.com/a/692407
+exec sync_gateway "$@" > >(tee -a /stdout.log) 2> >(tee -a /stderr.log >&2)

--- a/enterprise/sync-gateway/1.3.1-16/Dockerfile
+++ b/enterprise/sync-gateway/1.3.1-16/Dockerfile
@@ -22,8 +22,9 @@ RUN mkdir /opt/couchbase-sync-gateway/data
 # copy the default config into the container
 COPY config/sync_gateway_config.json /etc/sync_gateway/config.json
 
-# Invoke the sync_gateway executable by default
-ENTRYPOINT ["sync_gateway"]
+# Add bootstrap script
+COPY scripts/entrypoint.sh /
+ENTRYPOINT ["/entrypoint.sh"]
 
 # If user doesn't specify any args, use the default config
 CMD ["/etc/sync_gateway/config.json"]
@@ -31,4 +32,3 @@ CMD ["/etc/sync_gateway/config.json"]
 # Expose ports
 #  port 4984: public port
 EXPOSE 4984
-

--- a/enterprise/sync-gateway/1.3.1-16/scripts/entrypoint.sh
+++ b/enterprise/sync-gateway/1.3.1-16/scripts/entrypoint.sh
@@ -1,11 +1,12 @@
 #!/bin/bash
 set -e
 
-# Set up symlinks to log into a 'normal' location.
-mkdir -p /var/log/sync_gateway
-ln -sf /stdout.log /var/log/sync_gateway/sync_gateway_access.log
-ln -sf /stderr.log /var/log/sync_gateway/sync_gateway_error.log
+LOGFILE_DIR=/var/log/sync_gateway
+mkdir -p $LOGFILE_DIR
+
+LOGFILE_ACCESS=$LOGFILE_DIR/sync_gateway_access.log
+LOGFILE_ERROR=$LOGFILE_DIR/sync_gateway_error.log
 
 # Run SG and use tee to append stdout and stderr to separate logfiles
 # Process substitution described here: https://stackoverflow.com/a/692407
-exec sync_gateway "$@" > >(tee -a /stdout.log) 2> >(tee -a /stderr.log >&2)
+exec sync_gateway "$@" > >(tee -a $LOGFILE_ACCESS) 2> >(tee -a $LOGFILE_ERROR >&2)

--- a/enterprise/sync-gateway/1.3.1-16/scripts/entrypoint.sh
+++ b/enterprise/sync-gateway/1.3.1-16/scripts/entrypoint.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+set -e
+
+# Set up symlinks to log into a 'normal' location.
+mkdir -p /var/log/sync_gateway
+ln -sf /stdout.log /var/log/sync_gateway/sync_gateway_access.log
+ln -sf /stderr.log /var/log/sync_gateway/sync_gateway_error.log
+
+# Run SG and use tee to append stdout and stderr to separate logfiles
+# Process substitution described here: https://stackoverflow.com/a/692407
+exec sync_gateway "$@" > >(tee -a /stdout.log) 2> >(tee -a /stderr.log >&2)

--- a/enterprise/sync-gateway/1.4.1-3/Dockerfile
+++ b/enterprise/sync-gateway/1.4.1-3/Dockerfile
@@ -22,8 +22,9 @@ RUN mkdir /opt/couchbase-sync-gateway/data
 # copy the default config into the container
 COPY config/sync_gateway_config.json /etc/sync_gateway/config.json
 
-# Invoke the sync_gateway executable by default
-ENTRYPOINT ["sync_gateway"]
+# Add bootstrap script
+COPY scripts/entrypoint.sh /
+ENTRYPOINT ["/entrypoint.sh"]
 
 # If user doesn't specify any args, use the default config
 CMD ["/etc/sync_gateway/config.json"]
@@ -31,4 +32,3 @@ CMD ["/etc/sync_gateway/config.json"]
 # Expose ports
 #  port 4984: public port
 EXPOSE 4984
-

--- a/enterprise/sync-gateway/1.4.1-3/scripts/entrypoint.sh
+++ b/enterprise/sync-gateway/1.4.1-3/scripts/entrypoint.sh
@@ -1,11 +1,12 @@
 #!/bin/bash
 set -e
 
-# Set up symlinks to log into a 'normal' location.
-mkdir -p /var/log/sync_gateway
-ln -sf /stdout.log /var/log/sync_gateway/sync_gateway_access.log
-ln -sf /stderr.log /var/log/sync_gateway/sync_gateway_error.log
+LOGFILE_DIR=/var/log/sync_gateway
+mkdir -p $LOGFILE_DIR
+
+LOGFILE_ACCESS=$LOGFILE_DIR/sync_gateway_access.log
+LOGFILE_ERROR=$LOGFILE_DIR/sync_gateway_error.log
 
 # Run SG and use tee to append stdout and stderr to separate logfiles
 # Process substitution described here: https://stackoverflow.com/a/692407
-exec sync_gateway "$@" > >(tee -a /stdout.log) 2> >(tee -a /stderr.log >&2)
+exec sync_gateway "$@" > >(tee -a $LOGFILE_ACCESS) 2> >(tee -a $LOGFILE_ERROR >&2)

--- a/enterprise/sync-gateway/1.4.1-3/scripts/entrypoint.sh
+++ b/enterprise/sync-gateway/1.4.1-3/scripts/entrypoint.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+set -e
+
+# Set up symlinks to log into a 'normal' location.
+mkdir -p /var/log/sync_gateway
+ln -sf /stdout.log /var/log/sync_gateway/sync_gateway_access.log
+ln -sf /stderr.log /var/log/sync_gateway/sync_gateway_error.log
+
+# Run SG and use tee to append stdout and stderr to separate logfiles
+# Process substitution described here: https://stackoverflow.com/a/692407
+exec sync_gateway "$@" > >(tee -a /stdout.log) 2> >(tee -a /stderr.log >&2)

--- a/enterprise/sync-gateway/1.5.0-377/Dockerfile
+++ b/enterprise/sync-gateway/1.5.0-377/Dockerfile
@@ -22,8 +22,9 @@ RUN mkdir /opt/couchbase-sync-gateway/data
 # copy the default config into the container
 COPY config/sync_gateway_config.json /etc/sync_gateway/config.json
 
-# Invoke the sync_gateway executable by default
-ENTRYPOINT ["sync_gateway"]
+# Add bootstrap script
+COPY scripts/entrypoint.sh /
+ENTRYPOINT ["/entrypoint.sh"]
 
 # If user doesn't specify any args, use the default config
 CMD ["/etc/sync_gateway/config.json"]
@@ -31,4 +32,3 @@ CMD ["/etc/sync_gateway/config.json"]
 # Expose ports
 #  port 4984: public port
 EXPOSE 4984
-

--- a/enterprise/sync-gateway/1.5.0-377/scripts/entrypoint.sh
+++ b/enterprise/sync-gateway/1.5.0-377/scripts/entrypoint.sh
@@ -1,11 +1,12 @@
 #!/bin/bash
 set -e
 
-# Set up symlinks to log into a 'normal' location.
-mkdir -p /var/log/sync_gateway
-ln -sf /stdout.log /var/log/sync_gateway/sync_gateway_access.log
-ln -sf /stderr.log /var/log/sync_gateway/sync_gateway_error.log
+LOGFILE_DIR=/var/log/sync_gateway
+mkdir -p $LOGFILE_DIR
+
+LOGFILE_ACCESS=$LOGFILE_DIR/sync_gateway_access.log
+LOGFILE_ERROR=$LOGFILE_DIR/sync_gateway_error.log
 
 # Run SG and use tee to append stdout and stderr to separate logfiles
 # Process substitution described here: https://stackoverflow.com/a/692407
-exec sync_gateway "$@" > >(tee -a /stdout.log) 2> >(tee -a /stderr.log >&2)
+exec sync_gateway "$@" > >(tee -a $LOGFILE_ACCESS) 2> >(tee -a $LOGFILE_ERROR >&2)

--- a/enterprise/sync-gateway/1.5.0-377/scripts/entrypoint.sh
+++ b/enterprise/sync-gateway/1.5.0-377/scripts/entrypoint.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+set -e
+
+# Set up symlinks to log into a 'normal' location.
+mkdir -p /var/log/sync_gateway
+ln -sf /stdout.log /var/log/sync_gateway/sync_gateway_access.log
+ln -sf /stderr.log /var/log/sync_gateway/sync_gateway_error.log
+
+# Run SG and use tee to append stdout and stderr to separate logfiles
+# Process substitution described here: https://stackoverflow.com/a/692407
+exec sync_gateway "$@" > >(tee -a /stdout.log) 2> >(tee -a /stderr.log >&2)

--- a/enterprise/sync-gateway/1.5.1/Dockerfile
+++ b/enterprise/sync-gateway/1.5.1/Dockerfile
@@ -22,8 +22,9 @@ RUN mkdir /opt/couchbase-sync-gateway/data
 # copy the default config into the container
 COPY config/sync_gateway_config.json /etc/sync_gateway/config.json
 
-# Invoke the sync_gateway executable by default
-ENTRYPOINT ["sync_gateway"]
+# Add bootstrap script
+COPY scripts/entrypoint.sh /
+ENTRYPOINT ["/entrypoint.sh"]
 
 # If user doesn't specify any args, use the default config
 CMD ["/etc/sync_gateway/config.json"]
@@ -31,4 +32,3 @@ CMD ["/etc/sync_gateway/config.json"]
 # Expose ports
 #  port 4984: public port
 EXPOSE 4984
-

--- a/enterprise/sync-gateway/1.5.1/scripts/entrypoint.sh
+++ b/enterprise/sync-gateway/1.5.1/scripts/entrypoint.sh
@@ -1,11 +1,12 @@
 #!/bin/bash
 set -e
 
-# Set up symlinks to log into a 'normal' location.
-mkdir -p /var/log/sync_gateway
-ln -sf /stdout.log /var/log/sync_gateway/sync_gateway_access.log
-ln -sf /stderr.log /var/log/sync_gateway/sync_gateway_error.log
+LOGFILE_DIR=/var/log/sync_gateway
+mkdir -p $LOGFILE_DIR
+
+LOGFILE_ACCESS=$LOGFILE_DIR/sync_gateway_access.log
+LOGFILE_ERROR=$LOGFILE_DIR/sync_gateway_error.log
 
 # Run SG and use tee to append stdout and stderr to separate logfiles
 # Process substitution described here: https://stackoverflow.com/a/692407
-exec sync_gateway "$@" > >(tee -a /stdout.log) 2> >(tee -a /stderr.log >&2)
+exec sync_gateway "$@" > >(tee -a $LOGFILE_ACCESS) 2> >(tee -a $LOGFILE_ERROR >&2)

--- a/enterprise/sync-gateway/1.5.1/scripts/entrypoint.sh
+++ b/enterprise/sync-gateway/1.5.1/scripts/entrypoint.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+set -e
+
+# Set up symlinks to log into a 'normal' location.
+mkdir -p /var/log/sync_gateway
+ln -sf /stdout.log /var/log/sync_gateway/sync_gateway_access.log
+ln -sf /stderr.log /var/log/sync_gateway/sync_gateway_error.log
+
+# Run SG and use tee to append stdout and stderr to separate logfiles
+# Process substitution described here: https://stackoverflow.com/a/692407
+exec sync_gateway "$@" > >(tee -a /stdout.log) 2> >(tee -a /stderr.log >&2)

--- a/enterprise/sync-gateway/2.0.0-devbuild/Dockerfile
+++ b/enterprise/sync-gateway/2.0.0-devbuild/Dockerfile
@@ -22,8 +22,9 @@ RUN mkdir /opt/couchbase-sync-gateway/data
 # copy the default config into the container
 COPY config/sync_gateway_config.json /etc/sync_gateway/config.json
 
-# Invoke the sync_gateway executable by default
-ENTRYPOINT ["sync_gateway"]
+# Add bootstrap script
+COPY scripts/entrypoint.sh /
+ENTRYPOINT ["/entrypoint.sh"]
 
 # If user doesn't specify any args, use the default config
 CMD ["/etc/sync_gateway/config.json"]
@@ -31,4 +32,3 @@ CMD ["/etc/sync_gateway/config.json"]
 # Expose ports
 #  port 4984: public port
 EXPOSE 4984
-

--- a/enterprise/sync-gateway/2.0.0-devbuild/scripts/entrypoint.sh
+++ b/enterprise/sync-gateway/2.0.0-devbuild/scripts/entrypoint.sh
@@ -1,11 +1,12 @@
 #!/bin/bash
 set -e
 
-# Set up symlinks to log into a 'normal' location.
-mkdir -p /var/log/sync_gateway
-ln -sf /stdout.log /var/log/sync_gateway/sync_gateway_access.log
-ln -sf /stderr.log /var/log/sync_gateway/sync_gateway_error.log
+LOGFILE_DIR=/var/log/sync_gateway
+mkdir -p $LOGFILE_DIR
+
+LOGFILE_ACCESS=$LOGFILE_DIR/sync_gateway_access.log
+LOGFILE_ERROR=$LOGFILE_DIR/sync_gateway_error.log
 
 # Run SG and use tee to append stdout and stderr to separate logfiles
 # Process substitution described here: https://stackoverflow.com/a/692407
-exec sync_gateway "$@" > >(tee -a /stdout.log) 2> >(tee -a /stderr.log >&2)
+exec sync_gateway "$@" > >(tee -a $LOGFILE_ACCESS) 2> >(tee -a $LOGFILE_ERROR >&2)

--- a/enterprise/sync-gateway/2.0.0-devbuild/scripts/entrypoint.sh
+++ b/enterprise/sync-gateway/2.0.0-devbuild/scripts/entrypoint.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+set -e
+
+# Set up symlinks to log into a 'normal' location.
+mkdir -p /var/log/sync_gateway
+ln -sf /stdout.log /var/log/sync_gateway/sync_gateway_access.log
+ln -sf /stderr.log /var/log/sync_gateway/sync_gateway_error.log
+
+# Run SG and use tee to append stdout and stderr to separate logfiles
+# Process substitution described here: https://stackoverflow.com/a/692407
+exec sync_gateway "$@" > >(tee -a /stdout.log) 2> >(tee -a /stderr.log >&2)

--- a/generate/resources/sync-gateway/scripts/entrypoint.sh
+++ b/generate/resources/sync-gateway/scripts/entrypoint.sh
@@ -1,11 +1,12 @@
 #!/bin/bash
 set -e
 
-# Set up symlinks to log into a 'normal' location.
-mkdir -p /var/log/sync_gateway
-ln -sf /stdout.log /var/log/sync_gateway/sync_gateway_access.log
-ln -sf /stderr.log /var/log/sync_gateway/sync_gateway_error.log
+LOGFILE_DIR=/var/log/sync_gateway
+mkdir -p $LOGFILE_DIR
+
+LOGFILE_ACCESS=$LOGFILE_DIR/sync_gateway_access.log
+LOGFILE_ERROR=$LOGFILE_DIR/sync_gateway_error.log
 
 # Run SG and use tee to append stdout and stderr to separate logfiles
 # Process substitution described here: https://stackoverflow.com/a/692407
-exec sync_gateway "$@" > >(tee -a /stdout.log) 2> >(tee -a /stderr.log >&2)
+exec sync_gateway "$@" > >(tee -a $LOGFILE_ACCESS) 2> >(tee -a $LOGFILE_ERROR >&2)

--- a/generate/resources/sync-gateway/scripts/entrypoint.sh
+++ b/generate/resources/sync-gateway/scripts/entrypoint.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+set -e
+
+# Set up symlinks to log into a 'normal' location.
+mkdir -p /var/log/sync_gateway
+ln -sf /stdout.log /var/log/sync_gateway/sync_gateway_access.log
+ln -sf /stderr.log /var/log/sync_gateway/sync_gateway_error.log
+
+# Run SG and use tee to append stdout and stderr to separate logfiles
+# Process substitution described here: https://stackoverflow.com/a/692407
+exec sync_gateway "$@" > >(tee -a /stdout.log) 2> >(tee -a /stderr.log >&2)

--- a/generate/templates/sync-gateway/Dockerfile.template
+++ b/generate/templates/sync-gateway/Dockerfile.template
@@ -22,8 +22,9 @@ RUN mkdir /opt/couchbase-sync-gateway/data
 # copy the default config into the container
 COPY config/sync_gateway_config.json /etc/sync_gateway/config.json
 
-# Invoke the sync_gateway executable by default
-ENTRYPOINT ["sync_gateway"]
+# Add bootstrap script
+COPY scripts/entrypoint.sh /
+ENTRYPOINT ["/entrypoint.sh"]
 
 # If user doesn't specify any args, use the default config
 CMD ["/etc/sync_gateway/config.json"]
@@ -31,4 +32,3 @@ CMD ["/etc/sync_gateway/config.json"]
 # Expose ports
 #  port 4984: public port
 EXPOSE 4984
-


### PR DESCRIPTION
Fixes https://github.com/couchbase/sync_gateway/issues/2027

Sidenote: I don't have direct access to the `couchbase/docker` repo, so had to open a PR from a fork.

## Changes
- Adds an `entrypoint.sh` script to start sync_gateway, similar to Couchbase server.
- Creates symlinks to known locations of logfiles that `sgcollect_info` can read.
- Uses tee to capture stdout and stderr and write to logfiles.

## Testing
- [x] Tested running using no args (default configuration file)
- [x] Tested running with custom config path arg
- [x] Tested `sgcollect_info` for both scenarios above