### PR TITLE
CBD-1896: Support staging releases

### DIFF
--- a/community/couchbase-server/2.2.0/Dockerfile
+++ b/community/couchbase-server/2.2.0/Dockerfile
@@ -20,7 +20,7 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 ARG CB_VERSION=2.2.0
-ARG CB_RELEASE_URL=http://packages.couchbase.com/releases
+ARG CB_RELEASE_URL=https://packages.couchbase.com/releases
 ARG CB_PACKAGE=couchbase-server-community_2.2.0_x86_64.deb
 ARG CB_SHA256=051b0905e13241de19fbd9efb1e22a421f33429a1db3e4b5e3ae8756b9e4d6a2
 

--- a/community/couchbase-server/3.0.1/Dockerfile
+++ b/community/couchbase-server/3.0.1/Dockerfile
@@ -20,7 +20,7 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 ARG CB_VERSION=3.0.1
-ARG CB_RELEASE_URL=http://packages.couchbase.com/releases
+ARG CB_RELEASE_URL=https://packages.couchbase.com/releases
 ARG CB_PACKAGE=couchbase-server-community_3.0.1-ubuntu12.04_amd64.deb
 ARG CB_SHA256=59efbd8924969f71c9a6b438afea94d974db51607464c55d7a2d527368026150
 

--- a/community/couchbase-server/3.1.3/Dockerfile
+++ b/community/couchbase-server/3.1.3/Dockerfile
@@ -20,7 +20,7 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 ARG CB_VERSION=3.1.3
-ARG CB_RELEASE_URL=http://packages.couchbase.com/releases
+ARG CB_RELEASE_URL=https://packages.couchbase.com/releases
 ARG CB_PACKAGE=couchbase-server-community_3.1.3-ubuntu12.04_amd64.deb
 ARG CB_SHA256=dc919f78a74ae1f627b9bee26e3da70a33ceb1b3fd3259f2ed85b0754e6fcd41
 

--- a/community/couchbase-server/4.0.0/Dockerfile
+++ b/community/couchbase-server/4.0.0/Dockerfile
@@ -20,7 +20,7 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 ARG CB_VERSION=4.0.0
-ARG CB_RELEASE_URL=http://packages.couchbase.com/releases
+ARG CB_RELEASE_URL=https://packages.couchbase.com/releases
 ARG CB_PACKAGE=couchbase-server-community_4.0.0-ubuntu14.04_amd64.deb
 ARG CB_SHA256=e275717da0c22efb846b397a1ffeaf63a21ec91e4e481efe3b59de0a0d530982
 

--- a/community/couchbase-server/4.1.0/Dockerfile
+++ b/community/couchbase-server/4.1.0/Dockerfile
@@ -20,7 +20,7 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 ARG CB_VERSION=4.1.0
-ARG CB_RELEASE_URL=http://packages.couchbase.com/releases
+ARG CB_RELEASE_URL=https://packages.couchbase.com/releases
 ARG CB_PACKAGE=couchbase-server-community_4.1.0-ubuntu14.04_amd64.deb
 ARG CB_SHA256=400263bd03e32b69259ec9b821bf58922030ba9e2a266e2ef4a0d4ac162188ea
 

--- a/community/couchbase-server/4.1.1/Dockerfile
+++ b/community/couchbase-server/4.1.1/Dockerfile
@@ -20,7 +20,7 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 ARG CB_VERSION=4.1.1
-ARG CB_RELEASE_URL=http://packages.couchbase.com/releases
+ARG CB_RELEASE_URL=https://packages.couchbase.com/releases
 ARG CB_PACKAGE=couchbase-server-community_4.1.1-ubuntu14.04_amd64.deb
 ARG CB_SHA256=237b530643bb6c7bc2fd36363a235957b4f6ac9558e50ba5b1dad094b8a50883
 

--- a/community/couchbase-server/4.5.0/Dockerfile
+++ b/community/couchbase-server/4.5.0/Dockerfile
@@ -20,7 +20,7 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 ARG CB_VERSION=4.5.0
-ARG CB_RELEASE_URL=http://packages.couchbase.com/releases
+ARG CB_RELEASE_URL=https://packages.couchbase.com/releases
 ARG CB_PACKAGE=couchbase-server-community_4.5.0-ubuntu14.04_amd64.deb
 ARG CB_SHA256=7682b2c90717ba790b729341e32ce5a43f7eacb5279f48f47aae165c0ec3a633
 

--- a/community/couchbase-server/4.5.1/Dockerfile
+++ b/community/couchbase-server/4.5.1/Dockerfile
@@ -20,7 +20,7 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 ARG CB_VERSION=4.5.1
-ARG CB_RELEASE_URL=http://packages.couchbase.com/releases
+ARG CB_RELEASE_URL=https://packages.couchbase.com/releases
 ARG CB_PACKAGE=couchbase-server-community_4.5.1-ubuntu14.04_amd64.deb
 ARG CB_SHA256=de983d0137bd2de2608e52cbfdf01de6dd9d3c1d9bc45bd0702d253245a8a234
 

--- a/community/couchbase-server/5.0.1/Dockerfile
+++ b/community/couchbase-server/5.0.1/Dockerfile
@@ -20,7 +20,7 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 ARG CB_VERSION=5.0.1
-ARG CB_RELEASE_URL=http://packages.couchbase.com/releases
+ARG CB_RELEASE_URL=https://packages.couchbase.com/releases
 ARG CB_PACKAGE=couchbase-server-community_5.0.1-ubuntu16.04_amd64.deb
 ARG CB_SHA256=44570a34323934a9e668787c26b13e8556e678de2de15052e383e5573cf34931
 

--- a/enterprise/couchbase-server/2.5.2/Dockerfile
+++ b/enterprise/couchbase-server/2.5.2/Dockerfile
@@ -20,7 +20,7 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 ARG CB_VERSION=2.5.2
-ARG CB_RELEASE_URL=http://packages.couchbase.com/releases
+ARG CB_RELEASE_URL=https://packages.couchbase.com/releases
 ARG CB_PACKAGE=couchbase-server-enterprise_2.5.2_x86_64.deb
 ARG CB_SHA256=27a79a65758023c34ed900e8ef8c54bab4a65f4c84b7c94359cba910800a4b19
 

--- a/enterprise/couchbase-server/3.0.2/Dockerfile
+++ b/enterprise/couchbase-server/3.0.2/Dockerfile
@@ -20,7 +20,7 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 ARG CB_VERSION=3.0.2
-ARG CB_RELEASE_URL=http://packages.couchbase.com/releases
+ARG CB_RELEASE_URL=https://packages.couchbase.com/releases
 ARG CB_PACKAGE=couchbase-server-enterprise_3.0.2-ubuntu12.04_amd64.deb
 ARG CB_SHA256=29490c49f4ba5e25fe68db9abe7a78f884a0ea47c7825813b50fd5b9c2bf691c
 

--- a/enterprise/couchbase-server/3.0.3/Dockerfile
+++ b/enterprise/couchbase-server/3.0.3/Dockerfile
@@ -20,7 +20,7 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 ARG CB_VERSION=3.0.3
-ARG CB_RELEASE_URL=http://packages.couchbase.com/releases
+ARG CB_RELEASE_URL=https://packages.couchbase.com/releases
 ARG CB_PACKAGE=couchbase-server-enterprise_3.0.3-ubuntu12.04_amd64.deb
 ARG CB_SHA256=13e925fa8b806aecd09751bdb7be1f8cfa188ad894e266108e8c44785c08e474
 

--- a/enterprise/couchbase-server/3.1.0/Dockerfile
+++ b/enterprise/couchbase-server/3.1.0/Dockerfile
@@ -20,7 +20,7 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 ARG CB_VERSION=3.1.0
-ARG CB_RELEASE_URL=http://packages.couchbase.com/releases
+ARG CB_RELEASE_URL=https://packages.couchbase.com/releases
 ARG CB_PACKAGE=couchbase-server-enterprise_3.1.0-ubuntu12.04_amd64.deb
 ARG CB_SHA256=8eed4c768816ac22f6627d05516fa8a6975571b32b354c4f16185d8654f5bc1c
 

--- a/enterprise/couchbase-server/3.1.3/Dockerfile
+++ b/enterprise/couchbase-server/3.1.3/Dockerfile
@@ -20,7 +20,7 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 ARG CB_VERSION=3.1.3
-ARG CB_RELEASE_URL=http://packages.couchbase.com/releases
+ARG CB_RELEASE_URL=https://packages.couchbase.com/releases
 ARG CB_PACKAGE=couchbase-server-enterprise_3.1.3-ubuntu12.04_amd64.deb
 ARG CB_SHA256=3c48f279c8ac1634a881fa75def771b6a7362ed811e5b44e3cc4b6f9597376c2
 

--- a/enterprise/couchbase-server/3.1.5/Dockerfile
+++ b/enterprise/couchbase-server/3.1.5/Dockerfile
@@ -20,7 +20,7 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 ARG CB_VERSION=3.1.5
-ARG CB_RELEASE_URL=http://packages.couchbase.com/releases
+ARG CB_RELEASE_URL=https://packages.couchbase.com/releases
 ARG CB_PACKAGE=couchbase-server-enterprise_3.1.5-ubuntu12.04_amd64.deb
 ARG CB_SHA256=b4a7cbbe8a891debd9f95f165247d783c035d939b3ddedadc73a9cb4563f4fc3
 

--- a/enterprise/couchbase-server/3.1.6/Dockerfile
+++ b/enterprise/couchbase-server/3.1.6/Dockerfile
@@ -20,7 +20,7 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 ARG CB_VERSION=3.1.6
-ARG CB_RELEASE_URL=http://packages.couchbase.com/releases
+ARG CB_RELEASE_URL=https://packages.couchbase.com/releases
 ARG CB_PACKAGE=couchbase-server-enterprise_3.1.6-ubuntu12.04_amd64.deb
 ARG CB_SHA256=b13964639f2effcf7026834f0c023b43b22f44d12d7567712b5760bd1829ad6b
 

--- a/enterprise/couchbase-server/4.0.0/Dockerfile
+++ b/enterprise/couchbase-server/4.0.0/Dockerfile
@@ -20,7 +20,7 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 ARG CB_VERSION=4.0.0
-ARG CB_RELEASE_URL=http://packages.couchbase.com/releases
+ARG CB_RELEASE_URL=https://packages.couchbase.com/releases
 ARG CB_PACKAGE=couchbase-server-enterprise_4.0.0-ubuntu14.04_amd64.deb
 ARG CB_SHA256=c4fad00fe6006a31a82aa4879e7ae502cb9d397339e6d28f352312a0a5be9edd
 

--- a/enterprise/couchbase-server/4.1.0/Dockerfile
+++ b/enterprise/couchbase-server/4.1.0/Dockerfile
@@ -20,7 +20,7 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 ARG CB_VERSION=4.1.0
-ARG CB_RELEASE_URL=http://packages.couchbase.com/releases
+ARG CB_RELEASE_URL=https://packages.couchbase.com/releases
 ARG CB_PACKAGE=couchbase-server-enterprise_4.1.0-ubuntu14.04_amd64.deb
 ARG CB_SHA256=beb4ee31b5fea2bfa47c51132d3b29a12e6e2c537b7e5e8dca5d0d50558e4c53
 

--- a/enterprise/couchbase-server/4.1.1/Dockerfile
+++ b/enterprise/couchbase-server/4.1.1/Dockerfile
@@ -20,7 +20,7 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 ARG CB_VERSION=4.1.1
-ARG CB_RELEASE_URL=http://packages.couchbase.com/releases
+ARG CB_RELEASE_URL=https://packages.couchbase.com/releases
 ARG CB_PACKAGE=couchbase-server-enterprise_4.1.1-ubuntu14.04_amd64.deb
 ARG CB_SHA256=65c0ee37f0e6d816257b32a36207ec9b8e81c84112beb657c851f9aacb9b4382
 

--- a/enterprise/couchbase-server/4.1.2/Dockerfile
+++ b/enterprise/couchbase-server/4.1.2/Dockerfile
@@ -20,7 +20,7 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 ARG CB_VERSION=4.1.2
-ARG CB_RELEASE_URL=http://packages.couchbase.com/releases
+ARG CB_RELEASE_URL=https://packages.couchbase.com/releases
 ARG CB_PACKAGE=couchbase-server-enterprise_4.1.2-ubuntu14.04_amd64.deb
 ARG CB_SHA256=a9fa03e40700e77f0ee447cc8507c5ad80a767fc0f2796e0e506e32064e86e8f
 

--- a/enterprise/couchbase-server/4.5.0/Dockerfile
+++ b/enterprise/couchbase-server/4.5.0/Dockerfile
@@ -20,7 +20,7 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 ARG CB_VERSION=4.5.0
-ARG CB_RELEASE_URL=http://packages.couchbase.com/releases
+ARG CB_RELEASE_URL=https://packages.couchbase.com/releases
 ARG CB_PACKAGE=couchbase-server-enterprise_4.5.0-ubuntu14.04_amd64.deb
 ARG CB_SHA256=441398302210c0d73f27bdab741b471fc9da116bf45f521b314345f04560716e
 

--- a/enterprise/couchbase-server/4.5.1/Dockerfile
+++ b/enterprise/couchbase-server/4.5.1/Dockerfile
@@ -20,7 +20,7 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 ARG CB_VERSION=4.5.1
-ARG CB_RELEASE_URL=http://packages.couchbase.com/releases
+ARG CB_RELEASE_URL=https://packages.couchbase.com/releases
 ARG CB_PACKAGE=couchbase-server-enterprise_4.5.1-ubuntu14.04_amd64.deb
 ARG CB_SHA256=4e9075643a46c015acd2dbb5c7d6c047904b21c1934f4c53fbd1dd5d73c74c82
 

--- a/enterprise/couchbase-server/4.6.0-DP/Dockerfile
+++ b/enterprise/couchbase-server/4.6.0-DP/Dockerfile
@@ -20,7 +20,7 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 ARG CB_VERSION=4.6.0-DP
-ARG CB_RELEASE_URL=http://packages.couchbase.com/releases
+ARG CB_RELEASE_URL=https://packages.couchbase.com/releases
 ARG CB_PACKAGE=couchbase-server-enterprise_4.6.0-DP-ubuntu14.04_amd64.deb
 ARG CB_SHA256=a7bc3b08e2f5ad13c4456fc47a4b3e0b577db17f8c704f4607fe0d69d107c2b3
 

--- a/enterprise/couchbase-server/4.6.0/Dockerfile
+++ b/enterprise/couchbase-server/4.6.0/Dockerfile
@@ -20,7 +20,7 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 ARG CB_VERSION=4.6.0
-ARG CB_RELEASE_URL=http://packages.couchbase.com/releases
+ARG CB_RELEASE_URL=https://packages.couchbase.com/releases
 ARG CB_PACKAGE=couchbase-server-enterprise_4.6.0-ubuntu14.04_amd64.deb
 ARG CB_SHA256=f798fea39c6d693f1912c88c2195001373b5514f776e74599116cad392739028
 

--- a/enterprise/couchbase-server/4.6.1/Dockerfile
+++ b/enterprise/couchbase-server/4.6.1/Dockerfile
@@ -20,7 +20,7 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 ARG CB_VERSION=4.6.1
-ARG CB_RELEASE_URL=http://packages.couchbase.com/releases
+ARG CB_RELEASE_URL=https://packages.couchbase.com/releases
 ARG CB_PACKAGE=couchbase-server-enterprise_4.6.1-ubuntu14.04_amd64.deb
 ARG CB_SHA256=2c11c40424f9ddfe5a3821932215d0ae8d0151aa050b8f4e863fe74b88b988bf
 

--- a/enterprise/couchbase-server/4.6.2/Dockerfile
+++ b/enterprise/couchbase-server/4.6.2/Dockerfile
@@ -20,7 +20,7 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 ARG CB_VERSION=4.6.2
-ARG CB_RELEASE_URL=http://packages.couchbase.com/releases
+ARG CB_RELEASE_URL=https://packages.couchbase.com/releases
 ARG CB_PACKAGE=couchbase-server-enterprise_4.6.2-ubuntu14.04_amd64.deb
 ARG CB_SHA256=57340f1acb55041385dc28574e20aef591a898d07163ed56a52bd412dadb8cb6
 

--- a/enterprise/couchbase-server/4.6.3/Dockerfile
+++ b/enterprise/couchbase-server/4.6.3/Dockerfile
@@ -20,7 +20,7 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 ARG CB_VERSION=4.6.3
-ARG CB_RELEASE_URL=http://packages.couchbase.com/releases
+ARG CB_RELEASE_URL=https://packages.couchbase.com/releases
 ARG CB_PACKAGE=couchbase-server-enterprise_4.6.3-ubuntu14.04_amd64.deb
 ARG CB_SHA256=bc3b65c78793b819ecba87c330bd1bcc0a2edec214c597069c8eb7e34505eb69
 

--- a/enterprise/couchbase-server/4.6.4/Dockerfile
+++ b/enterprise/couchbase-server/4.6.4/Dockerfile
@@ -20,7 +20,7 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 ARG CB_VERSION=4.6.4
-ARG CB_RELEASE_URL=http://packages.couchbase.com/releases
+ARG CB_RELEASE_URL=https://packages.couchbase.com/releases
 ARG CB_PACKAGE=couchbase-server-enterprise_4.6.4-ubuntu14.04_amd64.deb
 ARG CB_SHA256=127f77825831f32cfa69704c699388413ae3b6f34dfd5eb1cb0fdb29e6a73579
 

--- a/enterprise/couchbase-server/5.0.1/Dockerfile
+++ b/enterprise/couchbase-server/5.0.1/Dockerfile
@@ -20,7 +20,7 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 ARG CB_VERSION=5.0.1
-ARG CB_RELEASE_URL=http://packages.couchbase.com/releases
+ARG CB_RELEASE_URL=https://packages.couchbase.com/releases
 ARG CB_PACKAGE=couchbase-server-enterprise_5.0.1-ubuntu16.04_amd64.deb
 ARG CB_SHA256=1b35827a9848a74b6b146f04c98b6ebf6cc84726beaccdf8870beb5ebd883623
 

--- a/enterprise/couchbase-server/5.1.0/Dockerfile
+++ b/enterprise/couchbase-server/5.1.0/Dockerfile
@@ -20,7 +20,7 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 ARG CB_VERSION=5.1.0
-ARG CB_RELEASE_URL=http://packages.couchbase.com/releases
+ARG CB_RELEASE_URL=https://packages.couchbase.com/releases
 ARG CB_PACKAGE=couchbase-server-enterprise_5.1.0-ubuntu16.04_amd64.deb
 ARG CB_SHA256=4d6a1f159577f283f6f980f6ab9161630eb2d8fd228429029de004b1be46ad76
 

--- a/enterprise/couchbase-server/5.5.0-Mar/Dockerfile
+++ b/enterprise/couchbase-server/5.5.0-Mar/Dockerfile
@@ -20,7 +20,7 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 ARG CB_VERSION=5.5.0-Mar
-ARG CB_RELEASE_URL=http://packages.couchbase.com/releases
+ARG CB_RELEASE_URL=https://packages.couchbase.com/releases
 ARG CB_PACKAGE=couchbase-server-enterprise_5.5.0-Mar-ubuntu16.04_amd64.deb
 ARG CB_SHA256=00476c78295c5294cf012c381524a14d9fe98dee774e67303db600a82446a5d7
 

--- a/enterprise/couchbase-server/5.5.0-beta/Dockerfile
+++ b/enterprise/couchbase-server/5.5.0-beta/Dockerfile
@@ -20,7 +20,7 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 ARG CB_VERSION=5.5.0-beta
-ARG CB_RELEASE_URL=http://packages.couchbase.com/releases
+ARG CB_RELEASE_URL=https://packages.couchbase.com/releases
 ARG CB_PACKAGE=couchbase-server-enterprise_5.5.0-beta-ubuntu16.04_amd64.deb
 ARG CB_SHA256=3d4eb959d51f26956ba7302a4e3fabfb922f0c8e4986c7ad52b570d13d617f26
 

--- a/generate/templates/couchbase-server/Dockerfile.template
+++ b/generate/templates/couchbase-server/Dockerfile.template
@@ -20,7 +20,7 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 ARG CB_VERSION={{ .CB_VERSION }}
-ARG CB_RELEASE_URL=http://packages.couchbase.com/releases
+ARG CB_RELEASE_URL={{ .CB_RELEASE_URL }}
 ARG CB_PACKAGE={{ .CB_PACKAGE }}
 ARG CB_SHA256={{ .CB_SHA256 }}
 


### PR DESCRIPTION
If a version directory has a suffix "-staging", the Dockerfile generator
will pull the package from the packages-staging.couchbase.com S3 location.

Also updated non-staging downloads to use https:.