### PR TITLE
Support for arbitrary user IDs

### DIFF
--- a/enterprise/couchbase-server/5.0.1/Dockerfile
+++ b/enterprise/couchbase-server/5.0.1/Dockerfile
@@ -38,7 +38,6 @@ RUN export INSTALL_DONT_START_SERVER=1 && \
 
 # Add runit script for couchbase-server
 COPY scripts/run /etc/service/couchbase-server/run
-RUN chown -R couchbase:couchbase /etc/service
 
 # Add dummy script for commands invoked by cbcollect_info that
 # make no sense in a Docker container
@@ -50,6 +49,12 @@ RUN ln -s dummy.sh /usr/local/bin/iptables-save && \
 
 # Fix curl RPATH
 RUN chrpath -r '$ORIGIN/../lib' /opt/couchbase/bin/curl
+
+# Allow container to run as arbitrary uid
+RUN chgrp -R 0 /opt/couchbase /etc/service && \
+		chmod -R g+rwX /opt/couchbase /etc/service && \
+    chmod -R g=u /etc/passwd
+USER 10001
 
 # Add bootstrap script
 COPY scripts/entrypoint.sh /

--- a/enterprise/couchbase-server/5.0.1/scripts/entrypoint.sh
+++ b/enterprise/couchbase-server/5.0.1/scripts/entrypoint.sh
@@ -40,8 +40,12 @@ overridePort "ssl_proxy_upstream_port"
 
 
 [[ "$1" == "couchbase-server" ]] && {
-
-    if [ $(whoami) = "couchbase" ]; then
+    if ! whoami &> /dev/null; then
+        # Ensure that unknown uid's are added to passwd
+        if [ -w /etc/passwd ]; then
+            echo "${USER_NAME:-couchbase}:x:$(id -u):0:${USER_NAME:-couchbase} user:${HOME}:/sbin/nologin" >> /etc/passwd
+        fi
+    elif [ $(whoami) = "couchbase" ]; then
         # Ensure that /opt/couchbase/var is owned by user 'couchbase' and
         # is writable
         if [ ! -w /opt/couchbase/var -o \

--- a/enterprise/couchbase-server/5.0.1/scripts/run
+++ b/enterprise/couchbase-server/5.0.1/scripts/run
@@ -11,9 +11,8 @@ mkdir -p var/lib/couchbase \
          var/lib/couchbase/logs \
          var/lib/moxi
 
-chown -R couchbase:couchbase var
 if [ $(whoami) = "couchbase" ]; then
   exec /opt/couchbase/bin/couchbase-server -- -kernel global_enable_tracing false -noinput
 else
-  exec chpst -ucouchbase  /opt/couchbase/bin/couchbase-server -- -kernel global_enable_tracing false -noinput
+  exec chpst /opt/couchbase/bin/couchbase-server -- -kernel global_enable_tracing false -noinput
 fi


### PR DESCRIPTION
Allows for better integration with openshift which doesn't allow containers
to run as root users (by default).  Solution here is to add the arbitrary
container user to the root group.  As according to openshift guidelines:

  "For an image to support running as an arbitrary user, directories and files that
  may be written to by processes in the image should be owned by the root group and
  be read/writable by that group. Files to be executed should also have group execute permissions."
  https://docs.openshift.com/container-platform/3.5/creating_images/guidelines.html

see also: https://github.com/couchbase/docker/issues/68