### PR TITLE
MB-30496: Revert "updated entrypoint.sh to enable capi port overriding" (#104)

### DIFF
--- a/community/couchbase-server/2.2.0/scripts/entrypoint.sh
+++ b/community/couchbase-server/2.2.0/scripts/entrypoint.sh
@@ -2,9 +2,7 @@
 set -e
 
 staticConfigFile=/opt/couchbase/etc/couchbase/static_config
-capiConfigFile=/opt/couchbase/etc/couchdb/default.d/capi.ini
 restPortValue=8091
-capiPortValue=8092
 
 # see https://developer.couchbase.com/documentation/server/current/install/install-ports.html
 function overridePort() {
@@ -26,15 +24,6 @@ function overridePort() {
             fi
         fi
     fi
-
-    if [ "$portNameUpper" == "CAPI_PORT" ]; then
-        if grep -Fq "{${portValue}," ${capiConfigFile}
-        then
-            echo "Don't override port ${portName} because already available in $staticConfigFile"
-        else
-            sed -i -e "s/${capiPortValue}/${portValue}/g" ${capiConfigFile}
-        fi
-    fi
 }
 
 overridePort "rest_port"
@@ -48,7 +37,7 @@ overridePort "ssl_rest_port"
 overridePort "ssl_capi_port"
 overridePort "ssl_proxy_downstream_port"
 overridePort "ssl_proxy_upstream_port"
-overridePort "capi_port"
+
 
 [[ "$1" == "couchbase-server" ]] && {
 

--- a/community/couchbase-server/3.0.1/scripts/entrypoint.sh
+++ b/community/couchbase-server/3.0.1/scripts/entrypoint.sh
@@ -2,9 +2,7 @@
 set -e
 
 staticConfigFile=/opt/couchbase/etc/couchbase/static_config
-capiConfigFile=/opt/couchbase/etc/couchdb/default.d/capi.ini
 restPortValue=8091
-capiPortValue=8092
 
 # see https://developer.couchbase.com/documentation/server/current/install/install-ports.html
 function overridePort() {
@@ -26,15 +24,6 @@ function overridePort() {
             fi
         fi
     fi
-
-    if [ "$portNameUpper" == "CAPI_PORT" ]; then
-        if grep -Fq "{${portValue}," ${capiConfigFile}
-        then
-            echo "Don't override port ${portName} because already available in $staticConfigFile"
-        else
-            sed -i -e "s/${capiPortValue}/${portValue}/g" ${capiConfigFile}
-        fi
-    fi
 }
 
 overridePort "rest_port"
@@ -48,7 +37,7 @@ overridePort "ssl_rest_port"
 overridePort "ssl_capi_port"
 overridePort "ssl_proxy_downstream_port"
 overridePort "ssl_proxy_upstream_port"
-overridePort "capi_port"
+
 
 [[ "$1" == "couchbase-server" ]] && {
 

--- a/community/couchbase-server/3.1.3/scripts/entrypoint.sh
+++ b/community/couchbase-server/3.1.3/scripts/entrypoint.sh
@@ -2,9 +2,7 @@
 set -e
 
 staticConfigFile=/opt/couchbase/etc/couchbase/static_config
-capiConfigFile=/opt/couchbase/etc/couchdb/default.d/capi.ini
 restPortValue=8091
-capiPortValue=8092
 
 # see https://developer.couchbase.com/documentation/server/current/install/install-ports.html
 function overridePort() {
@@ -26,15 +24,6 @@ function overridePort() {
             fi
         fi
     fi
-
-    if [ "$portNameUpper" == "CAPI_PORT" ]; then
-        if grep -Fq "{${portValue}," ${capiConfigFile}
-        then
-            echo "Don't override port ${portName} because already available in $staticConfigFile"
-        else
-            sed -i -e "s/${capiPortValue}/${portValue}/g" ${capiConfigFile}
-        fi
-    fi
 }
 
 overridePort "rest_port"
@@ -48,7 +37,7 @@ overridePort "ssl_rest_port"
 overridePort "ssl_capi_port"
 overridePort "ssl_proxy_downstream_port"
 overridePort "ssl_proxy_upstream_port"
-overridePort "capi_port"
+
 
 [[ "$1" == "couchbase-server" ]] && {
 

--- a/community/couchbase-server/4.0.0/scripts/entrypoint.sh
+++ b/community/couchbase-server/4.0.0/scripts/entrypoint.sh
@@ -2,9 +2,7 @@
 set -e
 
 staticConfigFile=/opt/couchbase/etc/couchbase/static_config
-capiConfigFile=/opt/couchbase/etc/couchdb/default.d/capi.ini
 restPortValue=8091
-capiPortValue=8092
 
 # see https://developer.couchbase.com/documentation/server/current/install/install-ports.html
 function overridePort() {
@@ -26,15 +24,6 @@ function overridePort() {
             fi
         fi
     fi
-
-    if [ "$portNameUpper" == "CAPI_PORT" ]; then
-        if grep -Fq "{${portValue}," ${capiConfigFile}
-        then
-            echo "Don't override port ${portName} because already available in $staticConfigFile"
-        else
-            sed -i -e "s/${capiPortValue}/${portValue}/g" ${capiConfigFile}
-        fi
-    fi
 }
 
 overridePort "rest_port"
@@ -48,7 +37,7 @@ overridePort "ssl_rest_port"
 overridePort "ssl_capi_port"
 overridePort "ssl_proxy_downstream_port"
 overridePort "ssl_proxy_upstream_port"
-overridePort "capi_port"
+
 
 [[ "$1" == "couchbase-server" ]] && {
 

--- a/community/couchbase-server/4.1.0/scripts/entrypoint.sh
+++ b/community/couchbase-server/4.1.0/scripts/entrypoint.sh
@@ -2,9 +2,7 @@
 set -e
 
 staticConfigFile=/opt/couchbase/etc/couchbase/static_config
-capiConfigFile=/opt/couchbase/etc/couchdb/default.d/capi.ini
 restPortValue=8091
-capiPortValue=8092
 
 # see https://developer.couchbase.com/documentation/server/current/install/install-ports.html
 function overridePort() {
@@ -26,15 +24,6 @@ function overridePort() {
             fi
         fi
     fi
-
-    if [ "$portNameUpper" == "CAPI_PORT" ]; then
-        if grep -Fq "{${portValue}," ${capiConfigFile}
-        then
-            echo "Don't override port ${portName} because already available in $staticConfigFile"
-        else
-            sed -i -e "s/${capiPortValue}/${portValue}/g" ${capiConfigFile}
-        fi
-    fi
 }
 
 overridePort "rest_port"
@@ -48,7 +37,7 @@ overridePort "ssl_rest_port"
 overridePort "ssl_capi_port"
 overridePort "ssl_proxy_downstream_port"
 overridePort "ssl_proxy_upstream_port"
-overridePort "capi_port"
+
 
 [[ "$1" == "couchbase-server" ]] && {
 

--- a/community/couchbase-server/4.1.1/scripts/entrypoint.sh
+++ b/community/couchbase-server/4.1.1/scripts/entrypoint.sh
@@ -2,9 +2,7 @@
 set -e
 
 staticConfigFile=/opt/couchbase/etc/couchbase/static_config
-capiConfigFile=/opt/couchbase/etc/couchdb/default.d/capi.ini
 restPortValue=8091
-capiPortValue=8092
 
 # see https://developer.couchbase.com/documentation/server/current/install/install-ports.html
 function overridePort() {
@@ -26,15 +24,6 @@ function overridePort() {
             fi
         fi
     fi
-
-    if [ "$portNameUpper" == "CAPI_PORT" ]; then
-        if grep -Fq "{${portValue}," ${capiConfigFile}
-        then
-            echo "Don't override port ${portName} because already available in $staticConfigFile"
-        else
-            sed -i -e "s/${capiPortValue}/${portValue}/g" ${capiConfigFile}
-        fi
-    fi
 }
 
 overridePort "rest_port"
@@ -48,7 +37,7 @@ overridePort "ssl_rest_port"
 overridePort "ssl_capi_port"
 overridePort "ssl_proxy_downstream_port"
 overridePort "ssl_proxy_upstream_port"
-overridePort "capi_port"
+
 
 [[ "$1" == "couchbase-server" ]] && {
 

--- a/community/couchbase-server/4.5.0/scripts/entrypoint.sh
+++ b/community/couchbase-server/4.5.0/scripts/entrypoint.sh
@@ -2,9 +2,7 @@
 set -e
 
 staticConfigFile=/opt/couchbase/etc/couchbase/static_config
-capiConfigFile=/opt/couchbase/etc/couchdb/default.d/capi.ini
 restPortValue=8091
-capiPortValue=8092
 
 # see https://developer.couchbase.com/documentation/server/current/install/install-ports.html
 function overridePort() {
@@ -26,15 +24,6 @@ function overridePort() {
             fi
         fi
     fi
-
-    if [ "$portNameUpper" == "CAPI_PORT" ]; then
-        if grep -Fq "{${portValue}," ${capiConfigFile}
-        then
-            echo "Don't override port ${portName} because already available in $staticConfigFile"
-        else
-            sed -i -e "s/${capiPortValue}/${portValue}/g" ${capiConfigFile}
-        fi
-    fi
 }
 
 overridePort "rest_port"
@@ -48,7 +37,7 @@ overridePort "ssl_rest_port"
 overridePort "ssl_capi_port"
 overridePort "ssl_proxy_downstream_port"
 overridePort "ssl_proxy_upstream_port"
-overridePort "capi_port"
+
 
 [[ "$1" == "couchbase-server" ]] && {
 

--- a/community/couchbase-server/4.5.1/scripts/entrypoint.sh
+++ b/community/couchbase-server/4.5.1/scripts/entrypoint.sh
@@ -2,9 +2,7 @@
 set -e
 
 staticConfigFile=/opt/couchbase/etc/couchbase/static_config
-capiConfigFile=/opt/couchbase/etc/couchdb/default.d/capi.ini
 restPortValue=8091
-capiPortValue=8092
 
 # see https://developer.couchbase.com/documentation/server/current/install/install-ports.html
 function overridePort() {
@@ -26,15 +24,6 @@ function overridePort() {
             fi
         fi
     fi
-
-    if [ "$portNameUpper" == "CAPI_PORT" ]; then
-        if grep -Fq "{${portValue}," ${capiConfigFile}
-        then
-            echo "Don't override port ${portName} because already available in $staticConfigFile"
-        else
-            sed -i -e "s/${capiPortValue}/${portValue}/g" ${capiConfigFile}
-        fi
-    fi
 }
 
 overridePort "rest_port"
@@ -48,7 +37,7 @@ overridePort "ssl_rest_port"
 overridePort "ssl_capi_port"
 overridePort "ssl_proxy_downstream_port"
 overridePort "ssl_proxy_upstream_port"
-overridePort "capi_port"
+
 
 [[ "$1" == "couchbase-server" ]] && {
 

--- a/community/couchbase-server/5.0.1/scripts/entrypoint.sh
+++ b/community/couchbase-server/5.0.1/scripts/entrypoint.sh
@@ -2,9 +2,7 @@
 set -e
 
 staticConfigFile=/opt/couchbase/etc/couchbase/static_config
-capiConfigFile=/opt/couchbase/etc/couchdb/default.d/capi.ini
 restPortValue=8091
-capiPortValue=8092
 
 # see https://developer.couchbase.com/documentation/server/current/install/install-ports.html
 function overridePort() {
@@ -26,15 +24,6 @@ function overridePort() {
             fi
         fi
     fi
-
-    if [ "$portNameUpper" == "CAPI_PORT" ]; then
-        if grep -Fq "{${portValue}," ${capiConfigFile}
-        then
-            echo "Don't override port ${portName} because already available in $staticConfigFile"
-        else
-            sed -i -e "s/${capiPortValue}/${portValue}/g" ${capiConfigFile}
-        fi
-    fi
 }
 
 overridePort "rest_port"
@@ -48,7 +37,7 @@ overridePort "ssl_rest_port"
 overridePort "ssl_capi_port"
 overridePort "ssl_proxy_downstream_port"
 overridePort "ssl_proxy_upstream_port"
-overridePort "capi_port"
+
 
 [[ "$1" == "couchbase-server" ]] && {
 

--- a/community/couchbase-server/5.1.1/scripts/entrypoint.sh
+++ b/community/couchbase-server/5.1.1/scripts/entrypoint.sh
@@ -2,9 +2,7 @@
 set -e
 
 staticConfigFile=/opt/couchbase/etc/couchbase/static_config
-capiConfigFile=/opt/couchbase/etc/couchdb/default.d/capi.ini
 restPortValue=8091
-capiPortValue=8092
 
 # see https://developer.couchbase.com/documentation/server/current/install/install-ports.html
 function overridePort() {
@@ -26,15 +24,6 @@ function overridePort() {
             fi
         fi
     fi
-
-    if [ "$portNameUpper" == "CAPI_PORT" ]; then
-        if grep -Fq "{${portValue}," ${capiConfigFile}
-        then
-            echo "Don't override port ${portName} because already available in $staticConfigFile"
-        else
-            sed -i -e "s/${capiPortValue}/${portValue}/g" ${capiConfigFile}
-        fi
-    fi
 }
 
 overridePort "rest_port"
@@ -48,7 +37,7 @@ overridePort "ssl_rest_port"
 overridePort "ssl_capi_port"
 overridePort "ssl_proxy_downstream_port"
 overridePort "ssl_proxy_upstream_port"
-overridePort "capi_port"
+
 
 [[ "$1" == "couchbase-server" ]] && {
 

--- a/enterprise/couchbase-server/2.5.2/scripts/entrypoint.sh
+++ b/enterprise/couchbase-server/2.5.2/scripts/entrypoint.sh
@@ -2,9 +2,7 @@
 set -e
 
 staticConfigFile=/opt/couchbase/etc/couchbase/static_config
-capiConfigFile=/opt/couchbase/etc/couchdb/default.d/capi.ini
 restPortValue=8091
-capiPortValue=8092
 
 # see https://developer.couchbase.com/documentation/server/current/install/install-ports.html
 function overridePort() {
@@ -26,15 +24,6 @@ function overridePort() {
             fi
         fi
     fi
-
-    if [ "$portNameUpper" == "CAPI_PORT" ]; then
-        if grep -Fq "{${portValue}," ${capiConfigFile}
-        then
-            echo "Don't override port ${portName} because already available in $staticConfigFile"
-        else
-            sed -i -e "s/${capiPortValue}/${portValue}/g" ${capiConfigFile}
-        fi
-    fi
 }
 
 overridePort "rest_port"
@@ -48,7 +37,7 @@ overridePort "ssl_rest_port"
 overridePort "ssl_capi_port"
 overridePort "ssl_proxy_downstream_port"
 overridePort "ssl_proxy_upstream_port"
-overridePort "capi_port"
+
 
 [[ "$1" == "couchbase-server" ]] && {
 

--- a/enterprise/couchbase-server/3.0.2/scripts/entrypoint.sh
+++ b/enterprise/couchbase-server/3.0.2/scripts/entrypoint.sh
@@ -2,9 +2,7 @@
 set -e
 
 staticConfigFile=/opt/couchbase/etc/couchbase/static_config
-capiConfigFile=/opt/couchbase/etc/couchdb/default.d/capi.ini
 restPortValue=8091
-capiPortValue=8092
 
 # see https://developer.couchbase.com/documentation/server/current/install/install-ports.html
 function overridePort() {
@@ -26,15 +24,6 @@ function overridePort() {
             fi
         fi
     fi
-
-    if [ "$portNameUpper" == "CAPI_PORT" ]; then
-        if grep -Fq "{${portValue}," ${capiConfigFile}
-        then
-            echo "Don't override port ${portName} because already available in $staticConfigFile"
-        else
-            sed -i -e "s/${capiPortValue}/${portValue}/g" ${capiConfigFile}
-        fi
-    fi
 }
 
 overridePort "rest_port"
@@ -48,7 +37,7 @@ overridePort "ssl_rest_port"
 overridePort "ssl_capi_port"
 overridePort "ssl_proxy_downstream_port"
 overridePort "ssl_proxy_upstream_port"
-overridePort "capi_port"
+
 
 [[ "$1" == "couchbase-server" ]] && {
 

--- a/enterprise/couchbase-server/3.0.3/scripts/entrypoint.sh
+++ b/enterprise/couchbase-server/3.0.3/scripts/entrypoint.sh
@@ -2,9 +2,7 @@
 set -e
 
 staticConfigFile=/opt/couchbase/etc/couchbase/static_config
-capiConfigFile=/opt/couchbase/etc/couchdb/default.d/capi.ini
 restPortValue=8091
-capiPortValue=8092
 
 # see https://developer.couchbase.com/documentation/server/current/install/install-ports.html
 function overridePort() {
@@ -26,15 +24,6 @@ function overridePort() {
             fi
         fi
     fi
-
-    if [ "$portNameUpper" == "CAPI_PORT" ]; then
-        if grep -Fq "{${portValue}," ${capiConfigFile}
-        then
-            echo "Don't override port ${portName} because already available in $staticConfigFile"
-        else
-            sed -i -e "s/${capiPortValue}/${portValue}/g" ${capiConfigFile}
-        fi
-    fi
 }
 
 overridePort "rest_port"
@@ -48,7 +37,7 @@ overridePort "ssl_rest_port"
 overridePort "ssl_capi_port"
 overridePort "ssl_proxy_downstream_port"
 overridePort "ssl_proxy_upstream_port"
-overridePort "capi_port"
+
 
 [[ "$1" == "couchbase-server" ]] && {
 

--- a/enterprise/couchbase-server/3.1.0/scripts/entrypoint.sh
+++ b/enterprise/couchbase-server/3.1.0/scripts/entrypoint.sh
@@ -2,9 +2,7 @@
 set -e
 
 staticConfigFile=/opt/couchbase/etc/couchbase/static_config
-capiConfigFile=/opt/couchbase/etc/couchdb/default.d/capi.ini
 restPortValue=8091
-capiPortValue=8092
 
 # see https://developer.couchbase.com/documentation/server/current/install/install-ports.html
 function overridePort() {
@@ -26,15 +24,6 @@ function overridePort() {
             fi
         fi
     fi
-
-    if [ "$portNameUpper" == "CAPI_PORT" ]; then
-        if grep -Fq "{${portValue}," ${capiConfigFile}
-        then
-            echo "Don't override port ${portName} because already available in $staticConfigFile"
-        else
-            sed -i -e "s/${capiPortValue}/${portValue}/g" ${capiConfigFile}
-        fi
-    fi
 }
 
 overridePort "rest_port"
@@ -48,7 +37,7 @@ overridePort "ssl_rest_port"
 overridePort "ssl_capi_port"
 overridePort "ssl_proxy_downstream_port"
 overridePort "ssl_proxy_upstream_port"
-overridePort "capi_port"
+
 
 [[ "$1" == "couchbase-server" ]] && {
 

--- a/enterprise/couchbase-server/3.1.3/scripts/entrypoint.sh
+++ b/enterprise/couchbase-server/3.1.3/scripts/entrypoint.sh
@@ -2,9 +2,7 @@
 set -e
 
 staticConfigFile=/opt/couchbase/etc/couchbase/static_config
-capiConfigFile=/opt/couchbase/etc/couchdb/default.d/capi.ini
 restPortValue=8091
-capiPortValue=8092
 
 # see https://developer.couchbase.com/documentation/server/current/install/install-ports.html
 function overridePort() {
@@ -26,15 +24,6 @@ function overridePort() {
             fi
         fi
     fi
-
-    if [ "$portNameUpper" == "CAPI_PORT" ]; then
-        if grep -Fq "{${portValue}," ${capiConfigFile}
-        then
-            echo "Don't override port ${portName} because already available in $staticConfigFile"
-        else
-            sed -i -e "s/${capiPortValue}/${portValue}/g" ${capiConfigFile}
-        fi
-    fi
 }
 
 overridePort "rest_port"
@@ -48,7 +37,7 @@ overridePort "ssl_rest_port"
 overridePort "ssl_capi_port"
 overridePort "ssl_proxy_downstream_port"
 overridePort "ssl_proxy_upstream_port"
-overridePort "capi_port"
+
 
 [[ "$1" == "couchbase-server" ]] && {
 

--- a/enterprise/couchbase-server/3.1.5/scripts/entrypoint.sh
+++ b/enterprise/couchbase-server/3.1.5/scripts/entrypoint.sh
@@ -2,9 +2,7 @@
 set -e
 
 staticConfigFile=/opt/couchbase/etc/couchbase/static_config
-capiConfigFile=/opt/couchbase/etc/couchdb/default.d/capi.ini
 restPortValue=8091
-capiPortValue=8092
 
 # see https://developer.couchbase.com/documentation/server/current/install/install-ports.html
 function overridePort() {
@@ -26,15 +24,6 @@ function overridePort() {
             fi
         fi
     fi
-
-    if [ "$portNameUpper" == "CAPI_PORT" ]; then
-        if grep -Fq "{${portValue}," ${capiConfigFile}
-        then
-            echo "Don't override port ${portName} because already available in $staticConfigFile"
-        else
-            sed -i -e "s/${capiPortValue}/${portValue}/g" ${capiConfigFile}
-        fi
-    fi
 }
 
 overridePort "rest_port"
@@ -48,7 +37,7 @@ overridePort "ssl_rest_port"
 overridePort "ssl_capi_port"
 overridePort "ssl_proxy_downstream_port"
 overridePort "ssl_proxy_upstream_port"
-overridePort "capi_port"
+
 
 [[ "$1" == "couchbase-server" ]] && {
 

--- a/enterprise/couchbase-server/3.1.6/scripts/entrypoint.sh
+++ b/enterprise/couchbase-server/3.1.6/scripts/entrypoint.sh
@@ -2,9 +2,7 @@
 set -e
 
 staticConfigFile=/opt/couchbase/etc/couchbase/static_config
-capiConfigFile=/opt/couchbase/etc/couchdb/default.d/capi.ini
 restPortValue=8091
-capiPortValue=8092
 
 # see https://developer.couchbase.com/documentation/server/current/install/install-ports.html
 function overridePort() {
@@ -26,15 +24,6 @@ function overridePort() {
             fi
         fi
     fi
-
-    if [ "$portNameUpper" == "CAPI_PORT" ]; then
-        if grep -Fq "{${portValue}," ${capiConfigFile}
-        then
-            echo "Don't override port ${portName} because already available in $staticConfigFile"
-        else
-            sed -i -e "s/${capiPortValue}/${portValue}/g" ${capiConfigFile}
-        fi
-    fi
 }
 
 overridePort "rest_port"
@@ -48,7 +37,7 @@ overridePort "ssl_rest_port"
 overridePort "ssl_capi_port"
 overridePort "ssl_proxy_downstream_port"
 overridePort "ssl_proxy_upstream_port"
-overridePort "capi_port"
+
 
 [[ "$1" == "couchbase-server" ]] && {
 

--- a/enterprise/couchbase-server/4.0.0/scripts/entrypoint.sh
+++ b/enterprise/couchbase-server/4.0.0/scripts/entrypoint.sh
@@ -2,9 +2,7 @@
 set -e
 
 staticConfigFile=/opt/couchbase/etc/couchbase/static_config
-capiConfigFile=/opt/couchbase/etc/couchdb/default.d/capi.ini
 restPortValue=8091
-capiPortValue=8092
 
 # see https://developer.couchbase.com/documentation/server/current/install/install-ports.html
 function overridePort() {
@@ -26,15 +24,6 @@ function overridePort() {
             fi
         fi
     fi
-
-    if [ "$portNameUpper" == "CAPI_PORT" ]; then
-        if grep -Fq "{${portValue}," ${capiConfigFile}
-        then
-            echo "Don't override port ${portName} because already available in $staticConfigFile"
-        else
-            sed -i -e "s/${capiPortValue}/${portValue}/g" ${capiConfigFile}
-        fi
-    fi
 }
 
 overridePort "rest_port"
@@ -48,7 +37,7 @@ overridePort "ssl_rest_port"
 overridePort "ssl_capi_port"
 overridePort "ssl_proxy_downstream_port"
 overridePort "ssl_proxy_upstream_port"
-overridePort "capi_port"
+
 
 [[ "$1" == "couchbase-server" ]] && {
 

--- a/enterprise/couchbase-server/4.1.0/scripts/entrypoint.sh
+++ b/enterprise/couchbase-server/4.1.0/scripts/entrypoint.sh
@@ -2,9 +2,7 @@
 set -e
 
 staticConfigFile=/opt/couchbase/etc/couchbase/static_config
-capiConfigFile=/opt/couchbase/etc/couchdb/default.d/capi.ini
 restPortValue=8091
-capiPortValue=8092
 
 # see https://developer.couchbase.com/documentation/server/current/install/install-ports.html
 function overridePort() {
@@ -26,15 +24,6 @@ function overridePort() {
             fi
         fi
     fi
-
-    if [ "$portNameUpper" == "CAPI_PORT" ]; then
-        if grep -Fq "{${portValue}," ${capiConfigFile}
-        then
-            echo "Don't override port ${portName} because already available in $staticConfigFile"
-        else
-            sed -i -e "s/${capiPortValue}/${portValue}/g" ${capiConfigFile}
-        fi
-    fi
 }
 
 overridePort "rest_port"
@@ -48,7 +37,7 @@ overridePort "ssl_rest_port"
 overridePort "ssl_capi_port"
 overridePort "ssl_proxy_downstream_port"
 overridePort "ssl_proxy_upstream_port"
-overridePort "capi_port"
+
 
 [[ "$1" == "couchbase-server" ]] && {
 

--- a/enterprise/couchbase-server/4.1.1/scripts/entrypoint.sh
+++ b/enterprise/couchbase-server/4.1.1/scripts/entrypoint.sh
@@ -2,9 +2,7 @@
 set -e
 
 staticConfigFile=/opt/couchbase/etc/couchbase/static_config
-capiConfigFile=/opt/couchbase/etc/couchdb/default.d/capi.ini
 restPortValue=8091
-capiPortValue=8092
 
 # see https://developer.couchbase.com/documentation/server/current/install/install-ports.html
 function overridePort() {
@@ -26,15 +24,6 @@ function overridePort() {
             fi
         fi
     fi
-
-    if [ "$portNameUpper" == "CAPI_PORT" ]; then
-        if grep -Fq "{${portValue}," ${capiConfigFile}
-        then
-            echo "Don't override port ${portName} because already available in $staticConfigFile"
-        else
-            sed -i -e "s/${capiPortValue}/${portValue}/g" ${capiConfigFile}
-        fi
-    fi
 }
 
 overridePort "rest_port"
@@ -48,7 +37,7 @@ overridePort "ssl_rest_port"
 overridePort "ssl_capi_port"
 overridePort "ssl_proxy_downstream_port"
 overridePort "ssl_proxy_upstream_port"
-overridePort "capi_port"
+
 
 [[ "$1" == "couchbase-server" ]] && {
 

--- a/enterprise/couchbase-server/4.1.2/scripts/entrypoint.sh
+++ b/enterprise/couchbase-server/4.1.2/scripts/entrypoint.sh
@@ -2,9 +2,7 @@
 set -e
 
 staticConfigFile=/opt/couchbase/etc/couchbase/static_config
-capiConfigFile=/opt/couchbase/etc/couchdb/default.d/capi.ini
 restPortValue=8091
-capiPortValue=8092
 
 # see https://developer.couchbase.com/documentation/server/current/install/install-ports.html
 function overridePort() {
@@ -26,15 +24,6 @@ function overridePort() {
             fi
         fi
     fi
-
-    if [ "$portNameUpper" == "CAPI_PORT" ]; then
-        if grep -Fq "{${portValue}," ${capiConfigFile}
-        then
-            echo "Don't override port ${portName} because already available in $staticConfigFile"
-        else
-            sed -i -e "s/${capiPortValue}/${portValue}/g" ${capiConfigFile}
-        fi
-    fi
 }
 
 overridePort "rest_port"
@@ -48,7 +37,7 @@ overridePort "ssl_rest_port"
 overridePort "ssl_capi_port"
 overridePort "ssl_proxy_downstream_port"
 overridePort "ssl_proxy_upstream_port"
-overridePort "capi_port"
+
 
 [[ "$1" == "couchbase-server" ]] && {
 

--- a/enterprise/couchbase-server/4.5.0/scripts/entrypoint.sh
+++ b/enterprise/couchbase-server/4.5.0/scripts/entrypoint.sh
@@ -2,9 +2,7 @@
 set -e
 
 staticConfigFile=/opt/couchbase/etc/couchbase/static_config
-capiConfigFile=/opt/couchbase/etc/couchdb/default.d/capi.ini
 restPortValue=8091
-capiPortValue=8092
 
 # see https://developer.couchbase.com/documentation/server/current/install/install-ports.html
 function overridePort() {
@@ -26,15 +24,6 @@ function overridePort() {
             fi
         fi
     fi
-
-    if [ "$portNameUpper" == "CAPI_PORT" ]; then
-        if grep -Fq "{${portValue}," ${capiConfigFile}
-        then
-            echo "Don't override port ${portName} because already available in $staticConfigFile"
-        else
-            sed -i -e "s/${capiPortValue}/${portValue}/g" ${capiConfigFile}
-        fi
-    fi
 }
 
 overridePort "rest_port"
@@ -48,7 +37,7 @@ overridePort "ssl_rest_port"
 overridePort "ssl_capi_port"
 overridePort "ssl_proxy_downstream_port"
 overridePort "ssl_proxy_upstream_port"
-overridePort "capi_port"
+
 
 [[ "$1" == "couchbase-server" ]] && {
 

--- a/enterprise/couchbase-server/4.5.1/scripts/entrypoint.sh
+++ b/enterprise/couchbase-server/4.5.1/scripts/entrypoint.sh
@@ -2,9 +2,7 @@
 set -e
 
 staticConfigFile=/opt/couchbase/etc/couchbase/static_config
-capiConfigFile=/opt/couchbase/etc/couchdb/default.d/capi.ini
 restPortValue=8091
-capiPortValue=8092
 
 # see https://developer.couchbase.com/documentation/server/current/install/install-ports.html
 function overridePort() {
@@ -26,15 +24,6 @@ function overridePort() {
             fi
         fi
     fi
-
-    if [ "$portNameUpper" == "CAPI_PORT" ]; then
-        if grep -Fq "{${portValue}," ${capiConfigFile}
-        then
-            echo "Don't override port ${portName} because already available in $staticConfigFile"
-        else
-            sed -i -e "s/${capiPortValue}/${portValue}/g" ${capiConfigFile}
-        fi
-    fi
 }
 
 overridePort "rest_port"
@@ -48,7 +37,7 @@ overridePort "ssl_rest_port"
 overridePort "ssl_capi_port"
 overridePort "ssl_proxy_downstream_port"
 overridePort "ssl_proxy_upstream_port"
-overridePort "capi_port"
+
 
 [[ "$1" == "couchbase-server" ]] && {
 

--- a/enterprise/couchbase-server/4.6.0-DP/scripts/entrypoint.sh
+++ b/enterprise/couchbase-server/4.6.0-DP/scripts/entrypoint.sh
@@ -2,9 +2,7 @@
 set -e
 
 staticConfigFile=/opt/couchbase/etc/couchbase/static_config
-capiConfigFile=/opt/couchbase/etc/couchdb/default.d/capi.ini
 restPortValue=8091
-capiPortValue=8092
 
 # see https://developer.couchbase.com/documentation/server/current/install/install-ports.html
 function overridePort() {
@@ -26,15 +24,6 @@ function overridePort() {
             fi
         fi
     fi
-
-    if [ "$portNameUpper" == "CAPI_PORT" ]; then
-        if grep -Fq "{${portValue}," ${capiConfigFile}
-        then
-            echo "Don't override port ${portName} because already available in $staticConfigFile"
-        else
-            sed -i -e "s/${capiPortValue}/${portValue}/g" ${capiConfigFile}
-        fi
-    fi
 }
 
 overridePort "rest_port"
@@ -48,7 +37,7 @@ overridePort "ssl_rest_port"
 overridePort "ssl_capi_port"
 overridePort "ssl_proxy_downstream_port"
 overridePort "ssl_proxy_upstream_port"
-overridePort "capi_port"
+
 
 [[ "$1" == "couchbase-server" ]] && {
 

--- a/enterprise/couchbase-server/4.6.0/scripts/entrypoint.sh
+++ b/enterprise/couchbase-server/4.6.0/scripts/entrypoint.sh
@@ -2,9 +2,7 @@
 set -e
 
 staticConfigFile=/opt/couchbase/etc/couchbase/static_config
-capiConfigFile=/opt/couchbase/etc/couchdb/default.d/capi.ini
 restPortValue=8091
-capiPortValue=8092
 
 # see https://developer.couchbase.com/documentation/server/current/install/install-ports.html
 function overridePort() {
@@ -26,15 +24,6 @@ function overridePort() {
             fi
         fi
     fi
-
-    if [ "$portNameUpper" == "CAPI_PORT" ]; then
-        if grep -Fq "{${portValue}," ${capiConfigFile}
-        then
-            echo "Don't override port ${portName} because already available in $staticConfigFile"
-        else
-            sed -i -e "s/${capiPortValue}/${portValue}/g" ${capiConfigFile}
-        fi
-    fi
 }
 
 overridePort "rest_port"
@@ -48,7 +37,7 @@ overridePort "ssl_rest_port"
 overridePort "ssl_capi_port"
 overridePort "ssl_proxy_downstream_port"
 overridePort "ssl_proxy_upstream_port"
-overridePort "capi_port"
+
 
 [[ "$1" == "couchbase-server" ]] && {
 

--- a/enterprise/couchbase-server/4.6.1/scripts/entrypoint.sh
+++ b/enterprise/couchbase-server/4.6.1/scripts/entrypoint.sh
@@ -2,9 +2,7 @@
 set -e
 
 staticConfigFile=/opt/couchbase/etc/couchbase/static_config
-capiConfigFile=/opt/couchbase/etc/couchdb/default.d/capi.ini
 restPortValue=8091
-capiPortValue=8092
 
 # see https://developer.couchbase.com/documentation/server/current/install/install-ports.html
 function overridePort() {
@@ -26,15 +24,6 @@ function overridePort() {
             fi
         fi
     fi
-
-    if [ "$portNameUpper" == "CAPI_PORT" ]; then
-        if grep -Fq "{${portValue}," ${capiConfigFile}
-        then
-            echo "Don't override port ${portName} because already available in $staticConfigFile"
-        else
-            sed -i -e "s/${capiPortValue}/${portValue}/g" ${capiConfigFile}
-        fi
-    fi
 }
 
 overridePort "rest_port"
@@ -48,7 +37,7 @@ overridePort "ssl_rest_port"
 overridePort "ssl_capi_port"
 overridePort "ssl_proxy_downstream_port"
 overridePort "ssl_proxy_upstream_port"
-overridePort "capi_port"
+
 
 [[ "$1" == "couchbase-server" ]] && {
 

--- a/enterprise/couchbase-server/4.6.2/scripts/entrypoint.sh
+++ b/enterprise/couchbase-server/4.6.2/scripts/entrypoint.sh
@@ -2,9 +2,7 @@
 set -e
 
 staticConfigFile=/opt/couchbase/etc/couchbase/static_config
-capiConfigFile=/opt/couchbase/etc/couchdb/default.d/capi.ini
 restPortValue=8091
-capiPortValue=8092
 
 # see https://developer.couchbase.com/documentation/server/current/install/install-ports.html
 function overridePort() {
@@ -26,15 +24,6 @@ function overridePort() {
             fi
         fi
     fi
-
-    if [ "$portNameUpper" == "CAPI_PORT" ]; then
-        if grep -Fq "{${portValue}," ${capiConfigFile}
-        then
-            echo "Don't override port ${portName} because already available in $staticConfigFile"
-        else
-            sed -i -e "s/${capiPortValue}/${portValue}/g" ${capiConfigFile}
-        fi
-    fi
 }
 
 overridePort "rest_port"
@@ -48,7 +37,7 @@ overridePort "ssl_rest_port"
 overridePort "ssl_capi_port"
 overridePort "ssl_proxy_downstream_port"
 overridePort "ssl_proxy_upstream_port"
-overridePort "capi_port"
+
 
 [[ "$1" == "couchbase-server" ]] && {
 

--- a/enterprise/couchbase-server/4.6.3/scripts/entrypoint.sh
+++ b/enterprise/couchbase-server/4.6.3/scripts/entrypoint.sh
@@ -2,9 +2,7 @@
 set -e
 
 staticConfigFile=/opt/couchbase/etc/couchbase/static_config
-capiConfigFile=/opt/couchbase/etc/couchdb/default.d/capi.ini
 restPortValue=8091
-capiPortValue=8092
 
 # see https://developer.couchbase.com/documentation/server/current/install/install-ports.html
 function overridePort() {
@@ -26,15 +24,6 @@ function overridePort() {
             fi
         fi
     fi
-
-    if [ "$portNameUpper" == "CAPI_PORT" ]; then
-        if grep -Fq "{${portValue}," ${capiConfigFile}
-        then
-            echo "Don't override port ${portName} because already available in $staticConfigFile"
-        else
-            sed -i -e "s/${capiPortValue}/${portValue}/g" ${capiConfigFile}
-        fi
-    fi
 }
 
 overridePort "rest_port"
@@ -48,7 +37,7 @@ overridePort "ssl_rest_port"
 overridePort "ssl_capi_port"
 overridePort "ssl_proxy_downstream_port"
 overridePort "ssl_proxy_upstream_port"
-overridePort "capi_port"
+
 
 [[ "$1" == "couchbase-server" ]] && {
 

--- a/enterprise/couchbase-server/4.6.4/scripts/entrypoint.sh
+++ b/enterprise/couchbase-server/4.6.4/scripts/entrypoint.sh
@@ -2,9 +2,7 @@
 set -e
 
 staticConfigFile=/opt/couchbase/etc/couchbase/static_config
-capiConfigFile=/opt/couchbase/etc/couchdb/default.d/capi.ini
 restPortValue=8091
-capiPortValue=8092
 
 # see https://developer.couchbase.com/documentation/server/current/install/install-ports.html
 function overridePort() {
@@ -26,15 +24,6 @@ function overridePort() {
             fi
         fi
     fi
-
-    if [ "$portNameUpper" == "CAPI_PORT" ]; then
-        if grep -Fq "{${portValue}," ${capiConfigFile}
-        then
-            echo "Don't override port ${portName} because already available in $staticConfigFile"
-        else
-            sed -i -e "s/${capiPortValue}/${portValue}/g" ${capiConfigFile}
-        fi
-    fi
 }
 
 overridePort "rest_port"
@@ -48,7 +37,7 @@ overridePort "ssl_rest_port"
 overridePort "ssl_capi_port"
 overridePort "ssl_proxy_downstream_port"
 overridePort "ssl_proxy_upstream_port"
-overridePort "capi_port"
+
 
 [[ "$1" == "couchbase-server" ]] && {
 

--- a/enterprise/couchbase-server/4.6.5/scripts/entrypoint.sh
+++ b/enterprise/couchbase-server/4.6.5/scripts/entrypoint.sh
@@ -2,9 +2,7 @@
 set -e
 
 staticConfigFile=/opt/couchbase/etc/couchbase/static_config
-capiConfigFile=/opt/couchbase/etc/couchdb/default.d/capi.ini
 restPortValue=8091
-capiPortValue=8092
 
 # see https://developer.couchbase.com/documentation/server/current/install/install-ports.html
 function overridePort() {
@@ -26,15 +24,6 @@ function overridePort() {
             fi
         fi
     fi
-
-    if [ "$portNameUpper" == "CAPI_PORT" ]; then
-        if grep -Fq "{${portValue}," ${capiConfigFile}
-        then
-            echo "Don't override port ${portName} because already available in $staticConfigFile"
-        else
-            sed -i -e "s/${capiPortValue}/${portValue}/g" ${capiConfigFile}
-        fi
-    fi
 }
 
 overridePort "rest_port"
@@ -48,7 +37,7 @@ overridePort "ssl_rest_port"
 overridePort "ssl_capi_port"
 overridePort "ssl_proxy_downstream_port"
 overridePort "ssl_proxy_upstream_port"
-overridePort "capi_port"
+
 
 [[ "$1" == "couchbase-server" ]] && {
 

--- a/enterprise/couchbase-server/5.0.1/scripts/entrypoint.sh
+++ b/enterprise/couchbase-server/5.0.1/scripts/entrypoint.sh
@@ -2,9 +2,7 @@
 set -e
 
 staticConfigFile=/opt/couchbase/etc/couchbase/static_config
-capiConfigFile=/opt/couchbase/etc/couchdb/default.d/capi.ini
 restPortValue=8091
-capiPortValue=8092
 
 # see https://developer.couchbase.com/documentation/server/current/install/install-ports.html
 function overridePort() {
@@ -26,15 +24,6 @@ function overridePort() {
             fi
         fi
     fi
-
-    if [ "$portNameUpper" == "CAPI_PORT" ]; then
-        if grep -Fq "{${portValue}," ${capiConfigFile}
-        then
-            echo "Don't override port ${portName} because already available in $staticConfigFile"
-        else
-            sed -i -e "s/${capiPortValue}/${portValue}/g" ${capiConfigFile}
-        fi
-    fi
 }
 
 overridePort "rest_port"
@@ -48,7 +37,7 @@ overridePort "ssl_rest_port"
 overridePort "ssl_capi_port"
 overridePort "ssl_proxy_downstream_port"
 overridePort "ssl_proxy_upstream_port"
-overridePort "capi_port"
+
 
 [[ "$1" == "couchbase-server" ]] && {
 

--- a/enterprise/couchbase-server/5.1.0/scripts/entrypoint.sh
+++ b/enterprise/couchbase-server/5.1.0/scripts/entrypoint.sh
@@ -2,9 +2,7 @@
 set -e
 
 staticConfigFile=/opt/couchbase/etc/couchbase/static_config
-capiConfigFile=/opt/couchbase/etc/couchdb/default.d/capi.ini
 restPortValue=8091
-capiPortValue=8092
 
 # see https://developer.couchbase.com/documentation/server/current/install/install-ports.html
 function overridePort() {
@@ -26,15 +24,6 @@ function overridePort() {
             fi
         fi
     fi
-
-    if [ "$portNameUpper" == "CAPI_PORT" ]; then
-        if grep -Fq "{${portValue}," ${capiConfigFile}
-        then
-            echo "Don't override port ${portName} because already available in $staticConfigFile"
-        else
-            sed -i -e "s/${capiPortValue}/${portValue}/g" ${capiConfigFile}
-        fi
-    fi
 }
 
 overridePort "rest_port"
@@ -48,7 +37,7 @@ overridePort "ssl_rest_port"
 overridePort "ssl_capi_port"
 overridePort "ssl_proxy_downstream_port"
 overridePort "ssl_proxy_upstream_port"
-overridePort "capi_port"
+
 
 [[ "$1" == "couchbase-server" ]] && {
 

--- a/enterprise/couchbase-server/5.1.1/scripts/entrypoint.sh
+++ b/enterprise/couchbase-server/5.1.1/scripts/entrypoint.sh
@@ -2,9 +2,7 @@
 set -e
 
 staticConfigFile=/opt/couchbase/etc/couchbase/static_config
-capiConfigFile=/opt/couchbase/etc/couchdb/default.d/capi.ini
 restPortValue=8091
-capiPortValue=8092
 
 # see https://developer.couchbase.com/documentation/server/current/install/install-ports.html
 function overridePort() {
@@ -26,15 +24,6 @@ function overridePort() {
             fi
         fi
     fi
-
-    if [ "$portNameUpper" == "CAPI_PORT" ]; then
-        if grep -Fq "{${portValue}," ${capiConfigFile}
-        then
-            echo "Don't override port ${portName} because already available in $staticConfigFile"
-        else
-            sed -i -e "s/${capiPortValue}/${portValue}/g" ${capiConfigFile}
-        fi
-    fi
 }
 
 overridePort "rest_port"
@@ -48,7 +37,7 @@ overridePort "ssl_rest_port"
 overridePort "ssl_capi_port"
 overridePort "ssl_proxy_downstream_port"
 overridePort "ssl_proxy_upstream_port"
-overridePort "capi_port"
+
 
 [[ "$1" == "couchbase-server" ]] && {
 

--- a/enterprise/couchbase-server/5.5.0-Mar/scripts/entrypoint.sh
+++ b/enterprise/couchbase-server/5.5.0-Mar/scripts/entrypoint.sh
@@ -2,9 +2,7 @@
 set -e
 
 staticConfigFile=/opt/couchbase/etc/couchbase/static_config
-capiConfigFile=/opt/couchbase/etc/couchdb/default.d/capi.ini
 restPortValue=8091
-capiPortValue=8092
 
 # see https://developer.couchbase.com/documentation/server/current/install/install-ports.html
 function overridePort() {
@@ -26,15 +24,6 @@ function overridePort() {
             fi
         fi
     fi
-
-    if [ "$portNameUpper" == "CAPI_PORT" ]; then
-        if grep -Fq "{${portValue}," ${capiConfigFile}
-        then
-            echo "Don't override port ${portName} because already available in $staticConfigFile"
-        else
-            sed -i -e "s/${capiPortValue}/${portValue}/g" ${capiConfigFile}
-        fi
-    fi
 }
 
 overridePort "rest_port"
@@ -48,7 +37,7 @@ overridePort "ssl_rest_port"
 overridePort "ssl_capi_port"
 overridePort "ssl_proxy_downstream_port"
 overridePort "ssl_proxy_upstream_port"
-overridePort "capi_port"
+
 
 [[ "$1" == "couchbase-server" ]] && {
 

--- a/enterprise/couchbase-server/5.5.0-beta/scripts/entrypoint.sh
+++ b/enterprise/couchbase-server/5.5.0-beta/scripts/entrypoint.sh
@@ -2,9 +2,7 @@
 set -e
 
 staticConfigFile=/opt/couchbase/etc/couchbase/static_config
-capiConfigFile=/opt/couchbase/etc/couchdb/default.d/capi.ini
 restPortValue=8091
-capiPortValue=8092
 
 # see https://developer.couchbase.com/documentation/server/current/install/install-ports.html
 function overridePort() {
@@ -26,15 +24,6 @@ function overridePort() {
             fi
         fi
     fi
-
-    if [ "$portNameUpper" == "CAPI_PORT" ]; then
-        if grep -Fq "{${portValue}," ${capiConfigFile}
-        then
-            echo "Don't override port ${portName} because already available in $staticConfigFile"
-        else
-            sed -i -e "s/${capiPortValue}/${portValue}/g" ${capiConfigFile}
-        fi
-    fi
 }
 
 overridePort "rest_port"
@@ -48,7 +37,7 @@ overridePort "ssl_rest_port"
 overridePort "ssl_capi_port"
 overridePort "ssl_proxy_downstream_port"
 overridePort "ssl_proxy_upstream_port"
-overridePort "capi_port"
+
 
 [[ "$1" == "couchbase-server" ]] && {
 

--- a/generate/resources/couchbase-server/scripts/entrypoint.sh
+++ b/generate/resources/couchbase-server/scripts/entrypoint.sh
@@ -2,9 +2,7 @@
 set -e
 
 staticConfigFile=/opt/couchbase/etc/couchbase/static_config
-capiConfigFile=/opt/couchbase/etc/couchdb/default.d/capi.ini
 restPortValue=8091
-capiPortValue=8092
 
 # see https://developer.couchbase.com/documentation/server/current/install/install-ports.html
 function overridePort() {
@@ -26,15 +24,6 @@ function overridePort() {
             fi
         fi
     fi
-
-    if [ "$portNameUpper" == "CAPI_PORT" ]; then
-        if grep -Fq "{${portValue}," ${capiConfigFile}
-        then
-            echo "Don't override port ${portName} because already available in $staticConfigFile"
-        else
-            sed -i -e "s/${capiPortValue}/${portValue}/g" ${capiConfigFile}
-        fi
-    fi
 }
 
 overridePort "rest_port"
@@ -48,7 +37,7 @@ overridePort "ssl_rest_port"
 overridePort "ssl_capi_port"
 overridePort "ssl_proxy_downstream_port"
 overridePort "ssl_proxy_upstream_port"
-overridePort "capi_port"
+
 
 [[ "$1" == "couchbase-server" ]] && {
 


### PR DESCRIPTION
This change unfortunately had several problems which resulted in serious
regressions. Reverting this change. If we need to support CAPI_PORT for
overriding, we will need to do it more carefully.