### PR TITLE
Add config generation based on env vars for Sync Gateway, JS file injection, and more

### DIFF
--- a/community/sync-gateway/1.0.4/Dockerfile
+++ b/community/sync-gateway/1.0.4/Dockerfile
@@ -19,15 +19,15 @@ RUN wget http://packages.couchbase.com/releases/couchbase-sync-gateway/1.0.4/cou
 # Create directory where the default config stores memory snapshots to disk
 RUN mkdir /opt/couchbase-sync-gateway/data
 
-# copy the default config into the container
-COPY config/sync_gateway_config.json /etc/sync_gateway/config.json
+# Create sync file for custom config.json or generated from env vars config.json
+RUN mkdir /sync
+
+# Copy config generator from environment variables
+COPY /scripts/create_config.py /
 
 # Add bootstrap script
 COPY scripts/entrypoint.sh /
 ENTRYPOINT ["/entrypoint.sh"]
-
-# If user doesn't specify any args, use the default config
-CMD ["/etc/sync_gateway/config.json"]
 
 # Expose ports
 #  port 4984: public port

--- a/community/sync-gateway/1.0.4/scripts/create_config.py
+++ b/community/sync-gateway/1.0.4/scripts/create_config.py
@@ -1,0 +1,116 @@
+from __future__ import print_function
+import os
+import json
+import logging
+
+logging.basicConfig(level=logging.INFO)
+
+
+def getenv_boolean(var_name, default_value=False):
+    result = default_value
+    env_value = os.getenv(var_name)
+    if env_value is not None:
+        result = env_value.upper() in ("TRUE", "1")
+    return result
+
+
+# Env vars for configs
+COUCHBASE_HOST = os.getenv(
+    "COUCHBASE_HOST", ""
+)  # e.g.: "couchbase". Leave empty to use default Walrus
+COUCHBASE_PORT = os.getenv("COUCHBASE_PORT", "8091")
+COUCHBASE_BUCKET_NAME = os.getenv("COUCHBASE_BUCKET_NAME", "app")
+COUCHBASE_SYNC_GATEWAY_LOG = os.getenv(
+    "COUCHBASE_SYNC_GATEWAY_LOG", "HTTP+"
+)  # e.g.: "*"
+COUCHBASE_SYNC_GATEWAY_ADMIN_INTERFACE = os.getenv(
+    "COUCHBASE_SYNC_GATEWAY_ADMIN_INTERFACE", ""
+)  # e.g.: ":4985", leave empty to disable
+COUCHBASE_SYNC_GATEWAY_USER = os.getenv("COUCHBASE_SYNC_GATEWAY_USER", "")
+COUCHBASE_SYNC_GATEWAY_PASSWORD = os.getenv("COUCHBASE_SYNC_GATEWAY_PASSWORD", "")
+COUCHBASE_SYNC_GATEWAY_DATABASE = os.getenv("COUCHBASE_SYNC_GATEWAY_DATABASE", "db")
+COUCHBASE_SYNC_GATEWAY_CORS_ORIGINS = os.getenv(
+    "COUCHBASE_SYNC_GATEWAY_CORS_ORIGINS", ""
+)
+COUCHBASE_SYNC_GATEWAY_NUM_INDEX_REPLICAS = int(
+    os.getenv("COUCHBASE_SYNC_GATEWAY_NUM_INDEX_REPLICAS", "0")
+)
+COUCHBASE_SYNC_GATEWAY_DISABLE_GUEST_USER = getenv_boolean(
+    "COUCHBASE_SYNC_GATEWAY_DISABLE_GUEST_USER", default_value=False
+)
+
+# Base config
+logging.info("Generating base config")
+config_dict = {
+    "interface": ":4984",
+    "logging": {"console": {"log_keys": [COUCHBASE_SYNC_GATEWAY_LOG]}},
+    "databases": {},
+}
+
+# Admin interface
+logging.info("Checking adminInterface config config")
+if COUCHBASE_SYNC_GATEWAY_ADMIN_INTERFACE:
+    logging.info("Generating adminInterface config config")
+    config_dict["adminInterface"] = COUCHBASE_SYNC_GATEWAY_ADMIN_INTERFACE
+
+# CORS
+logging.info("Checking CORS config")
+if COUCHBASE_SYNC_GATEWAY_CORS_ORIGINS:
+    cors_list = COUCHBASE_SYNC_GATEWAY_CORS_ORIGINS.split(",")
+    use_cors = [origin.strip() for origin in cors_list]
+
+    logging.info("Generating CORS config")
+    config_dict["CORS"] = {
+        "Origin": use_cors,
+        "LoginOrigin": use_cors,
+        "Headers": ["Content-Type"],
+        "MaxAge": 17280000,
+    }
+
+# Couchbase
+logging.info("Checking Couchbase config")
+if COUCHBASE_HOST and COUCHBASE_SYNC_GATEWAY_USER and COUCHBASE_SYNC_GATEWAY_PASSWORD:
+    logging.info("Generating Couchbase config")
+    use_server = "http://{COUCHBASE_HOST}:{COUCHBASE_PORT}".format(
+        COUCHBASE_HOST=COUCHBASE_HOST, COUCHBASE_PORT=COUCHBASE_PORT
+    )
+
+    config_dict["databases"][COUCHBASE_SYNC_GATEWAY_DATABASE] = {
+        "server": use_server,
+        "bucket": COUCHBASE_BUCKET_NAME,
+        "username": COUCHBASE_SYNC_GATEWAY_USER,
+        "password": COUCHBASE_SYNC_GATEWAY_PASSWORD,
+        "num_index_replicas": COUCHBASE_SYNC_GATEWAY_NUM_INDEX_REPLICAS,
+        "enable_shared_bucket_access": True,
+        "import_docs": "continuous",
+        "users": {"GUEST": {"disabled": COUCHBASE_SYNC_GATEWAY_DISABLE_GUEST_USER}},
+    }
+else:
+    config_dict["databases"][COUCHBASE_SYNC_GATEWAY_DATABASE] = {
+        "server": "walrus:/opt/couchbase-sync-gateway/data",
+        "users": {
+            "GUEST": {
+                "disabled": COUCHBASE_SYNC_GATEWAY_DISABLE_GUEST_USER,
+                "admin_channels": ["*"],
+            }
+        },
+    }
+
+# JS sync function
+logging.info("Checking JavaScript sync function file")
+js_function_path = "/sync/sync-function.js"
+sync_function = ""
+logging.info("Checking JS sync function from {}".format(js_function_path))
+if os.path.isfile(js_function_path):
+    logging.info("Reading JavaScript sync function file")
+    with open(js_function_path) as f:
+        sync_function = f.read()
+if sync_function:
+    logging.info("Generating JavaScript sync function config")
+    config_dict["databases"][COUCHBASE_SYNC_GATEWAY_DATABASE]["sync"] = sync_function
+
+# Generate JSON config
+logging.info("Writing final config JSON file")
+with open("/etc/sync_gateway/config.json", "w") as f:
+    json.dump(config_dict, f, indent=2)
+logging.info("Done")

--- a/community/sync-gateway/1.0.4/scripts/entrypoint.sh
+++ b/community/sync-gateway/1.0.4/scripts/entrypoint.sh
@@ -1,6 +1,52 @@
 #!/bin/bash
 set -e
 
+# Check connection in a separate function, that way, when 
+# there's no connection available yet and the return of the command
+# is non-zero, the script doesn't exit yet
+check_connection() {
+    curl -Is http://${COUCHBASE_SYNC_GATEWAY_USER}:${COUCHBASE_SYNC_GATEWAY_PASSWORD}@${COUCHBASE_HOST}:${COUCHBASE_PORT}/pools/default/buckets/${COUCHBASE_BUCKET_NAME} 2>&1 | grep "HTTP/1.1 200 OK" > /dev/null
+    if [ $? -eq 0 ]; then
+        echo "success";
+    else
+        echo "error";
+    fi;
+}
+
+# Try to connect to Couchbase only if COUCHBASE_HOST was declared as an env var
+if [ ! -z $COUCHBASE_HOST ]; then
+    # Try once per second, up to 300 times (5 min)
+    SECONDS_TO_TRY=300
+    for i in $(seq 1 $SECONDS_TO_TRY); do
+        echo "Checking connection, trial ${i}";
+        result=$(check_connection);
+        if [ $result == "success" ]; then
+            echo "Success: connection checked";
+            sleep 1;
+            break;
+        else
+            echo "Connection not available yet, sleeping 1 sec...";
+            sleep 1;
+            echo "----------";
+        fi;
+    done;
+fi;
+
+config="/etc/sync_gateway/config.json"
+
+if [ ! -z $@ ]; then
+    echo "Using config provided as command parameter: $@"
+    config=$@
+else
+    if [ -f /sync/config.json ]; then
+        echo "Using provided config in: /sync/config.json";
+        config="/sync/config.json"
+    else
+        echo "No config provided in /sync/config.json, generating one from environment variables";
+        python create_config.py
+    fi;
+fi;
+
 LOGFILE_DIR=/var/log/sync_gateway
 mkdir -p $LOGFILE_DIR
 
@@ -9,4 +55,4 @@ LOGFILE_ERROR=$LOGFILE_DIR/sync_gateway_error.log
 
 # Run SG and use tee to append stdout and stderr to separate logfiles
 # Process substitution described here: https://stackoverflow.com/a/692407
-exec sync_gateway "$@" > >(tee -a $LOGFILE_ACCESS) 2> >(tee -a $LOGFILE_ERROR >&2)
+exec sync_gateway "$config" > >(tee -a $LOGFILE_ACCESS) 2> >(tee -a $LOGFILE_ERROR >&2)

--- a/community/sync-gateway/1.1.0-forestdb_bucket/Dockerfile
+++ b/community/sync-gateway/1.1.0-forestdb_bucket/Dockerfile
@@ -19,15 +19,15 @@ RUN wget http://packages.couchbase.com/releases/couchbase-sync-gateway/1.1.0/cou
 # Create directory where the default config stores memory snapshots to disk
 RUN mkdir /opt/couchbase-sync-gateway/data
 
-# copy the default config into the container
-COPY config/sync_gateway_config.json /etc/sync_gateway/config.json
+# Create sync file for custom config.json or generated from env vars config.json
+RUN mkdir /sync
+
+# Copy config generator from environment variables
+COPY /scripts/create_config.py /
 
 # Add bootstrap script
 COPY scripts/entrypoint.sh /
 ENTRYPOINT ["/entrypoint.sh"]
-
-# If user doesn't specify any args, use the default config
-CMD ["/etc/sync_gateway/config.json"]
 
 # Expose ports
 #  port 4984: public port

--- a/community/sync-gateway/1.1.0-forestdb_bucket/scripts/create_config.py
+++ b/community/sync-gateway/1.1.0-forestdb_bucket/scripts/create_config.py
@@ -1,0 +1,116 @@
+from __future__ import print_function
+import os
+import json
+import logging
+
+logging.basicConfig(level=logging.INFO)
+
+
+def getenv_boolean(var_name, default_value=False):
+    result = default_value
+    env_value = os.getenv(var_name)
+    if env_value is not None:
+        result = env_value.upper() in ("TRUE", "1")
+    return result
+
+
+# Env vars for configs
+COUCHBASE_HOST = os.getenv(
+    "COUCHBASE_HOST", ""
+)  # e.g.: "couchbase". Leave empty to use default Walrus
+COUCHBASE_PORT = os.getenv("COUCHBASE_PORT", "8091")
+COUCHBASE_BUCKET_NAME = os.getenv("COUCHBASE_BUCKET_NAME", "app")
+COUCHBASE_SYNC_GATEWAY_LOG = os.getenv(
+    "COUCHBASE_SYNC_GATEWAY_LOG", "HTTP+"
+)  # e.g.: "*"
+COUCHBASE_SYNC_GATEWAY_ADMIN_INTERFACE = os.getenv(
+    "COUCHBASE_SYNC_GATEWAY_ADMIN_INTERFACE", ""
+)  # e.g.: ":4985", leave empty to disable
+COUCHBASE_SYNC_GATEWAY_USER = os.getenv("COUCHBASE_SYNC_GATEWAY_USER", "")
+COUCHBASE_SYNC_GATEWAY_PASSWORD = os.getenv("COUCHBASE_SYNC_GATEWAY_PASSWORD", "")
+COUCHBASE_SYNC_GATEWAY_DATABASE = os.getenv("COUCHBASE_SYNC_GATEWAY_DATABASE", "db")
+COUCHBASE_SYNC_GATEWAY_CORS_ORIGINS = os.getenv(
+    "COUCHBASE_SYNC_GATEWAY_CORS_ORIGINS", ""
+)
+COUCHBASE_SYNC_GATEWAY_NUM_INDEX_REPLICAS = int(
+    os.getenv("COUCHBASE_SYNC_GATEWAY_NUM_INDEX_REPLICAS", "0")
+)
+COUCHBASE_SYNC_GATEWAY_DISABLE_GUEST_USER = getenv_boolean(
+    "COUCHBASE_SYNC_GATEWAY_DISABLE_GUEST_USER", default_value=False
+)
+
+# Base config
+logging.info("Generating base config")
+config_dict = {
+    "interface": ":4984",
+    "logging": {"console": {"log_keys": [COUCHBASE_SYNC_GATEWAY_LOG]}},
+    "databases": {},
+}
+
+# Admin interface
+logging.info("Checking adminInterface config config")
+if COUCHBASE_SYNC_GATEWAY_ADMIN_INTERFACE:
+    logging.info("Generating adminInterface config config")
+    config_dict["adminInterface"] = COUCHBASE_SYNC_GATEWAY_ADMIN_INTERFACE
+
+# CORS
+logging.info("Checking CORS config")
+if COUCHBASE_SYNC_GATEWAY_CORS_ORIGINS:
+    cors_list = COUCHBASE_SYNC_GATEWAY_CORS_ORIGINS.split(",")
+    use_cors = [origin.strip() for origin in cors_list]
+
+    logging.info("Generating CORS config")
+    config_dict["CORS"] = {
+        "Origin": use_cors,
+        "LoginOrigin": use_cors,
+        "Headers": ["Content-Type"],
+        "MaxAge": 17280000,
+    }
+
+# Couchbase
+logging.info("Checking Couchbase config")
+if COUCHBASE_HOST and COUCHBASE_SYNC_GATEWAY_USER and COUCHBASE_SYNC_GATEWAY_PASSWORD:
+    logging.info("Generating Couchbase config")
+    use_server = "http://{COUCHBASE_HOST}:{COUCHBASE_PORT}".format(
+        COUCHBASE_HOST=COUCHBASE_HOST, COUCHBASE_PORT=COUCHBASE_PORT
+    )
+
+    config_dict["databases"][COUCHBASE_SYNC_GATEWAY_DATABASE] = {
+        "server": use_server,
+        "bucket": COUCHBASE_BUCKET_NAME,
+        "username": COUCHBASE_SYNC_GATEWAY_USER,
+        "password": COUCHBASE_SYNC_GATEWAY_PASSWORD,
+        "num_index_replicas": COUCHBASE_SYNC_GATEWAY_NUM_INDEX_REPLICAS,
+        "enable_shared_bucket_access": True,
+        "import_docs": "continuous",
+        "users": {"GUEST": {"disabled": COUCHBASE_SYNC_GATEWAY_DISABLE_GUEST_USER}},
+    }
+else:
+    config_dict["databases"][COUCHBASE_SYNC_GATEWAY_DATABASE] = {
+        "server": "walrus:/opt/couchbase-sync-gateway/data",
+        "users": {
+            "GUEST": {
+                "disabled": COUCHBASE_SYNC_GATEWAY_DISABLE_GUEST_USER,
+                "admin_channels": ["*"],
+            }
+        },
+    }
+
+# JS sync function
+logging.info("Checking JavaScript sync function file")
+js_function_path = "/sync/sync-function.js"
+sync_function = ""
+logging.info("Checking JS sync function from {}".format(js_function_path))
+if os.path.isfile(js_function_path):
+    logging.info("Reading JavaScript sync function file")
+    with open(js_function_path) as f:
+        sync_function = f.read()
+if sync_function:
+    logging.info("Generating JavaScript sync function config")
+    config_dict["databases"][COUCHBASE_SYNC_GATEWAY_DATABASE]["sync"] = sync_function
+
+# Generate JSON config
+logging.info("Writing final config JSON file")
+with open("/etc/sync_gateway/config.json", "w") as f:
+    json.dump(config_dict, f, indent=2)
+logging.info("Done")

--- a/community/sync-gateway/1.1.0-forestdb_bucket/scripts/entrypoint.sh
+++ b/community/sync-gateway/1.1.0-forestdb_bucket/scripts/entrypoint.sh
@@ -1,6 +1,52 @@
 #!/bin/bash
 set -e
 
+# Check connection in a separate function, that way, when 
+# there's no connection available yet and the return of the command
+# is non-zero, the script doesn't exit yet
+check_connection() {
+    curl -Is http://${COUCHBASE_SYNC_GATEWAY_USER}:${COUCHBASE_SYNC_GATEWAY_PASSWORD}@${COUCHBASE_HOST}:${COUCHBASE_PORT}/pools/default/buckets/${COUCHBASE_BUCKET_NAME} 2>&1 | grep "HTTP/1.1 200 OK" > /dev/null
+    if [ $? -eq 0 ]; then
+        echo "success";
+    else
+        echo "error";
+    fi;
+}
+
+# Try to connect to Couchbase only if COUCHBASE_HOST was declared as an env var
+if [ ! -z $COUCHBASE_HOST ]; then
+    # Try once per second, up to 300 times (5 min)
+    SECONDS_TO_TRY=300
+    for i in $(seq 1 $SECONDS_TO_TRY); do
+        echo "Checking connection, trial ${i}";
+        result=$(check_connection);
+        if [ $result == "success" ]; then
+            echo "Success: connection checked";
+            sleep 1;
+            break;
+        else
+            echo "Connection not available yet, sleeping 1 sec...";
+            sleep 1;
+            echo "----------";
+        fi;
+    done;
+fi;
+
+config="/etc/sync_gateway/config.json"
+
+if [ ! -z $@ ]; then
+    echo "Using config provided as command parameter: $@"
+    config=$@
+else
+    if [ -f /sync/config.json ]; then
+        echo "Using provided config in: /sync/config.json";
+        config="/sync/config.json"
+    else
+        echo "No config provided in /sync/config.json, generating one from environment variables";
+        python create_config.py
+    fi;
+fi;
+
 LOGFILE_DIR=/var/log/sync_gateway
 mkdir -p $LOGFILE_DIR
 
@@ -9,4 +55,4 @@ LOGFILE_ERROR=$LOGFILE_DIR/sync_gateway_error.log
 
 # Run SG and use tee to append stdout and stderr to separate logfiles
 # Process substitution described here: https://stackoverflow.com/a/692407
-exec sync_gateway "$@" > >(tee -a $LOGFILE_ACCESS) 2> >(tee -a $LOGFILE_ERROR >&2)
+exec sync_gateway "$config" > >(tee -a $LOGFILE_ACCESS) 2> >(tee -a $LOGFILE_ERROR >&2)

--- a/community/sync-gateway/1.1.0/Dockerfile
+++ b/community/sync-gateway/1.1.0/Dockerfile
@@ -19,15 +19,15 @@ RUN wget http://packages.couchbase.com/releases/couchbase-sync-gateway/1.1.0/cou
 # Create directory where the default config stores memory snapshots to disk
 RUN mkdir /opt/couchbase-sync-gateway/data
 
-# copy the default config into the container
-COPY config/sync_gateway_config.json /etc/sync_gateway/config.json
+# Create sync file for custom config.json or generated from env vars config.json
+RUN mkdir /sync
+
+# Copy config generator from environment variables
+COPY /scripts/create_config.py /
 
 # Add bootstrap script
 COPY scripts/entrypoint.sh /
 ENTRYPOINT ["/entrypoint.sh"]
-
-# If user doesn't specify any args, use the default config
-CMD ["/etc/sync_gateway/config.json"]
 
 # Expose ports
 #  port 4984: public port

--- a/community/sync-gateway/1.1.0/scripts/create_config.py
+++ b/community/sync-gateway/1.1.0/scripts/create_config.py
@@ -1,0 +1,116 @@
+from __future__ import print_function
+import os
+import json
+import logging
+
+logging.basicConfig(level=logging.INFO)
+
+
+def getenv_boolean(var_name, default_value=False):
+    result = default_value
+    env_value = os.getenv(var_name)
+    if env_value is not None:
+        result = env_value.upper() in ("TRUE", "1")
+    return result
+
+
+# Env vars for configs
+COUCHBASE_HOST = os.getenv(
+    "COUCHBASE_HOST", ""
+)  # e.g.: "couchbase". Leave empty to use default Walrus
+COUCHBASE_PORT = os.getenv("COUCHBASE_PORT", "8091")
+COUCHBASE_BUCKET_NAME = os.getenv("COUCHBASE_BUCKET_NAME", "app")
+COUCHBASE_SYNC_GATEWAY_LOG = os.getenv(
+    "COUCHBASE_SYNC_GATEWAY_LOG", "HTTP+"
+)  # e.g.: "*"
+COUCHBASE_SYNC_GATEWAY_ADMIN_INTERFACE = os.getenv(
+    "COUCHBASE_SYNC_GATEWAY_ADMIN_INTERFACE", ""
+)  # e.g.: ":4985", leave empty to disable
+COUCHBASE_SYNC_GATEWAY_USER = os.getenv("COUCHBASE_SYNC_GATEWAY_USER", "")
+COUCHBASE_SYNC_GATEWAY_PASSWORD = os.getenv("COUCHBASE_SYNC_GATEWAY_PASSWORD", "")
+COUCHBASE_SYNC_GATEWAY_DATABASE = os.getenv("COUCHBASE_SYNC_GATEWAY_DATABASE", "db")
+COUCHBASE_SYNC_GATEWAY_CORS_ORIGINS = os.getenv(
+    "COUCHBASE_SYNC_GATEWAY_CORS_ORIGINS", ""
+)
+COUCHBASE_SYNC_GATEWAY_NUM_INDEX_REPLICAS = int(
+    os.getenv("COUCHBASE_SYNC_GATEWAY_NUM_INDEX_REPLICAS", "0")
+)
+COUCHBASE_SYNC_GATEWAY_DISABLE_GUEST_USER = getenv_boolean(
+    "COUCHBASE_SYNC_GATEWAY_DISABLE_GUEST_USER", default_value=False
+)
+
+# Base config
+logging.info("Generating base config")
+config_dict = {
+    "interface": ":4984",
+    "logging": {"console": {"log_keys": [COUCHBASE_SYNC_GATEWAY_LOG]}},
+    "databases": {},
+}
+
+# Admin interface
+logging.info("Checking adminInterface config config")
+if COUCHBASE_SYNC_GATEWAY_ADMIN_INTERFACE:
+    logging.info("Generating adminInterface config config")
+    config_dict["adminInterface"] = COUCHBASE_SYNC_GATEWAY_ADMIN_INTERFACE
+
+# CORS
+logging.info("Checking CORS config")
+if COUCHBASE_SYNC_GATEWAY_CORS_ORIGINS:
+    cors_list = COUCHBASE_SYNC_GATEWAY_CORS_ORIGINS.split(",")
+    use_cors = [origin.strip() for origin in cors_list]
+
+    logging.info("Generating CORS config")
+    config_dict["CORS"] = {
+        "Origin": use_cors,
+        "LoginOrigin": use_cors,
+        "Headers": ["Content-Type"],
+        "MaxAge": 17280000,
+    }
+
+# Couchbase
+logging.info("Checking Couchbase config")
+if COUCHBASE_HOST and COUCHBASE_SYNC_GATEWAY_USER and COUCHBASE_SYNC_GATEWAY_PASSWORD:
+    logging.info("Generating Couchbase config")
+    use_server = "http://{COUCHBASE_HOST}:{COUCHBASE_PORT}".format(
+        COUCHBASE_HOST=COUCHBASE_HOST, COUCHBASE_PORT=COUCHBASE_PORT
+    )
+
+    config_dict["databases"][COUCHBASE_SYNC_GATEWAY_DATABASE] = {
+        "server": use_server,
+        "bucket": COUCHBASE_BUCKET_NAME,
+        "username": COUCHBASE_SYNC_GATEWAY_USER,
+        "password": COUCHBASE_SYNC_GATEWAY_PASSWORD,
+        "num_index_replicas": COUCHBASE_SYNC_GATEWAY_NUM_INDEX_REPLICAS,
+        "enable_shared_bucket_access": True,
+        "import_docs": "continuous",
+        "users": {"GUEST": {"disabled": COUCHBASE_SYNC_GATEWAY_DISABLE_GUEST_USER}},
+    }
+else:
+    config_dict["databases"][COUCHBASE_SYNC_GATEWAY_DATABASE] = {
+        "server": "walrus:/opt/couchbase-sync-gateway/data",
+        "users": {
+            "GUEST": {
+                "disabled": COUCHBASE_SYNC_GATEWAY_DISABLE_GUEST_USER,
+                "admin_channels": ["*"],
+            }
+        },
+    }
+
+# JS sync function
+logging.info("Checking JavaScript sync function file")
+js_function_path = "/sync/sync-function.js"
+sync_function = ""
+logging.info("Checking JS sync function from {}".format(js_function_path))
+if os.path.isfile(js_function_path):
+    logging.info("Reading JavaScript sync function file")
+    with open(js_function_path) as f:
+        sync_function = f.read()
+if sync_function:
+    logging.info("Generating JavaScript sync function config")
+    config_dict["databases"][COUCHBASE_SYNC_GATEWAY_DATABASE]["sync"] = sync_function
+
+# Generate JSON config
+logging.info("Writing final config JSON file")
+with open("/etc/sync_gateway/config.json", "w") as f:
+    json.dump(config_dict, f, indent=2)
+logging.info("Done")

--- a/community/sync-gateway/1.1.0/scripts/entrypoint.sh
+++ b/community/sync-gateway/1.1.0/scripts/entrypoint.sh
@@ -1,6 +1,52 @@
 #!/bin/bash
 set -e
 
+# Check connection in a separate function, that way, when 
+# there's no connection available yet and the return of the command
+# is non-zero, the script doesn't exit yet
+check_connection() {
+    curl -Is http://${COUCHBASE_SYNC_GATEWAY_USER}:${COUCHBASE_SYNC_GATEWAY_PASSWORD}@${COUCHBASE_HOST}:${COUCHBASE_PORT}/pools/default/buckets/${COUCHBASE_BUCKET_NAME} 2>&1 | grep "HTTP/1.1 200 OK" > /dev/null
+    if [ $? -eq 0 ]; then
+        echo "success";
+    else
+        echo "error";
+    fi;
+}
+
+# Try to connect to Couchbase only if COUCHBASE_HOST was declared as an env var
+if [ ! -z $COUCHBASE_HOST ]; then
+    # Try once per second, up to 300 times (5 min)
+    SECONDS_TO_TRY=300
+    for i in $(seq 1 $SECONDS_TO_TRY); do
+        echo "Checking connection, trial ${i}";
+        result=$(check_connection);
+        if [ $result == "success" ]; then
+            echo "Success: connection checked";
+            sleep 1;
+            break;
+        else
+            echo "Connection not available yet, sleeping 1 sec...";
+            sleep 1;
+            echo "----------";
+        fi;
+    done;
+fi;
+
+config="/etc/sync_gateway/config.json"
+
+if [ ! -z $@ ]; then
+    echo "Using config provided as command parameter: $@"
+    config=$@
+else
+    if [ -f /sync/config.json ]; then
+        echo "Using provided config in: /sync/config.json";
+        config="/sync/config.json"
+    else
+        echo "No config provided in /sync/config.json, generating one from environment variables";
+        python create_config.py
+    fi;
+fi;
+
 LOGFILE_DIR=/var/log/sync_gateway
 mkdir -p $LOGFILE_DIR
 
@@ -9,4 +55,4 @@ LOGFILE_ERROR=$LOGFILE_DIR/sync_gateway_error.log
 
 # Run SG and use tee to append stdout and stderr to separate logfiles
 # Process substitution described here: https://stackoverflow.com/a/692407
-exec sync_gateway "$@" > >(tee -a $LOGFILE_ACCESS) 2> >(tee -a $LOGFILE_ERROR >&2)
+exec sync_gateway "$config" > >(tee -a $LOGFILE_ACCESS) 2> >(tee -a $LOGFILE_ERROR >&2)

--- a/community/sync-gateway/1.1.1/Dockerfile
+++ b/community/sync-gateway/1.1.1/Dockerfile
@@ -19,15 +19,15 @@ RUN wget http://packages.couchbase.com/releases/couchbase-sync-gateway/1.1.1/cou
 # Create directory where the default config stores memory snapshots to disk
 RUN mkdir /opt/couchbase-sync-gateway/data
 
-# copy the default config into the container
-COPY config/sync_gateway_config.json /etc/sync_gateway/config.json
+# Create sync file for custom config.json or generated from env vars config.json
+RUN mkdir /sync
+
+# Copy config generator from environment variables
+COPY /scripts/create_config.py /
 
 # Add bootstrap script
 COPY scripts/entrypoint.sh /
 ENTRYPOINT ["/entrypoint.sh"]
-
-# If user doesn't specify any args, use the default config
-CMD ["/etc/sync_gateway/config.json"]
 
 # Expose ports
 #  port 4984: public port

--- a/community/sync-gateway/1.1.1/scripts/create_config.py
+++ b/community/sync-gateway/1.1.1/scripts/create_config.py
@@ -1,0 +1,116 @@
+from __future__ import print_function
+import os
+import json
+import logging
+
+logging.basicConfig(level=logging.INFO)
+
+
+def getenv_boolean(var_name, default_value=False):
+    result = default_value
+    env_value = os.getenv(var_name)
+    if env_value is not None:
+        result = env_value.upper() in ("TRUE", "1")
+    return result
+
+
+# Env vars for configs
+COUCHBASE_HOST = os.getenv(
+    "COUCHBASE_HOST", ""
+)  # e.g.: "couchbase". Leave empty to use default Walrus
+COUCHBASE_PORT = os.getenv("COUCHBASE_PORT", "8091")
+COUCHBASE_BUCKET_NAME = os.getenv("COUCHBASE_BUCKET_NAME", "app")
+COUCHBASE_SYNC_GATEWAY_LOG = os.getenv(
+    "COUCHBASE_SYNC_GATEWAY_LOG", "HTTP+"
+)  # e.g.: "*"
+COUCHBASE_SYNC_GATEWAY_ADMIN_INTERFACE = os.getenv(
+    "COUCHBASE_SYNC_GATEWAY_ADMIN_INTERFACE", ""
+)  # e.g.: ":4985", leave empty to disable
+COUCHBASE_SYNC_GATEWAY_USER = os.getenv("COUCHBASE_SYNC_GATEWAY_USER", "")
+COUCHBASE_SYNC_GATEWAY_PASSWORD = os.getenv("COUCHBASE_SYNC_GATEWAY_PASSWORD", "")
+COUCHBASE_SYNC_GATEWAY_DATABASE = os.getenv("COUCHBASE_SYNC_GATEWAY_DATABASE", "db")
+COUCHBASE_SYNC_GATEWAY_CORS_ORIGINS = os.getenv(
+    "COUCHBASE_SYNC_GATEWAY_CORS_ORIGINS", ""
+)
+COUCHBASE_SYNC_GATEWAY_NUM_INDEX_REPLICAS = int(
+    os.getenv("COUCHBASE_SYNC_GATEWAY_NUM_INDEX_REPLICAS", "0")
+)
+COUCHBASE_SYNC_GATEWAY_DISABLE_GUEST_USER = getenv_boolean(
+    "COUCHBASE_SYNC_GATEWAY_DISABLE_GUEST_USER", default_value=False
+)
+
+# Base config
+logging.info("Generating base config")
+config_dict = {
+    "interface": ":4984",
+    "logging": {"console": {"log_keys": [COUCHBASE_SYNC_GATEWAY_LOG]}},
+    "databases": {},
+}
+
+# Admin interface
+logging.info("Checking adminInterface config config")
+if COUCHBASE_SYNC_GATEWAY_ADMIN_INTERFACE:
+    logging.info("Generating adminInterface config config")
+    config_dict["adminInterface"] = COUCHBASE_SYNC_GATEWAY_ADMIN_INTERFACE
+
+# CORS
+logging.info("Checking CORS config")
+if COUCHBASE_SYNC_GATEWAY_CORS_ORIGINS:
+    cors_list = COUCHBASE_SYNC_GATEWAY_CORS_ORIGINS.split(",")
+    use_cors = [origin.strip() for origin in cors_list]
+
+    logging.info("Generating CORS config")
+    config_dict["CORS"] = {
+        "Origin": use_cors,
+        "LoginOrigin": use_cors,
+        "Headers": ["Content-Type"],
+        "MaxAge": 17280000,
+    }
+
+# Couchbase
+logging.info("Checking Couchbase config")
+if COUCHBASE_HOST and COUCHBASE_SYNC_GATEWAY_USER and COUCHBASE_SYNC_GATEWAY_PASSWORD:
+    logging.info("Generating Couchbase config")
+    use_server = "http://{COUCHBASE_HOST}:{COUCHBASE_PORT}".format(
+        COUCHBASE_HOST=COUCHBASE_HOST, COUCHBASE_PORT=COUCHBASE_PORT
+    )
+
+    config_dict["databases"][COUCHBASE_SYNC_GATEWAY_DATABASE] = {
+        "server": use_server,
+        "bucket": COUCHBASE_BUCKET_NAME,
+        "username": COUCHBASE_SYNC_GATEWAY_USER,
+        "password": COUCHBASE_SYNC_GATEWAY_PASSWORD,
+        "num_index_replicas": COUCHBASE_SYNC_GATEWAY_NUM_INDEX_REPLICAS,
+        "enable_shared_bucket_access": True,
+        "import_docs": "continuous",
+        "users": {"GUEST": {"disabled": COUCHBASE_SYNC_GATEWAY_DISABLE_GUEST_USER}},
+    }
+else:
+    config_dict["databases"][COUCHBASE_SYNC_GATEWAY_DATABASE] = {
+        "server": "walrus:/opt/couchbase-sync-gateway/data",
+        "users": {
+            "GUEST": {
+                "disabled": COUCHBASE_SYNC_GATEWAY_DISABLE_GUEST_USER,
+                "admin_channels": ["*"],
+            }
+        },
+    }
+
+# JS sync function
+logging.info("Checking JavaScript sync function file")
+js_function_path = "/sync/sync-function.js"
+sync_function = ""
+logging.info("Checking JS sync function from {}".format(js_function_path))
+if os.path.isfile(js_function_path):
+    logging.info("Reading JavaScript sync function file")
+    with open(js_function_path) as f:
+        sync_function = f.read()
+if sync_function:
+    logging.info("Generating JavaScript sync function config")
+    config_dict["databases"][COUCHBASE_SYNC_GATEWAY_DATABASE]["sync"] = sync_function
+
+# Generate JSON config
+logging.info("Writing final config JSON file")
+with open("/etc/sync_gateway/config.json", "w") as f:
+    json.dump(config_dict, f, indent=2)
+logging.info("Done")

--- a/community/sync-gateway/1.1.1/scripts/entrypoint.sh
+++ b/community/sync-gateway/1.1.1/scripts/entrypoint.sh
@@ -1,6 +1,52 @@
 #!/bin/bash
 set -e
 
+# Check connection in a separate function, that way, when 
+# there's no connection available yet and the return of the command
+# is non-zero, the script doesn't exit yet
+check_connection() {
+    curl -Is http://${COUCHBASE_SYNC_GATEWAY_USER}:${COUCHBASE_SYNC_GATEWAY_PASSWORD}@${COUCHBASE_HOST}:${COUCHBASE_PORT}/pools/default/buckets/${COUCHBASE_BUCKET_NAME} 2>&1 | grep "HTTP/1.1 200 OK" > /dev/null
+    if [ $? -eq 0 ]; then
+        echo "success";
+    else
+        echo "error";
+    fi;
+}
+
+# Try to connect to Couchbase only if COUCHBASE_HOST was declared as an env var
+if [ ! -z $COUCHBASE_HOST ]; then
+    # Try once per second, up to 300 times (5 min)
+    SECONDS_TO_TRY=300
+    for i in $(seq 1 $SECONDS_TO_TRY); do
+        echo "Checking connection, trial ${i}";
+        result=$(check_connection);
+        if [ $result == "success" ]; then
+            echo "Success: connection checked";
+            sleep 1;
+            break;
+        else
+            echo "Connection not available yet, sleeping 1 sec...";
+            sleep 1;
+            echo "----------";
+        fi;
+    done;
+fi;
+
+config="/etc/sync_gateway/config.json"
+
+if [ ! -z $@ ]; then
+    echo "Using config provided as command parameter: $@"
+    config=$@
+else
+    if [ -f /sync/config.json ]; then
+        echo "Using provided config in: /sync/config.json";
+        config="/sync/config.json"
+    else
+        echo "No config provided in /sync/config.json, generating one from environment variables";
+        python create_config.py
+    fi;
+fi;
+
 LOGFILE_DIR=/var/log/sync_gateway
 mkdir -p $LOGFILE_DIR
 
@@ -9,4 +55,4 @@ LOGFILE_ERROR=$LOGFILE_DIR/sync_gateway_error.log
 
 # Run SG and use tee to append stdout and stderr to separate logfiles
 # Process substitution described here: https://stackoverflow.com/a/692407
-exec sync_gateway "$@" > >(tee -a $LOGFILE_ACCESS) 2> >(tee -a $LOGFILE_ERROR >&2)
+exec sync_gateway "$config" > >(tee -a $LOGFILE_ACCESS) 2> >(tee -a $LOGFILE_ERROR >&2)

--- a/community/sync-gateway/1.2.0-rc0/Dockerfile
+++ b/community/sync-gateway/1.2.0-rc0/Dockerfile
@@ -19,15 +19,15 @@ RUN wget http://packages.couchbase.com/releases/couchbase-sync-gateway/1.2.0/cou
 # Create directory where the default config stores memory snapshots to disk
 RUN mkdir /opt/couchbase-sync-gateway/data
 
-# copy the default config into the container
-COPY config/sync_gateway_config.json /etc/sync_gateway/config.json
+# Create sync file for custom config.json or generated from env vars config.json
+RUN mkdir /sync
+
+# Copy config generator from environment variables
+COPY /scripts/create_config.py /
 
 # Add bootstrap script
 COPY scripts/entrypoint.sh /
 ENTRYPOINT ["/entrypoint.sh"]
-
-# If user doesn't specify any args, use the default config
-CMD ["/etc/sync_gateway/config.json"]
 
 # Expose ports
 #  port 4984: public port

--- a/community/sync-gateway/1.2.0-rc0/scripts/create_config.py
+++ b/community/sync-gateway/1.2.0-rc0/scripts/create_config.py
@@ -1,0 +1,116 @@
+from __future__ import print_function
+import os
+import json
+import logging
+
+logging.basicConfig(level=logging.INFO)
+
+
+def getenv_boolean(var_name, default_value=False):
+    result = default_value
+    env_value = os.getenv(var_name)
+    if env_value is not None:
+        result = env_value.upper() in ("TRUE", "1")
+    return result
+
+
+# Env vars for configs
+COUCHBASE_HOST = os.getenv(
+    "COUCHBASE_HOST", ""
+)  # e.g.: "couchbase". Leave empty to use default Walrus
+COUCHBASE_PORT = os.getenv("COUCHBASE_PORT", "8091")
+COUCHBASE_BUCKET_NAME = os.getenv("COUCHBASE_BUCKET_NAME", "app")
+COUCHBASE_SYNC_GATEWAY_LOG = os.getenv(
+    "COUCHBASE_SYNC_GATEWAY_LOG", "HTTP+"
+)  # e.g.: "*"
+COUCHBASE_SYNC_GATEWAY_ADMIN_INTERFACE = os.getenv(
+    "COUCHBASE_SYNC_GATEWAY_ADMIN_INTERFACE", ""
+)  # e.g.: ":4985", leave empty to disable
+COUCHBASE_SYNC_GATEWAY_USER = os.getenv("COUCHBASE_SYNC_GATEWAY_USER", "")
+COUCHBASE_SYNC_GATEWAY_PASSWORD = os.getenv("COUCHBASE_SYNC_GATEWAY_PASSWORD", "")
+COUCHBASE_SYNC_GATEWAY_DATABASE = os.getenv("COUCHBASE_SYNC_GATEWAY_DATABASE", "db")
+COUCHBASE_SYNC_GATEWAY_CORS_ORIGINS = os.getenv(
+    "COUCHBASE_SYNC_GATEWAY_CORS_ORIGINS", ""
+)
+COUCHBASE_SYNC_GATEWAY_NUM_INDEX_REPLICAS = int(
+    os.getenv("COUCHBASE_SYNC_GATEWAY_NUM_INDEX_REPLICAS", "0")
+)
+COUCHBASE_SYNC_GATEWAY_DISABLE_GUEST_USER = getenv_boolean(
+    "COUCHBASE_SYNC_GATEWAY_DISABLE_GUEST_USER", default_value=False
+)
+
+# Base config
+logging.info("Generating base config")
+config_dict = {
+    "interface": ":4984",
+    "logging": {"console": {"log_keys": [COUCHBASE_SYNC_GATEWAY_LOG]}},
+    "databases": {},
+}
+
+# Admin interface
+logging.info("Checking adminInterface config config")
+if COUCHBASE_SYNC_GATEWAY_ADMIN_INTERFACE:
+    logging.info("Generating adminInterface config config")
+    config_dict["adminInterface"] = COUCHBASE_SYNC_GATEWAY_ADMIN_INTERFACE
+
+# CORS
+logging.info("Checking CORS config")
+if COUCHBASE_SYNC_GATEWAY_CORS_ORIGINS:
+    cors_list = COUCHBASE_SYNC_GATEWAY_CORS_ORIGINS.split(",")
+    use_cors = [origin.strip() for origin in cors_list]
+
+    logging.info("Generating CORS config")
+    config_dict["CORS"] = {
+        "Origin": use_cors,
+        "LoginOrigin": use_cors,
+        "Headers": ["Content-Type"],
+        "MaxAge": 17280000,
+    }
+
+# Couchbase
+logging.info("Checking Couchbase config")
+if COUCHBASE_HOST and COUCHBASE_SYNC_GATEWAY_USER and COUCHBASE_SYNC_GATEWAY_PASSWORD:
+    logging.info("Generating Couchbase config")
+    use_server = "http://{COUCHBASE_HOST}:{COUCHBASE_PORT}".format(
+        COUCHBASE_HOST=COUCHBASE_HOST, COUCHBASE_PORT=COUCHBASE_PORT
+    )
+
+    config_dict["databases"][COUCHBASE_SYNC_GATEWAY_DATABASE] = {
+        "server": use_server,
+        "bucket": COUCHBASE_BUCKET_NAME,
+        "username": COUCHBASE_SYNC_GATEWAY_USER,
+        "password": COUCHBASE_SYNC_GATEWAY_PASSWORD,
+        "num_index_replicas": COUCHBASE_SYNC_GATEWAY_NUM_INDEX_REPLICAS,
+        "enable_shared_bucket_access": True,
+        "import_docs": "continuous",
+        "users": {"GUEST": {"disabled": COUCHBASE_SYNC_GATEWAY_DISABLE_GUEST_USER}},
+    }
+else:
+    config_dict["databases"][COUCHBASE_SYNC_GATEWAY_DATABASE] = {
+        "server": "walrus:/opt/couchbase-sync-gateway/data",
+        "users": {
+            "GUEST": {
+                "disabled": COUCHBASE_SYNC_GATEWAY_DISABLE_GUEST_USER,
+                "admin_channels": ["*"],
+            }
+        },
+    }
+
+# JS sync function
+logging.info("Checking JavaScript sync function file")
+js_function_path = "/sync/sync-function.js"
+sync_function = ""
+logging.info("Checking JS sync function from {}".format(js_function_path))
+if os.path.isfile(js_function_path):
+    logging.info("Reading JavaScript sync function file")
+    with open(js_function_path) as f:
+        sync_function = f.read()
+if sync_function:
+    logging.info("Generating JavaScript sync function config")
+    config_dict["databases"][COUCHBASE_SYNC_GATEWAY_DATABASE]["sync"] = sync_function
+
+# Generate JSON config
+logging.info("Writing final config JSON file")
+with open("/etc/sync_gateway/config.json", "w") as f:
+    json.dump(config_dict, f, indent=2)
+logging.info("Done")

--- a/community/sync-gateway/1.2.0-rc0/scripts/entrypoint.sh
+++ b/community/sync-gateway/1.2.0-rc0/scripts/entrypoint.sh
@@ -1,6 +1,52 @@
 #!/bin/bash
 set -e
 
+# Check connection in a separate function, that way, when 
+# there's no connection available yet and the return of the command
+# is non-zero, the script doesn't exit yet
+check_connection() {
+    curl -Is http://${COUCHBASE_SYNC_GATEWAY_USER}:${COUCHBASE_SYNC_GATEWAY_PASSWORD}@${COUCHBASE_HOST}:${COUCHBASE_PORT}/pools/default/buckets/${COUCHBASE_BUCKET_NAME} 2>&1 | grep "HTTP/1.1 200 OK" > /dev/null
+    if [ $? -eq 0 ]; then
+        echo "success";
+    else
+        echo "error";
+    fi;
+}
+
+# Try to connect to Couchbase only if COUCHBASE_HOST was declared as an env var
+if [ ! -z $COUCHBASE_HOST ]; then
+    # Try once per second, up to 300 times (5 min)
+    SECONDS_TO_TRY=300
+    for i in $(seq 1 $SECONDS_TO_TRY); do
+        echo "Checking connection, trial ${i}";
+        result=$(check_connection);
+        if [ $result == "success" ]; then
+            echo "Success: connection checked";
+            sleep 1;
+            break;
+        else
+            echo "Connection not available yet, sleeping 1 sec...";
+            sleep 1;
+            echo "----------";
+        fi;
+    done;
+fi;
+
+config="/etc/sync_gateway/config.json"
+
+if [ ! -z $@ ]; then
+    echo "Using config provided as command parameter: $@"
+    config=$@
+else
+    if [ -f /sync/config.json ]; then
+        echo "Using provided config in: /sync/config.json";
+        config="/sync/config.json"
+    else
+        echo "No config provided in /sync/config.json, generating one from environment variables";
+        python create_config.py
+    fi;
+fi;
+
 LOGFILE_DIR=/var/log/sync_gateway
 mkdir -p $LOGFILE_DIR
 
@@ -9,4 +55,4 @@ LOGFILE_ERROR=$LOGFILE_DIR/sync_gateway_error.log
 
 # Run SG and use tee to append stdout and stderr to separate logfiles
 # Process substitution described here: https://stackoverflow.com/a/692407
-exec sync_gateway "$@" > >(tee -a $LOGFILE_ACCESS) 2> >(tee -a $LOGFILE_ERROR >&2)
+exec sync_gateway "$config" > >(tee -a $LOGFILE_ACCESS) 2> >(tee -a $LOGFILE_ERROR >&2)

--- a/community/sync-gateway/1.2.0-rc1/Dockerfile
+++ b/community/sync-gateway/1.2.0-rc1/Dockerfile
@@ -19,15 +19,15 @@ RUN wget http://packages.couchbase.com/releases/couchbase-sync-gateway/1.2.0/cou
 # Create directory where the default config stores memory snapshots to disk
 RUN mkdir /opt/couchbase-sync-gateway/data
 
-# copy the default config into the container
-COPY config/sync_gateway_config.json /etc/sync_gateway/config.json
+# Create sync file for custom config.json or generated from env vars config.json
+RUN mkdir /sync
+
+# Copy config generator from environment variables
+COPY /scripts/create_config.py /
 
 # Add bootstrap script
 COPY scripts/entrypoint.sh /
 ENTRYPOINT ["/entrypoint.sh"]
-
-# If user doesn't specify any args, use the default config
-CMD ["/etc/sync_gateway/config.json"]
 
 # Expose ports
 #  port 4984: public port

--- a/community/sync-gateway/1.2.0-rc1/scripts/create_config.py
+++ b/community/sync-gateway/1.2.0-rc1/scripts/create_config.py
@@ -1,0 +1,116 @@
+from __future__ import print_function
+import os
+import json
+import logging
+
+logging.basicConfig(level=logging.INFO)
+
+
+def getenv_boolean(var_name, default_value=False):
+    result = default_value
+    env_value = os.getenv(var_name)
+    if env_value is not None:
+        result = env_value.upper() in ("TRUE", "1")
+    return result
+
+
+# Env vars for configs
+COUCHBASE_HOST = os.getenv(
+    "COUCHBASE_HOST", ""
+)  # e.g.: "couchbase". Leave empty to use default Walrus
+COUCHBASE_PORT = os.getenv("COUCHBASE_PORT", "8091")
+COUCHBASE_BUCKET_NAME = os.getenv("COUCHBASE_BUCKET_NAME", "app")
+COUCHBASE_SYNC_GATEWAY_LOG = os.getenv(
+    "COUCHBASE_SYNC_GATEWAY_LOG", "HTTP+"
+)  # e.g.: "*"
+COUCHBASE_SYNC_GATEWAY_ADMIN_INTERFACE = os.getenv(
+    "COUCHBASE_SYNC_GATEWAY_ADMIN_INTERFACE", ""
+)  # e.g.: ":4985", leave empty to disable
+COUCHBASE_SYNC_GATEWAY_USER = os.getenv("COUCHBASE_SYNC_GATEWAY_USER", "")
+COUCHBASE_SYNC_GATEWAY_PASSWORD = os.getenv("COUCHBASE_SYNC_GATEWAY_PASSWORD", "")
+COUCHBASE_SYNC_GATEWAY_DATABASE = os.getenv("COUCHBASE_SYNC_GATEWAY_DATABASE", "db")
+COUCHBASE_SYNC_GATEWAY_CORS_ORIGINS = os.getenv(
+    "COUCHBASE_SYNC_GATEWAY_CORS_ORIGINS", ""
+)
+COUCHBASE_SYNC_GATEWAY_NUM_INDEX_REPLICAS = int(
+    os.getenv("COUCHBASE_SYNC_GATEWAY_NUM_INDEX_REPLICAS", "0")
+)
+COUCHBASE_SYNC_GATEWAY_DISABLE_GUEST_USER = getenv_boolean(
+    "COUCHBASE_SYNC_GATEWAY_DISABLE_GUEST_USER", default_value=False
+)
+
+# Base config
+logging.info("Generating base config")
+config_dict = {
+    "interface": ":4984",
+    "logging": {"console": {"log_keys": [COUCHBASE_SYNC_GATEWAY_LOG]}},
+    "databases": {},
+}
+
+# Admin interface
+logging.info("Checking adminInterface config config")
+if COUCHBASE_SYNC_GATEWAY_ADMIN_INTERFACE:
+    logging.info("Generating adminInterface config config")
+    config_dict["adminInterface"] = COUCHBASE_SYNC_GATEWAY_ADMIN_INTERFACE
+
+# CORS
+logging.info("Checking CORS config")
+if COUCHBASE_SYNC_GATEWAY_CORS_ORIGINS:
+    cors_list = COUCHBASE_SYNC_GATEWAY_CORS_ORIGINS.split(",")
+    use_cors = [origin.strip() for origin in cors_list]
+
+    logging.info("Generating CORS config")
+    config_dict["CORS"] = {
+        "Origin": use_cors,
+        "LoginOrigin": use_cors,
+        "Headers": ["Content-Type"],
+        "MaxAge": 17280000,
+    }
+
+# Couchbase
+logging.info("Checking Couchbase config")
+if COUCHBASE_HOST and COUCHBASE_SYNC_GATEWAY_USER and COUCHBASE_SYNC_GATEWAY_PASSWORD:
+    logging.info("Generating Couchbase config")
+    use_server = "http://{COUCHBASE_HOST}:{COUCHBASE_PORT}".format(
+        COUCHBASE_HOST=COUCHBASE_HOST, COUCHBASE_PORT=COUCHBASE_PORT
+    )
+
+    config_dict["databases"][COUCHBASE_SYNC_GATEWAY_DATABASE] = {
+        "server": use_server,
+        "bucket": COUCHBASE_BUCKET_NAME,
+        "username": COUCHBASE_SYNC_GATEWAY_USER,
+        "password": COUCHBASE_SYNC_GATEWAY_PASSWORD,
+        "num_index_replicas": COUCHBASE_SYNC_GATEWAY_NUM_INDEX_REPLICAS,
+        "enable_shared_bucket_access": True,
+        "import_docs": "continuous",
+        "users": {"GUEST": {"disabled": COUCHBASE_SYNC_GATEWAY_DISABLE_GUEST_USER}},
+    }
+else:
+    config_dict["databases"][COUCHBASE_SYNC_GATEWAY_DATABASE] = {
+        "server": "walrus:/opt/couchbase-sync-gateway/data",
+        "users": {
+            "GUEST": {
+                "disabled": COUCHBASE_SYNC_GATEWAY_DISABLE_GUEST_USER,
+                "admin_channels": ["*"],
+            }
+        },
+    }
+
+# JS sync function
+logging.info("Checking JavaScript sync function file")
+js_function_path = "/sync/sync-function.js"
+sync_function = ""
+logging.info("Checking JS sync function from {}".format(js_function_path))
+if os.path.isfile(js_function_path):
+    logging.info("Reading JavaScript sync function file")
+    with open(js_function_path) as f:
+        sync_function = f.read()
+if sync_function:
+    logging.info("Generating JavaScript sync function config")
+    config_dict["databases"][COUCHBASE_SYNC_GATEWAY_DATABASE]["sync"] = sync_function
+
+# Generate JSON config
+logging.info("Writing final config JSON file")
+with open("/etc/sync_gateway/config.json", "w") as f:
+    json.dump(config_dict, f, indent=2)
+logging.info("Done")

--- a/community/sync-gateway/1.2.0-rc1/scripts/entrypoint.sh
+++ b/community/sync-gateway/1.2.0-rc1/scripts/entrypoint.sh
@@ -1,6 +1,52 @@
 #!/bin/bash
 set -e
 
+# Check connection in a separate function, that way, when 
+# there's no connection available yet and the return of the command
+# is non-zero, the script doesn't exit yet
+check_connection() {
+    curl -Is http://${COUCHBASE_SYNC_GATEWAY_USER}:${COUCHBASE_SYNC_GATEWAY_PASSWORD}@${COUCHBASE_HOST}:${COUCHBASE_PORT}/pools/default/buckets/${COUCHBASE_BUCKET_NAME} 2>&1 | grep "HTTP/1.1 200 OK" > /dev/null
+    if [ $? -eq 0 ]; then
+        echo "success";
+    else
+        echo "error";
+    fi;
+}
+
+# Try to connect to Couchbase only if COUCHBASE_HOST was declared as an env var
+if [ ! -z $COUCHBASE_HOST ]; then
+    # Try once per second, up to 300 times (5 min)
+    SECONDS_TO_TRY=300
+    for i in $(seq 1 $SECONDS_TO_TRY); do
+        echo "Checking connection, trial ${i}";
+        result=$(check_connection);
+        if [ $result == "success" ]; then
+            echo "Success: connection checked";
+            sleep 1;
+            break;
+        else
+            echo "Connection not available yet, sleeping 1 sec...";
+            sleep 1;
+            echo "----------";
+        fi;
+    done;
+fi;
+
+config="/etc/sync_gateway/config.json"
+
+if [ ! -z $@ ]; then
+    echo "Using config provided as command parameter: $@"
+    config=$@
+else
+    if [ -f /sync/config.json ]; then
+        echo "Using provided config in: /sync/config.json";
+        config="/sync/config.json"
+    else
+        echo "No config provided in /sync/config.json, generating one from environment variables";
+        python create_config.py
+    fi;
+fi;
+
 LOGFILE_DIR=/var/log/sync_gateway
 mkdir -p $LOGFILE_DIR
 
@@ -9,4 +55,4 @@ LOGFILE_ERROR=$LOGFILE_DIR/sync_gateway_error.log
 
 # Run SG and use tee to append stdout and stderr to separate logfiles
 # Process substitution described here: https://stackoverflow.com/a/692407
-exec sync_gateway "$@" > >(tee -a $LOGFILE_ACCESS) 2> >(tee -a $LOGFILE_ERROR >&2)
+exec sync_gateway "$config" > >(tee -a $LOGFILE_ACCESS) 2> >(tee -a $LOGFILE_ERROR >&2)

--- a/community/sync-gateway/1.2.0/Dockerfile
+++ b/community/sync-gateway/1.2.0/Dockerfile
@@ -19,15 +19,15 @@ RUN wget http://packages.couchbase.com/releases/couchbase-sync-gateway/1.2.0/cou
 # Create directory where the default config stores memory snapshots to disk
 RUN mkdir /opt/couchbase-sync-gateway/data
 
-# copy the default config into the container
-COPY config/sync_gateway_config.json /etc/sync_gateway/config.json
+# Create sync file for custom config.json or generated from env vars config.json
+RUN mkdir /sync
+
+# Copy config generator from environment variables
+COPY /scripts/create_config.py /
 
 # Add bootstrap script
 COPY scripts/entrypoint.sh /
 ENTRYPOINT ["/entrypoint.sh"]
-
-# If user doesn't specify any args, use the default config
-CMD ["/etc/sync_gateway/config.json"]
 
 # Expose ports
 #  port 4984: public port

--- a/community/sync-gateway/1.2.0/scripts/create_config.py
+++ b/community/sync-gateway/1.2.0/scripts/create_config.py
@@ -1,0 +1,116 @@
+from __future__ import print_function
+import os
+import json
+import logging
+
+logging.basicConfig(level=logging.INFO)
+
+
+def getenv_boolean(var_name, default_value=False):
+    result = default_value
+    env_value = os.getenv(var_name)
+    if env_value is not None:
+        result = env_value.upper() in ("TRUE", "1")
+    return result
+
+
+# Env vars for configs
+COUCHBASE_HOST = os.getenv(
+    "COUCHBASE_HOST", ""
+)  # e.g.: "couchbase". Leave empty to use default Walrus
+COUCHBASE_PORT = os.getenv("COUCHBASE_PORT", "8091")
+COUCHBASE_BUCKET_NAME = os.getenv("COUCHBASE_BUCKET_NAME", "app")
+COUCHBASE_SYNC_GATEWAY_LOG = os.getenv(
+    "COUCHBASE_SYNC_GATEWAY_LOG", "HTTP+"
+)  # e.g.: "*"
+COUCHBASE_SYNC_GATEWAY_ADMIN_INTERFACE = os.getenv(
+    "COUCHBASE_SYNC_GATEWAY_ADMIN_INTERFACE", ""
+)  # e.g.: ":4985", leave empty to disable
+COUCHBASE_SYNC_GATEWAY_USER = os.getenv("COUCHBASE_SYNC_GATEWAY_USER", "")
+COUCHBASE_SYNC_GATEWAY_PASSWORD = os.getenv("COUCHBASE_SYNC_GATEWAY_PASSWORD", "")
+COUCHBASE_SYNC_GATEWAY_DATABASE = os.getenv("COUCHBASE_SYNC_GATEWAY_DATABASE", "db")
+COUCHBASE_SYNC_GATEWAY_CORS_ORIGINS = os.getenv(
+    "COUCHBASE_SYNC_GATEWAY_CORS_ORIGINS", ""
+)
+COUCHBASE_SYNC_GATEWAY_NUM_INDEX_REPLICAS = int(
+    os.getenv("COUCHBASE_SYNC_GATEWAY_NUM_INDEX_REPLICAS", "0")
+)
+COUCHBASE_SYNC_GATEWAY_DISABLE_GUEST_USER = getenv_boolean(
+    "COUCHBASE_SYNC_GATEWAY_DISABLE_GUEST_USER", default_value=False
+)
+
+# Base config
+logging.info("Generating base config")
+config_dict = {
+    "interface": ":4984",
+    "logging": {"console": {"log_keys": [COUCHBASE_SYNC_GATEWAY_LOG]}},
+    "databases": {},
+}
+
+# Admin interface
+logging.info("Checking adminInterface config config")
+if COUCHBASE_SYNC_GATEWAY_ADMIN_INTERFACE:
+    logging.info("Generating adminInterface config config")
+    config_dict["adminInterface"] = COUCHBASE_SYNC_GATEWAY_ADMIN_INTERFACE
+
+# CORS
+logging.info("Checking CORS config")
+if COUCHBASE_SYNC_GATEWAY_CORS_ORIGINS:
+    cors_list = COUCHBASE_SYNC_GATEWAY_CORS_ORIGINS.split(",")
+    use_cors = [origin.strip() for origin in cors_list]
+
+    logging.info("Generating CORS config")
+    config_dict["CORS"] = {
+        "Origin": use_cors,
+        "LoginOrigin": use_cors,
+        "Headers": ["Content-Type"],
+        "MaxAge": 17280000,
+    }
+
+# Couchbase
+logging.info("Checking Couchbase config")
+if COUCHBASE_HOST and COUCHBASE_SYNC_GATEWAY_USER and COUCHBASE_SYNC_GATEWAY_PASSWORD:
+    logging.info("Generating Couchbase config")
+    use_server = "http://{COUCHBASE_HOST}:{COUCHBASE_PORT}".format(
+        COUCHBASE_HOST=COUCHBASE_HOST, COUCHBASE_PORT=COUCHBASE_PORT
+    )
+
+    config_dict["databases"][COUCHBASE_SYNC_GATEWAY_DATABASE] = {
+        "server": use_server,
+        "bucket": COUCHBASE_BUCKET_NAME,
+        "username": COUCHBASE_SYNC_GATEWAY_USER,
+        "password": COUCHBASE_SYNC_GATEWAY_PASSWORD,
+        "num_index_replicas": COUCHBASE_SYNC_GATEWAY_NUM_INDEX_REPLICAS,
+        "enable_shared_bucket_access": True,
+        "import_docs": "continuous",
+        "users": {"GUEST": {"disabled": COUCHBASE_SYNC_GATEWAY_DISABLE_GUEST_USER}},
+    }
+else:
+    config_dict["databases"][COUCHBASE_SYNC_GATEWAY_DATABASE] = {
+        "server": "walrus:/opt/couchbase-sync-gateway/data",
+        "users": {
+            "GUEST": {
+                "disabled": COUCHBASE_SYNC_GATEWAY_DISABLE_GUEST_USER,
+                "admin_channels": ["*"],
+            }
+        },
+    }
+
+# JS sync function
+logging.info("Checking JavaScript sync function file")
+js_function_path = "/sync/sync-function.js"
+sync_function = ""
+logging.info("Checking JS sync function from {}".format(js_function_path))
+if os.path.isfile(js_function_path):
+    logging.info("Reading JavaScript sync function file")
+    with open(js_function_path) as f:
+        sync_function = f.read()
+if sync_function:
+    logging.info("Generating JavaScript sync function config")
+    config_dict["databases"][COUCHBASE_SYNC_GATEWAY_DATABASE]["sync"] = sync_function
+
+# Generate JSON config
+logging.info("Writing final config JSON file")
+with open("/etc/sync_gateway/config.json", "w") as f:
+    json.dump(config_dict, f, indent=2)
+logging.info("Done")

--- a/community/sync-gateway/1.2.0/scripts/entrypoint.sh
+++ b/community/sync-gateway/1.2.0/scripts/entrypoint.sh
@@ -1,6 +1,52 @@
 #!/bin/bash
 set -e
 
+# Check connection in a separate function, that way, when 
+# there's no connection available yet and the return of the command
+# is non-zero, the script doesn't exit yet
+check_connection() {
+    curl -Is http://${COUCHBASE_SYNC_GATEWAY_USER}:${COUCHBASE_SYNC_GATEWAY_PASSWORD}@${COUCHBASE_HOST}:${COUCHBASE_PORT}/pools/default/buckets/${COUCHBASE_BUCKET_NAME} 2>&1 | grep "HTTP/1.1 200 OK" > /dev/null
+    if [ $? -eq 0 ]; then
+        echo "success";
+    else
+        echo "error";
+    fi;
+}
+
+# Try to connect to Couchbase only if COUCHBASE_HOST was declared as an env var
+if [ ! -z $COUCHBASE_HOST ]; then
+    # Try once per second, up to 300 times (5 min)
+    SECONDS_TO_TRY=300
+    for i in $(seq 1 $SECONDS_TO_TRY); do
+        echo "Checking connection, trial ${i}";
+        result=$(check_connection);
+        if [ $result == "success" ]; then
+            echo "Success: connection checked";
+            sleep 1;
+            break;
+        else
+            echo "Connection not available yet, sleeping 1 sec...";
+            sleep 1;
+            echo "----------";
+        fi;
+    done;
+fi;
+
+config="/etc/sync_gateway/config.json"
+
+if [ ! -z $@ ]; then
+    echo "Using config provided as command parameter: $@"
+    config=$@
+else
+    if [ -f /sync/config.json ]; then
+        echo "Using provided config in: /sync/config.json";
+        config="/sync/config.json"
+    else
+        echo "No config provided in /sync/config.json, generating one from environment variables";
+        python create_config.py
+    fi;
+fi;
+
 LOGFILE_DIR=/var/log/sync_gateway
 mkdir -p $LOGFILE_DIR
 
@@ -9,4 +55,4 @@ LOGFILE_ERROR=$LOGFILE_DIR/sync_gateway_error.log
 
 # Run SG and use tee to append stdout and stderr to separate logfiles
 # Process substitution described here: https://stackoverflow.com/a/692407
-exec sync_gateway "$@" > >(tee -a $LOGFILE_ACCESS) 2> >(tee -a $LOGFILE_ERROR >&2)
+exec sync_gateway "$config" > >(tee -a $LOGFILE_ACCESS) 2> >(tee -a $LOGFILE_ERROR >&2)

--- a/community/sync-gateway/1.2.1/Dockerfile
+++ b/community/sync-gateway/1.2.1/Dockerfile
@@ -19,15 +19,15 @@ RUN wget http://packages.couchbase.com/releases/couchbase-sync-gateway/1.2.1/cou
 # Create directory where the default config stores memory snapshots to disk
 RUN mkdir /opt/couchbase-sync-gateway/data
 
-# copy the default config into the container
-COPY config/sync_gateway_config.json /etc/sync_gateway/config.json
+# Create sync file for custom config.json or generated from env vars config.json
+RUN mkdir /sync
+
+# Copy config generator from environment variables
+COPY /scripts/create_config.py /
 
 # Add bootstrap script
 COPY scripts/entrypoint.sh /
 ENTRYPOINT ["/entrypoint.sh"]
-
-# If user doesn't specify any args, use the default config
-CMD ["/etc/sync_gateway/config.json"]
 
 # Expose ports
 #  port 4984: public port

--- a/community/sync-gateway/1.2.1/scripts/create_config.py
+++ b/community/sync-gateway/1.2.1/scripts/create_config.py
@@ -1,0 +1,116 @@
+from __future__ import print_function
+import os
+import json
+import logging
+
+logging.basicConfig(level=logging.INFO)
+
+
+def getenv_boolean(var_name, default_value=False):
+    result = default_value
+    env_value = os.getenv(var_name)
+    if env_value is not None:
+        result = env_value.upper() in ("TRUE", "1")
+    return result
+
+
+# Env vars for configs
+COUCHBASE_HOST = os.getenv(
+    "COUCHBASE_HOST", ""
+)  # e.g.: "couchbase". Leave empty to use default Walrus
+COUCHBASE_PORT = os.getenv("COUCHBASE_PORT", "8091")
+COUCHBASE_BUCKET_NAME = os.getenv("COUCHBASE_BUCKET_NAME", "app")
+COUCHBASE_SYNC_GATEWAY_LOG = os.getenv(
+    "COUCHBASE_SYNC_GATEWAY_LOG", "HTTP+"
+)  # e.g.: "*"
+COUCHBASE_SYNC_GATEWAY_ADMIN_INTERFACE = os.getenv(
+    "COUCHBASE_SYNC_GATEWAY_ADMIN_INTERFACE", ""
+)  # e.g.: ":4985", leave empty to disable
+COUCHBASE_SYNC_GATEWAY_USER = os.getenv("COUCHBASE_SYNC_GATEWAY_USER", "")
+COUCHBASE_SYNC_GATEWAY_PASSWORD = os.getenv("COUCHBASE_SYNC_GATEWAY_PASSWORD", "")
+COUCHBASE_SYNC_GATEWAY_DATABASE = os.getenv("COUCHBASE_SYNC_GATEWAY_DATABASE", "db")
+COUCHBASE_SYNC_GATEWAY_CORS_ORIGINS = os.getenv(
+    "COUCHBASE_SYNC_GATEWAY_CORS_ORIGINS", ""
+)
+COUCHBASE_SYNC_GATEWAY_NUM_INDEX_REPLICAS = int(
+    os.getenv("COUCHBASE_SYNC_GATEWAY_NUM_INDEX_REPLICAS", "0")
+)
+COUCHBASE_SYNC_GATEWAY_DISABLE_GUEST_USER = getenv_boolean(
+    "COUCHBASE_SYNC_GATEWAY_DISABLE_GUEST_USER", default_value=False
+)
+
+# Base config
+logging.info("Generating base config")
+config_dict = {
+    "interface": ":4984",
+    "logging": {"console": {"log_keys": [COUCHBASE_SYNC_GATEWAY_LOG]}},
+    "databases": {},
+}
+
+# Admin interface
+logging.info("Checking adminInterface config config")
+if COUCHBASE_SYNC_GATEWAY_ADMIN_INTERFACE:
+    logging.info("Generating adminInterface config config")
+    config_dict["adminInterface"] = COUCHBASE_SYNC_GATEWAY_ADMIN_INTERFACE
+
+# CORS
+logging.info("Checking CORS config")
+if COUCHBASE_SYNC_GATEWAY_CORS_ORIGINS:
+    cors_list = COUCHBASE_SYNC_GATEWAY_CORS_ORIGINS.split(",")
+    use_cors = [origin.strip() for origin in cors_list]
+
+    logging.info("Generating CORS config")
+    config_dict["CORS"] = {
+        "Origin": use_cors,
+        "LoginOrigin": use_cors,
+        "Headers": ["Content-Type"],
+        "MaxAge": 17280000,
+    }
+
+# Couchbase
+logging.info("Checking Couchbase config")
+if COUCHBASE_HOST and COUCHBASE_SYNC_GATEWAY_USER and COUCHBASE_SYNC_GATEWAY_PASSWORD:
+    logging.info("Generating Couchbase config")
+    use_server = "http://{COUCHBASE_HOST}:{COUCHBASE_PORT}".format(
+        COUCHBASE_HOST=COUCHBASE_HOST, COUCHBASE_PORT=COUCHBASE_PORT
+    )
+
+    config_dict["databases"][COUCHBASE_SYNC_GATEWAY_DATABASE] = {
+        "server": use_server,
+        "bucket": COUCHBASE_BUCKET_NAME,
+        "username": COUCHBASE_SYNC_GATEWAY_USER,
+        "password": COUCHBASE_SYNC_GATEWAY_PASSWORD,
+        "num_index_replicas": COUCHBASE_SYNC_GATEWAY_NUM_INDEX_REPLICAS,
+        "enable_shared_bucket_access": True,
+        "import_docs": "continuous",
+        "users": {"GUEST": {"disabled": COUCHBASE_SYNC_GATEWAY_DISABLE_GUEST_USER}},
+    }
+else:
+    config_dict["databases"][COUCHBASE_SYNC_GATEWAY_DATABASE] = {
+        "server": "walrus:/opt/couchbase-sync-gateway/data",
+        "users": {
+            "GUEST": {
+                "disabled": COUCHBASE_SYNC_GATEWAY_DISABLE_GUEST_USER,
+                "admin_channels": ["*"],
+            }
+        },
+    }
+
+# JS sync function
+logging.info("Checking JavaScript sync function file")
+js_function_path = "/sync/sync-function.js"
+sync_function = ""
+logging.info("Checking JS sync function from {}".format(js_function_path))
+if os.path.isfile(js_function_path):
+    logging.info("Reading JavaScript sync function file")
+    with open(js_function_path) as f:
+        sync_function = f.read()
+if sync_function:
+    logging.info("Generating JavaScript sync function config")
+    config_dict["databases"][COUCHBASE_SYNC_GATEWAY_DATABASE]["sync"] = sync_function
+
+# Generate JSON config
+logging.info("Writing final config JSON file")
+with open("/etc/sync_gateway/config.json", "w") as f:
+    json.dump(config_dict, f, indent=2)
+logging.info("Done")

--- a/community/sync-gateway/1.2.1/scripts/entrypoint.sh
+++ b/community/sync-gateway/1.2.1/scripts/entrypoint.sh
@@ -1,6 +1,52 @@
 #!/bin/bash
 set -e
 
+# Check connection in a separate function, that way, when 
+# there's no connection available yet and the return of the command
+# is non-zero, the script doesn't exit yet
+check_connection() {
+    curl -Is http://${COUCHBASE_SYNC_GATEWAY_USER}:${COUCHBASE_SYNC_GATEWAY_PASSWORD}@${COUCHBASE_HOST}:${COUCHBASE_PORT}/pools/default/buckets/${COUCHBASE_BUCKET_NAME} 2>&1 | grep "HTTP/1.1 200 OK" > /dev/null
+    if [ $? -eq 0 ]; then
+        echo "success";
+    else
+        echo "error";
+    fi;
+}
+
+# Try to connect to Couchbase only if COUCHBASE_HOST was declared as an env var
+if [ ! -z $COUCHBASE_HOST ]; then
+    # Try once per second, up to 300 times (5 min)
+    SECONDS_TO_TRY=300
+    for i in $(seq 1 $SECONDS_TO_TRY); do
+        echo "Checking connection, trial ${i}";
+        result=$(check_connection);
+        if [ $result == "success" ]; then
+            echo "Success: connection checked";
+            sleep 1;
+            break;
+        else
+            echo "Connection not available yet, sleeping 1 sec...";
+            sleep 1;
+            echo "----------";
+        fi;
+    done;
+fi;
+
+config="/etc/sync_gateway/config.json"
+
+if [ ! -z $@ ]; then
+    echo "Using config provided as command parameter: $@"
+    config=$@
+else
+    if [ -f /sync/config.json ]; then
+        echo "Using provided config in: /sync/config.json";
+        config="/sync/config.json"
+    else
+        echo "No config provided in /sync/config.json, generating one from environment variables";
+        python create_config.py
+    fi;
+fi;
+
 LOGFILE_DIR=/var/log/sync_gateway
 mkdir -p $LOGFILE_DIR
 
@@ -9,4 +55,4 @@ LOGFILE_ERROR=$LOGFILE_DIR/sync_gateway_error.log
 
 # Run SG and use tee to append stdout and stderr to separate logfiles
 # Process substitution described here: https://stackoverflow.com/a/692407
-exec sync_gateway "$@" > >(tee -a $LOGFILE_ACCESS) 2> >(tee -a $LOGFILE_ERROR >&2)
+exec sync_gateway "$config" > >(tee -a $LOGFILE_ACCESS) 2> >(tee -a $LOGFILE_ERROR >&2)

--- a/community/sync-gateway/1.3.0-274/Dockerfile
+++ b/community/sync-gateway/1.3.0-274/Dockerfile
@@ -19,15 +19,15 @@ RUN wget http://packages.couchbase.com/releases/couchbase-sync-gateway/1.3.0/cou
 # Create directory where the default config stores memory snapshots to disk
 RUN mkdir /opt/couchbase-sync-gateway/data
 
-# copy the default config into the container
-COPY config/sync_gateway_config.json /etc/sync_gateway/config.json
+# Create sync file for custom config.json or generated from env vars config.json
+RUN mkdir /sync
+
+# Copy config generator from environment variables
+COPY /scripts/create_config.py /
 
 # Add bootstrap script
 COPY scripts/entrypoint.sh /
 ENTRYPOINT ["/entrypoint.sh"]
-
-# If user doesn't specify any args, use the default config
-CMD ["/etc/sync_gateway/config.json"]
 
 # Expose ports
 #  port 4984: public port

--- a/community/sync-gateway/1.3.0-274/scripts/create_config.py
+++ b/community/sync-gateway/1.3.0-274/scripts/create_config.py
@@ -1,0 +1,116 @@
+from __future__ import print_function
+import os
+import json
+import logging
+
+logging.basicConfig(level=logging.INFO)
+
+
+def getenv_boolean(var_name, default_value=False):
+    result = default_value
+    env_value = os.getenv(var_name)
+    if env_value is not None:
+        result = env_value.upper() in ("TRUE", "1")
+    return result
+
+
+# Env vars for configs
+COUCHBASE_HOST = os.getenv(
+    "COUCHBASE_HOST", ""
+)  # e.g.: "couchbase". Leave empty to use default Walrus
+COUCHBASE_PORT = os.getenv("COUCHBASE_PORT", "8091")
+COUCHBASE_BUCKET_NAME = os.getenv("COUCHBASE_BUCKET_NAME", "app")
+COUCHBASE_SYNC_GATEWAY_LOG = os.getenv(
+    "COUCHBASE_SYNC_GATEWAY_LOG", "HTTP+"
+)  # e.g.: "*"
+COUCHBASE_SYNC_GATEWAY_ADMIN_INTERFACE = os.getenv(
+    "COUCHBASE_SYNC_GATEWAY_ADMIN_INTERFACE", ""
+)  # e.g.: ":4985", leave empty to disable
+COUCHBASE_SYNC_GATEWAY_USER = os.getenv("COUCHBASE_SYNC_GATEWAY_USER", "")
+COUCHBASE_SYNC_GATEWAY_PASSWORD = os.getenv("COUCHBASE_SYNC_GATEWAY_PASSWORD", "")
+COUCHBASE_SYNC_GATEWAY_DATABASE = os.getenv("COUCHBASE_SYNC_GATEWAY_DATABASE", "db")
+COUCHBASE_SYNC_GATEWAY_CORS_ORIGINS = os.getenv(
+    "COUCHBASE_SYNC_GATEWAY_CORS_ORIGINS", ""
+)
+COUCHBASE_SYNC_GATEWAY_NUM_INDEX_REPLICAS = int(
+    os.getenv("COUCHBASE_SYNC_GATEWAY_NUM_INDEX_REPLICAS", "0")
+)
+COUCHBASE_SYNC_GATEWAY_DISABLE_GUEST_USER = getenv_boolean(
+    "COUCHBASE_SYNC_GATEWAY_DISABLE_GUEST_USER", default_value=False
+)
+
+# Base config
+logging.info("Generating base config")
+config_dict = {
+    "interface": ":4984",
+    "logging": {"console": {"log_keys": [COUCHBASE_SYNC_GATEWAY_LOG]}},
+    "databases": {},
+}
+
+# Admin interface
+logging.info("Checking adminInterface config config")
+if COUCHBASE_SYNC_GATEWAY_ADMIN_INTERFACE:
+    logging.info("Generating adminInterface config config")
+    config_dict["adminInterface"] = COUCHBASE_SYNC_GATEWAY_ADMIN_INTERFACE
+
+# CORS
+logging.info("Checking CORS config")
+if COUCHBASE_SYNC_GATEWAY_CORS_ORIGINS:
+    cors_list = COUCHBASE_SYNC_GATEWAY_CORS_ORIGINS.split(",")
+    use_cors = [origin.strip() for origin in cors_list]
+
+    logging.info("Generating CORS config")
+    config_dict["CORS"] = {
+        "Origin": use_cors,
+        "LoginOrigin": use_cors,
+        "Headers": ["Content-Type"],
+        "MaxAge": 17280000,
+    }
+
+# Couchbase
+logging.info("Checking Couchbase config")
+if COUCHBASE_HOST and COUCHBASE_SYNC_GATEWAY_USER and COUCHBASE_SYNC_GATEWAY_PASSWORD:
+    logging.info("Generating Couchbase config")
+    use_server = "http://{COUCHBASE_HOST}:{COUCHBASE_PORT}".format(
+        COUCHBASE_HOST=COUCHBASE_HOST, COUCHBASE_PORT=COUCHBASE_PORT
+    )
+
+    config_dict["databases"][COUCHBASE_SYNC_GATEWAY_DATABASE] = {
+        "server": use_server,
+        "bucket": COUCHBASE_BUCKET_NAME,
+        "username": COUCHBASE_SYNC_GATEWAY_USER,
+        "password": COUCHBASE_SYNC_GATEWAY_PASSWORD,
+        "num_index_replicas": COUCHBASE_SYNC_GATEWAY_NUM_INDEX_REPLICAS,
+        "enable_shared_bucket_access": True,
+        "import_docs": "continuous",
+        "users": {"GUEST": {"disabled": COUCHBASE_SYNC_GATEWAY_DISABLE_GUEST_USER}},
+    }
+else:
+    config_dict["databases"][COUCHBASE_SYNC_GATEWAY_DATABASE] = {
+        "server": "walrus:/opt/couchbase-sync-gateway/data",
+        "users": {
+            "GUEST": {
+                "disabled": COUCHBASE_SYNC_GATEWAY_DISABLE_GUEST_USER,
+                "admin_channels": ["*"],
+            }
+        },
+    }
+
+# JS sync function
+logging.info("Checking JavaScript sync function file")
+js_function_path = "/sync/sync-function.js"
+sync_function = ""
+logging.info("Checking JS sync function from {}".format(js_function_path))
+if os.path.isfile(js_function_path):
+    logging.info("Reading JavaScript sync function file")
+    with open(js_function_path) as f:
+        sync_function = f.read()
+if sync_function:
+    logging.info("Generating JavaScript sync function config")
+    config_dict["databases"][COUCHBASE_SYNC_GATEWAY_DATABASE]["sync"] = sync_function
+
+# Generate JSON config
+logging.info("Writing final config JSON file")
+with open("/etc/sync_gateway/config.json", "w") as f:
+    json.dump(config_dict, f, indent=2)
+logging.info("Done")

--- a/community/sync-gateway/1.3.0-274/scripts/entrypoint.sh
+++ b/community/sync-gateway/1.3.0-274/scripts/entrypoint.sh
@@ -1,6 +1,52 @@
 #!/bin/bash
 set -e
 
+# Check connection in a separate function, that way, when 
+# there's no connection available yet and the return of the command
+# is non-zero, the script doesn't exit yet
+check_connection() {
+    curl -Is http://${COUCHBASE_SYNC_GATEWAY_USER}:${COUCHBASE_SYNC_GATEWAY_PASSWORD}@${COUCHBASE_HOST}:${COUCHBASE_PORT}/pools/default/buckets/${COUCHBASE_BUCKET_NAME} 2>&1 | grep "HTTP/1.1 200 OK" > /dev/null
+    if [ $? -eq 0 ]; then
+        echo "success";
+    else
+        echo "error";
+    fi;
+}
+
+# Try to connect to Couchbase only if COUCHBASE_HOST was declared as an env var
+if [ ! -z $COUCHBASE_HOST ]; then
+    # Try once per second, up to 300 times (5 min)
+    SECONDS_TO_TRY=300
+    for i in $(seq 1 $SECONDS_TO_TRY); do
+        echo "Checking connection, trial ${i}";
+        result=$(check_connection);
+        if [ $result == "success" ]; then
+            echo "Success: connection checked";
+            sleep 1;
+            break;
+        else
+            echo "Connection not available yet, sleeping 1 sec...";
+            sleep 1;
+            echo "----------";
+        fi;
+    done;
+fi;
+
+config="/etc/sync_gateway/config.json"
+
+if [ ! -z $@ ]; then
+    echo "Using config provided as command parameter: $@"
+    config=$@
+else
+    if [ -f /sync/config.json ]; then
+        echo "Using provided config in: /sync/config.json";
+        config="/sync/config.json"
+    else
+        echo "No config provided in /sync/config.json, generating one from environment variables";
+        python create_config.py
+    fi;
+fi;
+
 LOGFILE_DIR=/var/log/sync_gateway
 mkdir -p $LOGFILE_DIR
 
@@ -9,4 +55,4 @@ LOGFILE_ERROR=$LOGFILE_DIR/sync_gateway_error.log
 
 # Run SG and use tee to append stdout and stderr to separate logfiles
 # Process substitution described here: https://stackoverflow.com/a/692407
-exec sync_gateway "$@" > >(tee -a $LOGFILE_ACCESS) 2> >(tee -a $LOGFILE_ERROR >&2)
+exec sync_gateway "$config" > >(tee -a $LOGFILE_ACCESS) 2> >(tee -a $LOGFILE_ERROR >&2)

--- a/community/sync-gateway/1.3.1-16/Dockerfile
+++ b/community/sync-gateway/1.3.1-16/Dockerfile
@@ -19,15 +19,15 @@ RUN wget http://packages.couchbase.com/releases/couchbase-sync-gateway/1.3.1/cou
 # Create directory where the default config stores memory snapshots to disk
 RUN mkdir /opt/couchbase-sync-gateway/data
 
-# copy the default config into the container
-COPY config/sync_gateway_config.json /etc/sync_gateway/config.json
+# Create sync file for custom config.json or generated from env vars config.json
+RUN mkdir /sync
+
+# Copy config generator from environment variables
+COPY /scripts/create_config.py /
 
 # Add bootstrap script
 COPY scripts/entrypoint.sh /
 ENTRYPOINT ["/entrypoint.sh"]
-
-# If user doesn't specify any args, use the default config
-CMD ["/etc/sync_gateway/config.json"]
 
 # Expose ports
 #  port 4984: public port

--- a/community/sync-gateway/1.3.1-16/scripts/create_config.py
+++ b/community/sync-gateway/1.3.1-16/scripts/create_config.py
@@ -1,0 +1,116 @@
+from __future__ import print_function
+import os
+import json
+import logging
+
+logging.basicConfig(level=logging.INFO)
+
+
+def getenv_boolean(var_name, default_value=False):
+    result = default_value
+    env_value = os.getenv(var_name)
+    if env_value is not None:
+        result = env_value.upper() in ("TRUE", "1")
+    return result
+
+
+# Env vars for configs
+COUCHBASE_HOST = os.getenv(
+    "COUCHBASE_HOST", ""
+)  # e.g.: "couchbase". Leave empty to use default Walrus
+COUCHBASE_PORT = os.getenv("COUCHBASE_PORT", "8091")
+COUCHBASE_BUCKET_NAME = os.getenv("COUCHBASE_BUCKET_NAME", "app")
+COUCHBASE_SYNC_GATEWAY_LOG = os.getenv(
+    "COUCHBASE_SYNC_GATEWAY_LOG", "HTTP+"
+)  # e.g.: "*"
+COUCHBASE_SYNC_GATEWAY_ADMIN_INTERFACE = os.getenv(
+    "COUCHBASE_SYNC_GATEWAY_ADMIN_INTERFACE", ""
+)  # e.g.: ":4985", leave empty to disable
+COUCHBASE_SYNC_GATEWAY_USER = os.getenv("COUCHBASE_SYNC_GATEWAY_USER", "")
+COUCHBASE_SYNC_GATEWAY_PASSWORD = os.getenv("COUCHBASE_SYNC_GATEWAY_PASSWORD", "")
+COUCHBASE_SYNC_GATEWAY_DATABASE = os.getenv("COUCHBASE_SYNC_GATEWAY_DATABASE", "db")
+COUCHBASE_SYNC_GATEWAY_CORS_ORIGINS = os.getenv(
+    "COUCHBASE_SYNC_GATEWAY_CORS_ORIGINS", ""
+)
+COUCHBASE_SYNC_GATEWAY_NUM_INDEX_REPLICAS = int(
+    os.getenv("COUCHBASE_SYNC_GATEWAY_NUM_INDEX_REPLICAS", "0")
+)
+COUCHBASE_SYNC_GATEWAY_DISABLE_GUEST_USER = getenv_boolean(
+    "COUCHBASE_SYNC_GATEWAY_DISABLE_GUEST_USER", default_value=False
+)
+
+# Base config
+logging.info("Generating base config")
+config_dict = {
+    "interface": ":4984",
+    "logging": {"console": {"log_keys": [COUCHBASE_SYNC_GATEWAY_LOG]}},
+    "databases": {},
+}
+
+# Admin interface
+logging.info("Checking adminInterface config config")
+if COUCHBASE_SYNC_GATEWAY_ADMIN_INTERFACE:
+    logging.info("Generating adminInterface config config")
+    config_dict["adminInterface"] = COUCHBASE_SYNC_GATEWAY_ADMIN_INTERFACE
+
+# CORS
+logging.info("Checking CORS config")
+if COUCHBASE_SYNC_GATEWAY_CORS_ORIGINS:
+    cors_list = COUCHBASE_SYNC_GATEWAY_CORS_ORIGINS.split(",")
+    use_cors = [origin.strip() for origin in cors_list]
+
+    logging.info("Generating CORS config")
+    config_dict["CORS"] = {
+        "Origin": use_cors,
+        "LoginOrigin": use_cors,
+        "Headers": ["Content-Type"],
+        "MaxAge": 17280000,
+    }
+
+# Couchbase
+logging.info("Checking Couchbase config")
+if COUCHBASE_HOST and COUCHBASE_SYNC_GATEWAY_USER and COUCHBASE_SYNC_GATEWAY_PASSWORD:
+    logging.info("Generating Couchbase config")
+    use_server = "http://{COUCHBASE_HOST}:{COUCHBASE_PORT}".format(
+        COUCHBASE_HOST=COUCHBASE_HOST, COUCHBASE_PORT=COUCHBASE_PORT
+    )
+
+    config_dict["databases"][COUCHBASE_SYNC_GATEWAY_DATABASE] = {
+        "server": use_server,
+        "bucket": COUCHBASE_BUCKET_NAME,
+        "username": COUCHBASE_SYNC_GATEWAY_USER,
+        "password": COUCHBASE_SYNC_GATEWAY_PASSWORD,
+        "num_index_replicas": COUCHBASE_SYNC_GATEWAY_NUM_INDEX_REPLICAS,
+        "enable_shared_bucket_access": True,
+        "import_docs": "continuous",
+        "users": {"GUEST": {"disabled": COUCHBASE_SYNC_GATEWAY_DISABLE_GUEST_USER}},
+    }
+else:
+    config_dict["databases"][COUCHBASE_SYNC_GATEWAY_DATABASE] = {
+        "server": "walrus:/opt/couchbase-sync-gateway/data",
+        "users": {
+            "GUEST": {
+                "disabled": COUCHBASE_SYNC_GATEWAY_DISABLE_GUEST_USER,
+                "admin_channels": ["*"],
+            }
+        },
+    }
+
+# JS sync function
+logging.info("Checking JavaScript sync function file")
+js_function_path = "/sync/sync-function.js"
+sync_function = ""
+logging.info("Checking JS sync function from {}".format(js_function_path))
+if os.path.isfile(js_function_path):
+    logging.info("Reading JavaScript sync function file")
+    with open(js_function_path) as f:
+        sync_function = f.read()
+if sync_function:
+    logging.info("Generating JavaScript sync function config")
+    config_dict["databases"][COUCHBASE_SYNC_GATEWAY_DATABASE]["sync"] = sync_function
+
+# Generate JSON config
+logging.info("Writing final config JSON file")
+with open("/etc/sync_gateway/config.json", "w") as f:
+    json.dump(config_dict, f, indent=2)
+logging.info("Done")

--- a/community/sync-gateway/1.3.1-16/scripts/entrypoint.sh
+++ b/community/sync-gateway/1.3.1-16/scripts/entrypoint.sh
@@ -1,6 +1,52 @@
 #!/bin/bash
 set -e
 
+# Check connection in a separate function, that way, when 
+# there's no connection available yet and the return of the command
+# is non-zero, the script doesn't exit yet
+check_connection() {
+    curl -Is http://${COUCHBASE_SYNC_GATEWAY_USER}:${COUCHBASE_SYNC_GATEWAY_PASSWORD}@${COUCHBASE_HOST}:${COUCHBASE_PORT}/pools/default/buckets/${COUCHBASE_BUCKET_NAME} 2>&1 | grep "HTTP/1.1 200 OK" > /dev/null
+    if [ $? -eq 0 ]; then
+        echo "success";
+    else
+        echo "error";
+    fi;
+}
+
+# Try to connect to Couchbase only if COUCHBASE_HOST was declared as an env var
+if [ ! -z $COUCHBASE_HOST ]; then
+    # Try once per second, up to 300 times (5 min)
+    SECONDS_TO_TRY=300
+    for i in $(seq 1 $SECONDS_TO_TRY); do
+        echo "Checking connection, trial ${i}";
+        result=$(check_connection);
+        if [ $result == "success" ]; then
+            echo "Success: connection checked";
+            sleep 1;
+            break;
+        else
+            echo "Connection not available yet, sleeping 1 sec...";
+            sleep 1;
+            echo "----------";
+        fi;
+    done;
+fi;
+
+config="/etc/sync_gateway/config.json"
+
+if [ ! -z $@ ]; then
+    echo "Using config provided as command parameter: $@"
+    config=$@
+else
+    if [ -f /sync/config.json ]; then
+        echo "Using provided config in: /sync/config.json";
+        config="/sync/config.json"
+    else
+        echo "No config provided in /sync/config.json, generating one from environment variables";
+        python create_config.py
+    fi;
+fi;
+
 LOGFILE_DIR=/var/log/sync_gateway
 mkdir -p $LOGFILE_DIR
 
@@ -9,4 +55,4 @@ LOGFILE_ERROR=$LOGFILE_DIR/sync_gateway_error.log
 
 # Run SG and use tee to append stdout and stderr to separate logfiles
 # Process substitution described here: https://stackoverflow.com/a/692407
-exec sync_gateway "$@" > >(tee -a $LOGFILE_ACCESS) 2> >(tee -a $LOGFILE_ERROR >&2)
+exec sync_gateway "$config" > >(tee -a $LOGFILE_ACCESS) 2> >(tee -a $LOGFILE_ERROR >&2)

--- a/community/sync-gateway/1.4.0-2/Dockerfile
+++ b/community/sync-gateway/1.4.0-2/Dockerfile
@@ -19,15 +19,15 @@ RUN wget http://packages.couchbase.com/releases/couchbase-sync-gateway/1.4.0/cou
 # Create directory where the default config stores memory snapshots to disk
 RUN mkdir /opt/couchbase-sync-gateway/data
 
-# copy the default config into the container
-COPY config/sync_gateway_config.json /etc/sync_gateway/config.json
+# Create sync file for custom config.json or generated from env vars config.json
+RUN mkdir /sync
+
+# Copy config generator from environment variables
+COPY /scripts/create_config.py /
 
 # Add bootstrap script
 COPY scripts/entrypoint.sh /
 ENTRYPOINT ["/entrypoint.sh"]
-
-# If user doesn't specify any args, use the default config
-CMD ["/etc/sync_gateway/config.json"]
 
 # Expose ports
 #  port 4984: public port

--- a/community/sync-gateway/1.4.0-2/scripts/create_config.py
+++ b/community/sync-gateway/1.4.0-2/scripts/create_config.py
@@ -1,0 +1,116 @@
+from __future__ import print_function
+import os
+import json
+import logging
+
+logging.basicConfig(level=logging.INFO)
+
+
+def getenv_boolean(var_name, default_value=False):
+    result = default_value
+    env_value = os.getenv(var_name)
+    if env_value is not None:
+        result = env_value.upper() in ("TRUE", "1")
+    return result
+
+
+# Env vars for configs
+COUCHBASE_HOST = os.getenv(
+    "COUCHBASE_HOST", ""
+)  # e.g.: "couchbase". Leave empty to use default Walrus
+COUCHBASE_PORT = os.getenv("COUCHBASE_PORT", "8091")
+COUCHBASE_BUCKET_NAME = os.getenv("COUCHBASE_BUCKET_NAME", "app")
+COUCHBASE_SYNC_GATEWAY_LOG = os.getenv(
+    "COUCHBASE_SYNC_GATEWAY_LOG", "HTTP+"
+)  # e.g.: "*"
+COUCHBASE_SYNC_GATEWAY_ADMIN_INTERFACE = os.getenv(
+    "COUCHBASE_SYNC_GATEWAY_ADMIN_INTERFACE", ""
+)  # e.g.: ":4985", leave empty to disable
+COUCHBASE_SYNC_GATEWAY_USER = os.getenv("COUCHBASE_SYNC_GATEWAY_USER", "")
+COUCHBASE_SYNC_GATEWAY_PASSWORD = os.getenv("COUCHBASE_SYNC_GATEWAY_PASSWORD", "")
+COUCHBASE_SYNC_GATEWAY_DATABASE = os.getenv("COUCHBASE_SYNC_GATEWAY_DATABASE", "db")
+COUCHBASE_SYNC_GATEWAY_CORS_ORIGINS = os.getenv(
+    "COUCHBASE_SYNC_GATEWAY_CORS_ORIGINS", ""
+)
+COUCHBASE_SYNC_GATEWAY_NUM_INDEX_REPLICAS = int(
+    os.getenv("COUCHBASE_SYNC_GATEWAY_NUM_INDEX_REPLICAS", "0")
+)
+COUCHBASE_SYNC_GATEWAY_DISABLE_GUEST_USER = getenv_boolean(
+    "COUCHBASE_SYNC_GATEWAY_DISABLE_GUEST_USER", default_value=False
+)
+
+# Base config
+logging.info("Generating base config")
+config_dict = {
+    "interface": ":4984",
+    "logging": {"console": {"log_keys": [COUCHBASE_SYNC_GATEWAY_LOG]}},
+    "databases": {},
+}
+
+# Admin interface
+logging.info("Checking adminInterface config config")
+if COUCHBASE_SYNC_GATEWAY_ADMIN_INTERFACE:
+    logging.info("Generating adminInterface config config")
+    config_dict["adminInterface"] = COUCHBASE_SYNC_GATEWAY_ADMIN_INTERFACE
+
+# CORS
+logging.info("Checking CORS config")
+if COUCHBASE_SYNC_GATEWAY_CORS_ORIGINS:
+    cors_list = COUCHBASE_SYNC_GATEWAY_CORS_ORIGINS.split(",")
+    use_cors = [origin.strip() for origin in cors_list]
+
+    logging.info("Generating CORS config")
+    config_dict["CORS"] = {
+        "Origin": use_cors,
+        "LoginOrigin": use_cors,
+        "Headers": ["Content-Type"],
+        "MaxAge": 17280000,
+    }
+
+# Couchbase
+logging.info("Checking Couchbase config")
+if COUCHBASE_HOST and COUCHBASE_SYNC_GATEWAY_USER and COUCHBASE_SYNC_GATEWAY_PASSWORD:
+    logging.info("Generating Couchbase config")
+    use_server = "http://{COUCHBASE_HOST}:{COUCHBASE_PORT}".format(
+        COUCHBASE_HOST=COUCHBASE_HOST, COUCHBASE_PORT=COUCHBASE_PORT
+    )
+
+    config_dict["databases"][COUCHBASE_SYNC_GATEWAY_DATABASE] = {
+        "server": use_server,
+        "bucket": COUCHBASE_BUCKET_NAME,
+        "username": COUCHBASE_SYNC_GATEWAY_USER,
+        "password": COUCHBASE_SYNC_GATEWAY_PASSWORD,
+        "num_index_replicas": COUCHBASE_SYNC_GATEWAY_NUM_INDEX_REPLICAS,
+        "enable_shared_bucket_access": True,
+        "import_docs": "continuous",
+        "users": {"GUEST": {"disabled": COUCHBASE_SYNC_GATEWAY_DISABLE_GUEST_USER}},
+    }
+else:
+    config_dict["databases"][COUCHBASE_SYNC_GATEWAY_DATABASE] = {
+        "server": "walrus:/opt/couchbase-sync-gateway/data",
+        "users": {
+            "GUEST": {
+                "disabled": COUCHBASE_SYNC_GATEWAY_DISABLE_GUEST_USER,
+                "admin_channels": ["*"],
+            }
+        },
+    }
+
+# JS sync function
+logging.info("Checking JavaScript sync function file")
+js_function_path = "/sync/sync-function.js"
+sync_function = ""
+logging.info("Checking JS sync function from {}".format(js_function_path))
+if os.path.isfile(js_function_path):
+    logging.info("Reading JavaScript sync function file")
+    with open(js_function_path) as f:
+        sync_function = f.read()
+if sync_function:
+    logging.info("Generating JavaScript sync function config")
+    config_dict["databases"][COUCHBASE_SYNC_GATEWAY_DATABASE]["sync"] = sync_function
+
+# Generate JSON config
+logging.info("Writing final config JSON file")
+with open("/etc/sync_gateway/config.json", "w") as f:
+    json.dump(config_dict, f, indent=2)
+logging.info("Done")

--- a/community/sync-gateway/1.4.0-2/scripts/entrypoint.sh
+++ b/community/sync-gateway/1.4.0-2/scripts/entrypoint.sh
@@ -1,6 +1,52 @@
 #!/bin/bash
 set -e
 
+# Check connection in a separate function, that way, when 
+# there's no connection available yet and the return of the command
+# is non-zero, the script doesn't exit yet
+check_connection() {
+    curl -Is http://${COUCHBASE_SYNC_GATEWAY_USER}:${COUCHBASE_SYNC_GATEWAY_PASSWORD}@${COUCHBASE_HOST}:${COUCHBASE_PORT}/pools/default/buckets/${COUCHBASE_BUCKET_NAME} 2>&1 | grep "HTTP/1.1 200 OK" > /dev/null
+    if [ $? -eq 0 ]; then
+        echo "success";
+    else
+        echo "error";
+    fi;
+}
+
+# Try to connect to Couchbase only if COUCHBASE_HOST was declared as an env var
+if [ ! -z $COUCHBASE_HOST ]; then
+    # Try once per second, up to 300 times (5 min)
+    SECONDS_TO_TRY=300
+    for i in $(seq 1 $SECONDS_TO_TRY); do
+        echo "Checking connection, trial ${i}";
+        result=$(check_connection);
+        if [ $result == "success" ]; then
+            echo "Success: connection checked";
+            sleep 1;
+            break;
+        else
+            echo "Connection not available yet, sleeping 1 sec...";
+            sleep 1;
+            echo "----------";
+        fi;
+    done;
+fi;
+
+config="/etc/sync_gateway/config.json"
+
+if [ ! -z $@ ]; then
+    echo "Using config provided as command parameter: $@"
+    config=$@
+else
+    if [ -f /sync/config.json ]; then
+        echo "Using provided config in: /sync/config.json";
+        config="/sync/config.json"
+    else
+        echo "No config provided in /sync/config.json, generating one from environment variables";
+        python create_config.py
+    fi;
+fi;
+
 LOGFILE_DIR=/var/log/sync_gateway
 mkdir -p $LOGFILE_DIR
 
@@ -9,4 +55,4 @@ LOGFILE_ERROR=$LOGFILE_DIR/sync_gateway_error.log
 
 # Run SG and use tee to append stdout and stderr to separate logfiles
 # Process substitution described here: https://stackoverflow.com/a/692407
-exec sync_gateway "$@" > >(tee -a $LOGFILE_ACCESS) 2> >(tee -a $LOGFILE_ERROR >&2)
+exec sync_gateway "$config" > >(tee -a $LOGFILE_ACCESS) 2> >(tee -a $LOGFILE_ERROR >&2)

--- a/community/sync-gateway/1.4.1-3/Dockerfile
+++ b/community/sync-gateway/1.4.1-3/Dockerfile
@@ -19,15 +19,15 @@ RUN wget http://packages.couchbase.com/releases/couchbase-sync-gateway/1.4.1/cou
 # Create directory where the default config stores memory snapshots to disk
 RUN mkdir /opt/couchbase-sync-gateway/data
 
-# copy the default config into the container
-COPY config/sync_gateway_config.json /etc/sync_gateway/config.json
+# Create sync file for custom config.json or generated from env vars config.json
+RUN mkdir /sync
+
+# Copy config generator from environment variables
+COPY /scripts/create_config.py /
 
 # Add bootstrap script
 COPY scripts/entrypoint.sh /
 ENTRYPOINT ["/entrypoint.sh"]
-
-# If user doesn't specify any args, use the default config
-CMD ["/etc/sync_gateway/config.json"]
 
 # Expose ports
 #  port 4984: public port

--- a/community/sync-gateway/1.4.1-3/scripts/create_config.py
+++ b/community/sync-gateway/1.4.1-3/scripts/create_config.py
@@ -1,0 +1,116 @@
+from __future__ import print_function
+import os
+import json
+import logging
+
+logging.basicConfig(level=logging.INFO)
+
+
+def getenv_boolean(var_name, default_value=False):
+    result = default_value
+    env_value = os.getenv(var_name)
+    if env_value is not None:
+        result = env_value.upper() in ("TRUE", "1")
+    return result
+
+
+# Env vars for configs
+COUCHBASE_HOST = os.getenv(
+    "COUCHBASE_HOST", ""
+)  # e.g.: "couchbase". Leave empty to use default Walrus
+COUCHBASE_PORT = os.getenv("COUCHBASE_PORT", "8091")
+COUCHBASE_BUCKET_NAME = os.getenv("COUCHBASE_BUCKET_NAME", "app")
+COUCHBASE_SYNC_GATEWAY_LOG = os.getenv(
+    "COUCHBASE_SYNC_GATEWAY_LOG", "HTTP+"
+)  # e.g.: "*"
+COUCHBASE_SYNC_GATEWAY_ADMIN_INTERFACE = os.getenv(
+    "COUCHBASE_SYNC_GATEWAY_ADMIN_INTERFACE", ""
+)  # e.g.: ":4985", leave empty to disable
+COUCHBASE_SYNC_GATEWAY_USER = os.getenv("COUCHBASE_SYNC_GATEWAY_USER", "")
+COUCHBASE_SYNC_GATEWAY_PASSWORD = os.getenv("COUCHBASE_SYNC_GATEWAY_PASSWORD", "")
+COUCHBASE_SYNC_GATEWAY_DATABASE = os.getenv("COUCHBASE_SYNC_GATEWAY_DATABASE", "db")
+COUCHBASE_SYNC_GATEWAY_CORS_ORIGINS = os.getenv(
+    "COUCHBASE_SYNC_GATEWAY_CORS_ORIGINS", ""
+)
+COUCHBASE_SYNC_GATEWAY_NUM_INDEX_REPLICAS = int(
+    os.getenv("COUCHBASE_SYNC_GATEWAY_NUM_INDEX_REPLICAS", "0")
+)
+COUCHBASE_SYNC_GATEWAY_DISABLE_GUEST_USER = getenv_boolean(
+    "COUCHBASE_SYNC_GATEWAY_DISABLE_GUEST_USER", default_value=False
+)
+
+# Base config
+logging.info("Generating base config")
+config_dict = {
+    "interface": ":4984",
+    "logging": {"console": {"log_keys": [COUCHBASE_SYNC_GATEWAY_LOG]}},
+    "databases": {},
+}
+
+# Admin interface
+logging.info("Checking adminInterface config config")
+if COUCHBASE_SYNC_GATEWAY_ADMIN_INTERFACE:
+    logging.info("Generating adminInterface config config")
+    config_dict["adminInterface"] = COUCHBASE_SYNC_GATEWAY_ADMIN_INTERFACE
+
+# CORS
+logging.info("Checking CORS config")
+if COUCHBASE_SYNC_GATEWAY_CORS_ORIGINS:
+    cors_list = COUCHBASE_SYNC_GATEWAY_CORS_ORIGINS.split(",")
+    use_cors = [origin.strip() for origin in cors_list]
+
+    logging.info("Generating CORS config")
+    config_dict["CORS"] = {
+        "Origin": use_cors,
+        "LoginOrigin": use_cors,
+        "Headers": ["Content-Type"],
+        "MaxAge": 17280000,
+    }
+
+# Couchbase
+logging.info("Checking Couchbase config")
+if COUCHBASE_HOST and COUCHBASE_SYNC_GATEWAY_USER and COUCHBASE_SYNC_GATEWAY_PASSWORD:
+    logging.info("Generating Couchbase config")
+    use_server = "http://{COUCHBASE_HOST}:{COUCHBASE_PORT}".format(
+        COUCHBASE_HOST=COUCHBASE_HOST, COUCHBASE_PORT=COUCHBASE_PORT
+    )
+
+    config_dict["databases"][COUCHBASE_SYNC_GATEWAY_DATABASE] = {
+        "server": use_server,
+        "bucket": COUCHBASE_BUCKET_NAME,
+        "username": COUCHBASE_SYNC_GATEWAY_USER,
+        "password": COUCHBASE_SYNC_GATEWAY_PASSWORD,
+        "num_index_replicas": COUCHBASE_SYNC_GATEWAY_NUM_INDEX_REPLICAS,
+        "enable_shared_bucket_access": True,
+        "import_docs": "continuous",
+        "users": {"GUEST": {"disabled": COUCHBASE_SYNC_GATEWAY_DISABLE_GUEST_USER}},
+    }
+else:
+    config_dict["databases"][COUCHBASE_SYNC_GATEWAY_DATABASE] = {
+        "server": "walrus:/opt/couchbase-sync-gateway/data",
+        "users": {
+            "GUEST": {
+                "disabled": COUCHBASE_SYNC_GATEWAY_DISABLE_GUEST_USER,
+                "admin_channels": ["*"],
+            }
+        },
+    }
+
+# JS sync function
+logging.info("Checking JavaScript sync function file")
+js_function_path = "/sync/sync-function.js"
+sync_function = ""
+logging.info("Checking JS sync function from {}".format(js_function_path))
+if os.path.isfile(js_function_path):
+    logging.info("Reading JavaScript sync function file")
+    with open(js_function_path) as f:
+        sync_function = f.read()
+if sync_function:
+    logging.info("Generating JavaScript sync function config")
+    config_dict["databases"][COUCHBASE_SYNC_GATEWAY_DATABASE]["sync"] = sync_function
+
+# Generate JSON config
+logging.info("Writing final config JSON file")
+with open("/etc/sync_gateway/config.json", "w") as f:
+    json.dump(config_dict, f, indent=2)
+logging.info("Done")

--- a/community/sync-gateway/1.4.1-3/scripts/entrypoint.sh
+++ b/community/sync-gateway/1.4.1-3/scripts/entrypoint.sh
@@ -1,6 +1,52 @@
 #!/bin/bash
 set -e
 
+# Check connection in a separate function, that way, when 
+# there's no connection available yet and the return of the command
+# is non-zero, the script doesn't exit yet
+check_connection() {
+    curl -Is http://${COUCHBASE_SYNC_GATEWAY_USER}:${COUCHBASE_SYNC_GATEWAY_PASSWORD}@${COUCHBASE_HOST}:${COUCHBASE_PORT}/pools/default/buckets/${COUCHBASE_BUCKET_NAME} 2>&1 | grep "HTTP/1.1 200 OK" > /dev/null
+    if [ $? -eq 0 ]; then
+        echo "success";
+    else
+        echo "error";
+    fi;
+}
+
+# Try to connect to Couchbase only if COUCHBASE_HOST was declared as an env var
+if [ ! -z $COUCHBASE_HOST ]; then
+    # Try once per second, up to 300 times (5 min)
+    SECONDS_TO_TRY=300
+    for i in $(seq 1 $SECONDS_TO_TRY); do
+        echo "Checking connection, trial ${i}";
+        result=$(check_connection);
+        if [ $result == "success" ]; then
+            echo "Success: connection checked";
+            sleep 1;
+            break;
+        else
+            echo "Connection not available yet, sleeping 1 sec...";
+            sleep 1;
+            echo "----------";
+        fi;
+    done;
+fi;
+
+config="/etc/sync_gateway/config.json"
+
+if [ ! -z $@ ]; then
+    echo "Using config provided as command parameter: $@"
+    config=$@
+else
+    if [ -f /sync/config.json ]; then
+        echo "Using provided config in: /sync/config.json";
+        config="/sync/config.json"
+    else
+        echo "No config provided in /sync/config.json, generating one from environment variables";
+        python create_config.py
+    fi;
+fi;
+
 LOGFILE_DIR=/var/log/sync_gateway
 mkdir -p $LOGFILE_DIR
 
@@ -9,4 +55,4 @@ LOGFILE_ERROR=$LOGFILE_DIR/sync_gateway_error.log
 
 # Run SG and use tee to append stdout and stderr to separate logfiles
 # Process substitution described here: https://stackoverflow.com/a/692407
-exec sync_gateway "$@" > >(tee -a $LOGFILE_ACCESS) 2> >(tee -a $LOGFILE_ERROR >&2)
+exec sync_gateway "$config" > >(tee -a $LOGFILE_ACCESS) 2> >(tee -a $LOGFILE_ERROR >&2)

--- a/community/sync-gateway/1.5.0-377/Dockerfile
+++ b/community/sync-gateway/1.5.0-377/Dockerfile
@@ -19,15 +19,15 @@ RUN wget http://packages.couchbase.com/releases/couchbase-sync-gateway/1.5.0/cou
 # Create directory where the default config stores memory snapshots to disk
 RUN mkdir /opt/couchbase-sync-gateway/data
 
-# copy the default config into the container
-COPY config/sync_gateway_config.json /etc/sync_gateway/config.json
+# Create sync file for custom config.json or generated from env vars config.json
+RUN mkdir /sync
+
+# Copy config generator from environment variables
+COPY /scripts/create_config.py /
 
 # Add bootstrap script
 COPY scripts/entrypoint.sh /
 ENTRYPOINT ["/entrypoint.sh"]
-
-# If user doesn't specify any args, use the default config
-CMD ["/etc/sync_gateway/config.json"]
 
 # Expose ports
 #  port 4984: public port

--- a/community/sync-gateway/1.5.0-377/scripts/create_config.py
+++ b/community/sync-gateway/1.5.0-377/scripts/create_config.py
@@ -1,0 +1,116 @@
+from __future__ import print_function
+import os
+import json
+import logging
+
+logging.basicConfig(level=logging.INFO)
+
+
+def getenv_boolean(var_name, default_value=False):
+    result = default_value
+    env_value = os.getenv(var_name)
+    if env_value is not None:
+        result = env_value.upper() in ("TRUE", "1")
+    return result
+
+
+# Env vars for configs
+COUCHBASE_HOST = os.getenv(
+    "COUCHBASE_HOST", ""
+)  # e.g.: "couchbase". Leave empty to use default Walrus
+COUCHBASE_PORT = os.getenv("COUCHBASE_PORT", "8091")
+COUCHBASE_BUCKET_NAME = os.getenv("COUCHBASE_BUCKET_NAME", "app")
+COUCHBASE_SYNC_GATEWAY_LOG = os.getenv(
+    "COUCHBASE_SYNC_GATEWAY_LOG", "HTTP+"
+)  # e.g.: "*"
+COUCHBASE_SYNC_GATEWAY_ADMIN_INTERFACE = os.getenv(
+    "COUCHBASE_SYNC_GATEWAY_ADMIN_INTERFACE", ""
+)  # e.g.: ":4985", leave empty to disable
+COUCHBASE_SYNC_GATEWAY_USER = os.getenv("COUCHBASE_SYNC_GATEWAY_USER", "")
+COUCHBASE_SYNC_GATEWAY_PASSWORD = os.getenv("COUCHBASE_SYNC_GATEWAY_PASSWORD", "")
+COUCHBASE_SYNC_GATEWAY_DATABASE = os.getenv("COUCHBASE_SYNC_GATEWAY_DATABASE", "db")
+COUCHBASE_SYNC_GATEWAY_CORS_ORIGINS = os.getenv(
+    "COUCHBASE_SYNC_GATEWAY_CORS_ORIGINS", ""
+)
+COUCHBASE_SYNC_GATEWAY_NUM_INDEX_REPLICAS = int(
+    os.getenv("COUCHBASE_SYNC_GATEWAY_NUM_INDEX_REPLICAS", "0")
+)
+COUCHBASE_SYNC_GATEWAY_DISABLE_GUEST_USER = getenv_boolean(
+    "COUCHBASE_SYNC_GATEWAY_DISABLE_GUEST_USER", default_value=False
+)
+
+# Base config
+logging.info("Generating base config")
+config_dict = {
+    "interface": ":4984",
+    "logging": {"console": {"log_keys": [COUCHBASE_SYNC_GATEWAY_LOG]}},
+    "databases": {},
+}
+
+# Admin interface
+logging.info("Checking adminInterface config config")
+if COUCHBASE_SYNC_GATEWAY_ADMIN_INTERFACE:
+    logging.info("Generating adminInterface config config")
+    config_dict["adminInterface"] = COUCHBASE_SYNC_GATEWAY_ADMIN_INTERFACE
+
+# CORS
+logging.info("Checking CORS config")
+if COUCHBASE_SYNC_GATEWAY_CORS_ORIGINS:
+    cors_list = COUCHBASE_SYNC_GATEWAY_CORS_ORIGINS.split(",")
+    use_cors = [origin.strip() for origin in cors_list]
+
+    logging.info("Generating CORS config")
+    config_dict["CORS"] = {
+        "Origin": use_cors,
+        "LoginOrigin": use_cors,
+        "Headers": ["Content-Type"],
+        "MaxAge": 17280000,
+    }
+
+# Couchbase
+logging.info("Checking Couchbase config")
+if COUCHBASE_HOST and COUCHBASE_SYNC_GATEWAY_USER and COUCHBASE_SYNC_GATEWAY_PASSWORD:
+    logging.info("Generating Couchbase config")
+    use_server = "http://{COUCHBASE_HOST}:{COUCHBASE_PORT}".format(
+        COUCHBASE_HOST=COUCHBASE_HOST, COUCHBASE_PORT=COUCHBASE_PORT
+    )
+
+    config_dict["databases"][COUCHBASE_SYNC_GATEWAY_DATABASE] = {
+        "server": use_server,
+        "bucket": COUCHBASE_BUCKET_NAME,
+        "username": COUCHBASE_SYNC_GATEWAY_USER,
+        "password": COUCHBASE_SYNC_GATEWAY_PASSWORD,
+        "num_index_replicas": COUCHBASE_SYNC_GATEWAY_NUM_INDEX_REPLICAS,
+        "enable_shared_bucket_access": True,
+        "import_docs": "continuous",
+        "users": {"GUEST": {"disabled": COUCHBASE_SYNC_GATEWAY_DISABLE_GUEST_USER}},
+    }
+else:
+    config_dict["databases"][COUCHBASE_SYNC_GATEWAY_DATABASE] = {
+        "server": "walrus:/opt/couchbase-sync-gateway/data",
+        "users": {
+            "GUEST": {
+                "disabled": COUCHBASE_SYNC_GATEWAY_DISABLE_GUEST_USER,
+                "admin_channels": ["*"],
+            }
+        },
+    }
+
+# JS sync function
+logging.info("Checking JavaScript sync function file")
+js_function_path = "/sync/sync-function.js"
+sync_function = ""
+logging.info("Checking JS sync function from {}".format(js_function_path))
+if os.path.isfile(js_function_path):
+    logging.info("Reading JavaScript sync function file")
+    with open(js_function_path) as f:
+        sync_function = f.read()
+if sync_function:
+    logging.info("Generating JavaScript sync function config")
+    config_dict["databases"][COUCHBASE_SYNC_GATEWAY_DATABASE]["sync"] = sync_function
+
+# Generate JSON config
+logging.info("Writing final config JSON file")
+with open("/etc/sync_gateway/config.json", "w") as f:
+    json.dump(config_dict, f, indent=2)
+logging.info("Done")

--- a/community/sync-gateway/1.5.0-377/scripts/entrypoint.sh
+++ b/community/sync-gateway/1.5.0-377/scripts/entrypoint.sh
@@ -1,6 +1,52 @@
 #!/bin/bash
 set -e
 
+# Check connection in a separate function, that way, when 
+# there's no connection available yet and the return of the command
+# is non-zero, the script doesn't exit yet
+check_connection() {
+    curl -Is http://${COUCHBASE_SYNC_GATEWAY_USER}:${COUCHBASE_SYNC_GATEWAY_PASSWORD}@${COUCHBASE_HOST}:${COUCHBASE_PORT}/pools/default/buckets/${COUCHBASE_BUCKET_NAME} 2>&1 | grep "HTTP/1.1 200 OK" > /dev/null
+    if [ $? -eq 0 ]; then
+        echo "success";
+    else
+        echo "error";
+    fi;
+}
+
+# Try to connect to Couchbase only if COUCHBASE_HOST was declared as an env var
+if [ ! -z $COUCHBASE_HOST ]; then
+    # Try once per second, up to 300 times (5 min)
+    SECONDS_TO_TRY=300
+    for i in $(seq 1 $SECONDS_TO_TRY); do
+        echo "Checking connection, trial ${i}";
+        result=$(check_connection);
+        if [ $result == "success" ]; then
+            echo "Success: connection checked";
+            sleep 1;
+            break;
+        else
+            echo "Connection not available yet, sleeping 1 sec...";
+            sleep 1;
+            echo "----------";
+        fi;
+    done;
+fi;
+
+config="/etc/sync_gateway/config.json"
+
+if [ ! -z $@ ]; then
+    echo "Using config provided as command parameter: $@"
+    config=$@
+else
+    if [ -f /sync/config.json ]; then
+        echo "Using provided config in: /sync/config.json";
+        config="/sync/config.json"
+    else
+        echo "No config provided in /sync/config.json, generating one from environment variables";
+        python create_config.py
+    fi;
+fi;
+
 LOGFILE_DIR=/var/log/sync_gateway
 mkdir -p $LOGFILE_DIR
 
@@ -9,4 +55,4 @@ LOGFILE_ERROR=$LOGFILE_DIR/sync_gateway_error.log
 
 # Run SG and use tee to append stdout and stderr to separate logfiles
 # Process substitution described here: https://stackoverflow.com/a/692407
-exec sync_gateway "$@" > >(tee -a $LOGFILE_ACCESS) 2> >(tee -a $LOGFILE_ERROR >&2)
+exec sync_gateway "$config" > >(tee -a $LOGFILE_ACCESS) 2> >(tee -a $LOGFILE_ERROR >&2)

--- a/community/sync-gateway/1.5.1/Dockerfile
+++ b/community/sync-gateway/1.5.1/Dockerfile
@@ -19,15 +19,15 @@ RUN wget http://packages.couchbase.com/releases/couchbase-sync-gateway/1.5.1/cou
 # Create directory where the default config stores memory snapshots to disk
 RUN mkdir /opt/couchbase-sync-gateway/data
 
-# copy the default config into the container
-COPY config/sync_gateway_config.json /etc/sync_gateway/config.json
+# Create sync file for custom config.json or generated from env vars config.json
+RUN mkdir /sync
+
+# Copy config generator from environment variables
+COPY /scripts/create_config.py /
 
 # Add bootstrap script
 COPY scripts/entrypoint.sh /
 ENTRYPOINT ["/entrypoint.sh"]
-
-# If user doesn't specify any args, use the default config
-CMD ["/etc/sync_gateway/config.json"]
 
 # Expose ports
 #  port 4984: public port

--- a/community/sync-gateway/1.5.1/scripts/create_config.py
+++ b/community/sync-gateway/1.5.1/scripts/create_config.py
@@ -1,0 +1,116 @@
+from __future__ import print_function
+import os
+import json
+import logging
+
+logging.basicConfig(level=logging.INFO)
+
+
+def getenv_boolean(var_name, default_value=False):
+    result = default_value
+    env_value = os.getenv(var_name)
+    if env_value is not None:
+        result = env_value.upper() in ("TRUE", "1")
+    return result
+
+
+# Env vars for configs
+COUCHBASE_HOST = os.getenv(
+    "COUCHBASE_HOST", ""
+)  # e.g.: "couchbase". Leave empty to use default Walrus
+COUCHBASE_PORT = os.getenv("COUCHBASE_PORT", "8091")
+COUCHBASE_BUCKET_NAME = os.getenv("COUCHBASE_BUCKET_NAME", "app")
+COUCHBASE_SYNC_GATEWAY_LOG = os.getenv(
+    "COUCHBASE_SYNC_GATEWAY_LOG", "HTTP+"
+)  # e.g.: "*"
+COUCHBASE_SYNC_GATEWAY_ADMIN_INTERFACE = os.getenv(
+    "COUCHBASE_SYNC_GATEWAY_ADMIN_INTERFACE", ""
+)  # e.g.: ":4985", leave empty to disable
+COUCHBASE_SYNC_GATEWAY_USER = os.getenv("COUCHBASE_SYNC_GATEWAY_USER", "")
+COUCHBASE_SYNC_GATEWAY_PASSWORD = os.getenv("COUCHBASE_SYNC_GATEWAY_PASSWORD", "")
+COUCHBASE_SYNC_GATEWAY_DATABASE = os.getenv("COUCHBASE_SYNC_GATEWAY_DATABASE", "db")
+COUCHBASE_SYNC_GATEWAY_CORS_ORIGINS = os.getenv(
+    "COUCHBASE_SYNC_GATEWAY_CORS_ORIGINS", ""
+)
+COUCHBASE_SYNC_GATEWAY_NUM_INDEX_REPLICAS = int(
+    os.getenv("COUCHBASE_SYNC_GATEWAY_NUM_INDEX_REPLICAS", "0")
+)
+COUCHBASE_SYNC_GATEWAY_DISABLE_GUEST_USER = getenv_boolean(
+    "COUCHBASE_SYNC_GATEWAY_DISABLE_GUEST_USER", default_value=False
+)
+
+# Base config
+logging.info("Generating base config")
+config_dict = {
+    "interface": ":4984",
+    "logging": {"console": {"log_keys": [COUCHBASE_SYNC_GATEWAY_LOG]}},
+    "databases": {},
+}
+
+# Admin interface
+logging.info("Checking adminInterface config config")
+if COUCHBASE_SYNC_GATEWAY_ADMIN_INTERFACE:
+    logging.info("Generating adminInterface config config")
+    config_dict["adminInterface"] = COUCHBASE_SYNC_GATEWAY_ADMIN_INTERFACE
+
+# CORS
+logging.info("Checking CORS config")
+if COUCHBASE_SYNC_GATEWAY_CORS_ORIGINS:
+    cors_list = COUCHBASE_SYNC_GATEWAY_CORS_ORIGINS.split(",")
+    use_cors = [origin.strip() for origin in cors_list]
+
+    logging.info("Generating CORS config")
+    config_dict["CORS"] = {
+        "Origin": use_cors,
+        "LoginOrigin": use_cors,
+        "Headers": ["Content-Type"],
+        "MaxAge": 17280000,
+    }
+
+# Couchbase
+logging.info("Checking Couchbase config")
+if COUCHBASE_HOST and COUCHBASE_SYNC_GATEWAY_USER and COUCHBASE_SYNC_GATEWAY_PASSWORD:
+    logging.info("Generating Couchbase config")
+    use_server = "http://{COUCHBASE_HOST}:{COUCHBASE_PORT}".format(
+        COUCHBASE_HOST=COUCHBASE_HOST, COUCHBASE_PORT=COUCHBASE_PORT
+    )
+
+    config_dict["databases"][COUCHBASE_SYNC_GATEWAY_DATABASE] = {
+        "server": use_server,
+        "bucket": COUCHBASE_BUCKET_NAME,
+        "username": COUCHBASE_SYNC_GATEWAY_USER,
+        "password": COUCHBASE_SYNC_GATEWAY_PASSWORD,
+        "num_index_replicas": COUCHBASE_SYNC_GATEWAY_NUM_INDEX_REPLICAS,
+        "enable_shared_bucket_access": True,
+        "import_docs": "continuous",
+        "users": {"GUEST": {"disabled": COUCHBASE_SYNC_GATEWAY_DISABLE_GUEST_USER}},
+    }
+else:
+    config_dict["databases"][COUCHBASE_SYNC_GATEWAY_DATABASE] = {
+        "server": "walrus:/opt/couchbase-sync-gateway/data",
+        "users": {
+            "GUEST": {
+                "disabled": COUCHBASE_SYNC_GATEWAY_DISABLE_GUEST_USER,
+                "admin_channels": ["*"],
+            }
+        },
+    }
+
+# JS sync function
+logging.info("Checking JavaScript sync function file")
+js_function_path = "/sync/sync-function.js"
+sync_function = ""
+logging.info("Checking JS sync function from {}".format(js_function_path))
+if os.path.isfile(js_function_path):
+    logging.info("Reading JavaScript sync function file")
+    with open(js_function_path) as f:
+        sync_function = f.read()
+if sync_function:
+    logging.info("Generating JavaScript sync function config")
+    config_dict["databases"][COUCHBASE_SYNC_GATEWAY_DATABASE]["sync"] = sync_function
+
+# Generate JSON config
+logging.info("Writing final config JSON file")
+with open("/etc/sync_gateway/config.json", "w") as f:
+    json.dump(config_dict, f, indent=2)
+logging.info("Done")

--- a/community/sync-gateway/1.5.1/scripts/entrypoint.sh
+++ b/community/sync-gateway/1.5.1/scripts/entrypoint.sh
@@ -1,6 +1,52 @@
 #!/bin/bash
 set -e
 
+# Check connection in a separate function, that way, when 
+# there's no connection available yet and the return of the command
+# is non-zero, the script doesn't exit yet
+check_connection() {
+    curl -Is http://${COUCHBASE_SYNC_GATEWAY_USER}:${COUCHBASE_SYNC_GATEWAY_PASSWORD}@${COUCHBASE_HOST}:${COUCHBASE_PORT}/pools/default/buckets/${COUCHBASE_BUCKET_NAME} 2>&1 | grep "HTTP/1.1 200 OK" > /dev/null
+    if [ $? -eq 0 ]; then
+        echo "success";
+    else
+        echo "error";
+    fi;
+}
+
+# Try to connect to Couchbase only if COUCHBASE_HOST was declared as an env var
+if [ ! -z $COUCHBASE_HOST ]; then
+    # Try once per second, up to 300 times (5 min)
+    SECONDS_TO_TRY=300
+    for i in $(seq 1 $SECONDS_TO_TRY); do
+        echo "Checking connection, trial ${i}";
+        result=$(check_connection);
+        if [ $result == "success" ]; then
+            echo "Success: connection checked";
+            sleep 1;
+            break;
+        else
+            echo "Connection not available yet, sleeping 1 sec...";
+            sleep 1;
+            echo "----------";
+        fi;
+    done;
+fi;
+
+config="/etc/sync_gateway/config.json"
+
+if [ ! -z $@ ]; then
+    echo "Using config provided as command parameter: $@"
+    config=$@
+else
+    if [ -f /sync/config.json ]; then
+        echo "Using provided config in: /sync/config.json";
+        config="/sync/config.json"
+    else
+        echo "No config provided in /sync/config.json, generating one from environment variables";
+        python create_config.py
+    fi;
+fi;
+
 LOGFILE_DIR=/var/log/sync_gateway
 mkdir -p $LOGFILE_DIR
 
@@ -9,4 +55,4 @@ LOGFILE_ERROR=$LOGFILE_DIR/sync_gateway_error.log
 
 # Run SG and use tee to append stdout and stderr to separate logfiles
 # Process substitution described here: https://stackoverflow.com/a/692407
-exec sync_gateway "$@" > >(tee -a $LOGFILE_ACCESS) 2> >(tee -a $LOGFILE_ERROR >&2)
+exec sync_gateway "$config" > >(tee -a $LOGFILE_ACCESS) 2> >(tee -a $LOGFILE_ERROR >&2)

--- a/community/sync-gateway/2.0.0-devbuild/Dockerfile
+++ b/community/sync-gateway/2.0.0-devbuild/Dockerfile
@@ -19,15 +19,15 @@ RUN wget http://cbmobile-packages.s3.amazonaws.com/couchbase-sync-gateway-commun
 # Create directory where the default config stores memory snapshots to disk
 RUN mkdir /opt/couchbase-sync-gateway/data
 
-# copy the default config into the container
-COPY config/sync_gateway_config.json /etc/sync_gateway/config.json
+# Create sync file for custom config.json or generated from env vars config.json
+RUN mkdir /sync
+
+# Copy config generator from environment variables
+COPY /scripts/create_config.py /
 
 # Add bootstrap script
 COPY scripts/entrypoint.sh /
 ENTRYPOINT ["/entrypoint.sh"]
-
-# If user doesn't specify any args, use the default config
-CMD ["/etc/sync_gateway/config.json"]
 
 # Expose ports
 #  port 4984: public port

--- a/community/sync-gateway/2.0.0-devbuild/scripts/create_config.py
+++ b/community/sync-gateway/2.0.0-devbuild/scripts/create_config.py
@@ -1,0 +1,116 @@
+from __future__ import print_function
+import os
+import json
+import logging
+
+logging.basicConfig(level=logging.INFO)
+
+
+def getenv_boolean(var_name, default_value=False):
+    result = default_value
+    env_value = os.getenv(var_name)
+    if env_value is not None:
+        result = env_value.upper() in ("TRUE", "1")
+    return result
+
+
+# Env vars for configs
+COUCHBASE_HOST = os.getenv(
+    "COUCHBASE_HOST", ""
+)  # e.g.: "couchbase". Leave empty to use default Walrus
+COUCHBASE_PORT = os.getenv("COUCHBASE_PORT", "8091")
+COUCHBASE_BUCKET_NAME = os.getenv("COUCHBASE_BUCKET_NAME", "app")
+COUCHBASE_SYNC_GATEWAY_LOG = os.getenv(
+    "COUCHBASE_SYNC_GATEWAY_LOG", "HTTP+"
+)  # e.g.: "*"
+COUCHBASE_SYNC_GATEWAY_ADMIN_INTERFACE = os.getenv(
+    "COUCHBASE_SYNC_GATEWAY_ADMIN_INTERFACE", ""
+)  # e.g.: ":4985", leave empty to disable
+COUCHBASE_SYNC_GATEWAY_USER = os.getenv("COUCHBASE_SYNC_GATEWAY_USER", "")
+COUCHBASE_SYNC_GATEWAY_PASSWORD = os.getenv("COUCHBASE_SYNC_GATEWAY_PASSWORD", "")
+COUCHBASE_SYNC_GATEWAY_DATABASE = os.getenv("COUCHBASE_SYNC_GATEWAY_DATABASE", "db")
+COUCHBASE_SYNC_GATEWAY_CORS_ORIGINS = os.getenv(
+    "COUCHBASE_SYNC_GATEWAY_CORS_ORIGINS", ""
+)
+COUCHBASE_SYNC_GATEWAY_NUM_INDEX_REPLICAS = int(
+    os.getenv("COUCHBASE_SYNC_GATEWAY_NUM_INDEX_REPLICAS", "0")
+)
+COUCHBASE_SYNC_GATEWAY_DISABLE_GUEST_USER = getenv_boolean(
+    "COUCHBASE_SYNC_GATEWAY_DISABLE_GUEST_USER", default_value=False
+)
+
+# Base config
+logging.info("Generating base config")
+config_dict = {
+    "interface": ":4984",
+    "logging": {"console": {"log_keys": [COUCHBASE_SYNC_GATEWAY_LOG]}},
+    "databases": {},
+}
+
+# Admin interface
+logging.info("Checking adminInterface config config")
+if COUCHBASE_SYNC_GATEWAY_ADMIN_INTERFACE:
+    logging.info("Generating adminInterface config config")
+    config_dict["adminInterface"] = COUCHBASE_SYNC_GATEWAY_ADMIN_INTERFACE
+
+# CORS
+logging.info("Checking CORS config")
+if COUCHBASE_SYNC_GATEWAY_CORS_ORIGINS:
+    cors_list = COUCHBASE_SYNC_GATEWAY_CORS_ORIGINS.split(",")
+    use_cors = [origin.strip() for origin in cors_list]
+
+    logging.info("Generating CORS config")
+    config_dict["CORS"] = {
+        "Origin": use_cors,
+        "LoginOrigin": use_cors,
+        "Headers": ["Content-Type"],
+        "MaxAge": 17280000,
+    }
+
+# Couchbase
+logging.info("Checking Couchbase config")
+if COUCHBASE_HOST and COUCHBASE_SYNC_GATEWAY_USER and COUCHBASE_SYNC_GATEWAY_PASSWORD:
+    logging.info("Generating Couchbase config")
+    use_server = "http://{COUCHBASE_HOST}:{COUCHBASE_PORT}".format(
+        COUCHBASE_HOST=COUCHBASE_HOST, COUCHBASE_PORT=COUCHBASE_PORT
+    )
+
+    config_dict["databases"][COUCHBASE_SYNC_GATEWAY_DATABASE] = {
+        "server": use_server,
+        "bucket": COUCHBASE_BUCKET_NAME,
+        "username": COUCHBASE_SYNC_GATEWAY_USER,
+        "password": COUCHBASE_SYNC_GATEWAY_PASSWORD,
+        "num_index_replicas": COUCHBASE_SYNC_GATEWAY_NUM_INDEX_REPLICAS,
+        "enable_shared_bucket_access": True,
+        "import_docs": "continuous",
+        "users": {"GUEST": {"disabled": COUCHBASE_SYNC_GATEWAY_DISABLE_GUEST_USER}},
+    }
+else:
+    config_dict["databases"][COUCHBASE_SYNC_GATEWAY_DATABASE] = {
+        "server": "walrus:/opt/couchbase-sync-gateway/data",
+        "users": {
+            "GUEST": {
+                "disabled": COUCHBASE_SYNC_GATEWAY_DISABLE_GUEST_USER,
+                "admin_channels": ["*"],
+            }
+        },
+    }
+
+# JS sync function
+logging.info("Checking JavaScript sync function file")
+js_function_path = "/sync/sync-function.js"
+sync_function = ""
+logging.info("Checking JS sync function from {}".format(js_function_path))
+if os.path.isfile(js_function_path):
+    logging.info("Reading JavaScript sync function file")
+    with open(js_function_path) as f:
+        sync_function = f.read()
+if sync_function:
+    logging.info("Generating JavaScript sync function config")
+    config_dict["databases"][COUCHBASE_SYNC_GATEWAY_DATABASE]["sync"] = sync_function
+
+# Generate JSON config
+logging.info("Writing final config JSON file")
+with open("/etc/sync_gateway/config.json", "w") as f:
+    json.dump(config_dict, f, indent=2)
+logging.info("Done")

--- a/community/sync-gateway/2.0.0-devbuild/scripts/entrypoint.sh
+++ b/community/sync-gateway/2.0.0-devbuild/scripts/entrypoint.sh
@@ -1,6 +1,52 @@
 #!/bin/bash
 set -e
 
+# Check connection in a separate function, that way, when 
+# there's no connection available yet and the return of the command
+# is non-zero, the script doesn't exit yet
+check_connection() {
+    curl -Is http://${COUCHBASE_SYNC_GATEWAY_USER}:${COUCHBASE_SYNC_GATEWAY_PASSWORD}@${COUCHBASE_HOST}:${COUCHBASE_PORT}/pools/default/buckets/${COUCHBASE_BUCKET_NAME} 2>&1 | grep "HTTP/1.1 200 OK" > /dev/null
+    if [ $? -eq 0 ]; then
+        echo "success";
+    else
+        echo "error";
+    fi;
+}
+
+# Try to connect to Couchbase only if COUCHBASE_HOST was declared as an env var
+if [ ! -z $COUCHBASE_HOST ]; then
+    # Try once per second, up to 300 times (5 min)
+    SECONDS_TO_TRY=300
+    for i in $(seq 1 $SECONDS_TO_TRY); do
+        echo "Checking connection, trial ${i}";
+        result=$(check_connection);
+        if [ $result == "success" ]; then
+            echo "Success: connection checked";
+            sleep 1;
+            break;
+        else
+            echo "Connection not available yet, sleeping 1 sec...";
+            sleep 1;
+            echo "----------";
+        fi;
+    done;
+fi;
+
+config="/etc/sync_gateway/config.json"
+
+if [ ! -z $@ ]; then
+    echo "Using config provided as command parameter: $@"
+    config=$@
+else
+    if [ -f /sync/config.json ]; then
+        echo "Using provided config in: /sync/config.json";
+        config="/sync/config.json"
+    else
+        echo "No config provided in /sync/config.json, generating one from environment variables";
+        python create_config.py
+    fi;
+fi;
+
 LOGFILE_DIR=/var/log/sync_gateway
 mkdir -p $LOGFILE_DIR
 
@@ -9,4 +55,4 @@ LOGFILE_ERROR=$LOGFILE_DIR/sync_gateway_error.log
 
 # Run SG and use tee to append stdout and stderr to separate logfiles
 # Process substitution described here: https://stackoverflow.com/a/692407
-exec sync_gateway "$@" > >(tee -a $LOGFILE_ACCESS) 2> >(tee -a $LOGFILE_ERROR >&2)
+exec sync_gateway "$config" > >(tee -a $LOGFILE_ACCESS) 2> >(tee -a $LOGFILE_ERROR >&2)

--- a/community/sync-gateway/2.0.0/Dockerfile
+++ b/community/sync-gateway/2.0.0/Dockerfile
@@ -19,15 +19,15 @@ RUN wget http://packages.couchbase.com/releases/couchbase-sync-gateway/2.0.0/cou
 # Create directory where the default config stores memory snapshots to disk
 RUN mkdir /opt/couchbase-sync-gateway/data
 
-# copy the default config into the container
-COPY config/sync_gateway_config.json /etc/sync_gateway/config.json
+# Create sync file for custom config.json or generated from env vars config.json
+RUN mkdir /sync
+
+# Copy config generator from environment variables
+COPY /scripts/create_config.py /
 
 # Add bootstrap script
 COPY scripts/entrypoint.sh /
 ENTRYPOINT ["/entrypoint.sh"]
-
-# If user doesn't specify any args, use the default config
-CMD ["/etc/sync_gateway/config.json"]
 
 # Expose ports
 #  port 4984: public port

--- a/community/sync-gateway/2.0.0/scripts/create_config.py
+++ b/community/sync-gateway/2.0.0/scripts/create_config.py
@@ -1,0 +1,116 @@
+from __future__ import print_function
+import os
+import json
+import logging
+
+logging.basicConfig(level=logging.INFO)
+
+
+def getenv_boolean(var_name, default_value=False):
+    result = default_value
+    env_value = os.getenv(var_name)
+    if env_value is not None:
+        result = env_value.upper() in ("TRUE", "1")
+    return result
+
+
+# Env vars for configs
+COUCHBASE_HOST = os.getenv(
+    "COUCHBASE_HOST", ""
+)  # e.g.: "couchbase". Leave empty to use default Walrus
+COUCHBASE_PORT = os.getenv("COUCHBASE_PORT", "8091")
+COUCHBASE_BUCKET_NAME = os.getenv("COUCHBASE_BUCKET_NAME", "app")
+COUCHBASE_SYNC_GATEWAY_LOG = os.getenv(
+    "COUCHBASE_SYNC_GATEWAY_LOG", "HTTP+"
+)  # e.g.: "*"
+COUCHBASE_SYNC_GATEWAY_ADMIN_INTERFACE = os.getenv(
+    "COUCHBASE_SYNC_GATEWAY_ADMIN_INTERFACE", ""
+)  # e.g.: ":4985", leave empty to disable
+COUCHBASE_SYNC_GATEWAY_USER = os.getenv("COUCHBASE_SYNC_GATEWAY_USER", "")
+COUCHBASE_SYNC_GATEWAY_PASSWORD = os.getenv("COUCHBASE_SYNC_GATEWAY_PASSWORD", "")
+COUCHBASE_SYNC_GATEWAY_DATABASE = os.getenv("COUCHBASE_SYNC_GATEWAY_DATABASE", "db")
+COUCHBASE_SYNC_GATEWAY_CORS_ORIGINS = os.getenv(
+    "COUCHBASE_SYNC_GATEWAY_CORS_ORIGINS", ""
+)
+COUCHBASE_SYNC_GATEWAY_NUM_INDEX_REPLICAS = int(
+    os.getenv("COUCHBASE_SYNC_GATEWAY_NUM_INDEX_REPLICAS", "0")
+)
+COUCHBASE_SYNC_GATEWAY_DISABLE_GUEST_USER = getenv_boolean(
+    "COUCHBASE_SYNC_GATEWAY_DISABLE_GUEST_USER", default_value=False
+)
+
+# Base config
+logging.info("Generating base config")
+config_dict = {
+    "interface": ":4984",
+    "logging": {"console": {"log_keys": [COUCHBASE_SYNC_GATEWAY_LOG]}},
+    "databases": {},
+}
+
+# Admin interface
+logging.info("Checking adminInterface config config")
+if COUCHBASE_SYNC_GATEWAY_ADMIN_INTERFACE:
+    logging.info("Generating adminInterface config config")
+    config_dict["adminInterface"] = COUCHBASE_SYNC_GATEWAY_ADMIN_INTERFACE
+
+# CORS
+logging.info("Checking CORS config")
+if COUCHBASE_SYNC_GATEWAY_CORS_ORIGINS:
+    cors_list = COUCHBASE_SYNC_GATEWAY_CORS_ORIGINS.split(",")
+    use_cors = [origin.strip() for origin in cors_list]
+
+    logging.info("Generating CORS config")
+    config_dict["CORS"] = {
+        "Origin": use_cors,
+        "LoginOrigin": use_cors,
+        "Headers": ["Content-Type"],
+        "MaxAge": 17280000,
+    }
+
+# Couchbase
+logging.info("Checking Couchbase config")
+if COUCHBASE_HOST and COUCHBASE_SYNC_GATEWAY_USER and COUCHBASE_SYNC_GATEWAY_PASSWORD:
+    logging.info("Generating Couchbase config")
+    use_server = "http://{COUCHBASE_HOST}:{COUCHBASE_PORT}".format(
+        COUCHBASE_HOST=COUCHBASE_HOST, COUCHBASE_PORT=COUCHBASE_PORT
+    )
+
+    config_dict["databases"][COUCHBASE_SYNC_GATEWAY_DATABASE] = {
+        "server": use_server,
+        "bucket": COUCHBASE_BUCKET_NAME,
+        "username": COUCHBASE_SYNC_GATEWAY_USER,
+        "password": COUCHBASE_SYNC_GATEWAY_PASSWORD,
+        "num_index_replicas": COUCHBASE_SYNC_GATEWAY_NUM_INDEX_REPLICAS,
+        "enable_shared_bucket_access": True,
+        "import_docs": "continuous",
+        "users": {"GUEST": {"disabled": COUCHBASE_SYNC_GATEWAY_DISABLE_GUEST_USER}},
+    }
+else:
+    config_dict["databases"][COUCHBASE_SYNC_GATEWAY_DATABASE] = {
+        "server": "walrus:/opt/couchbase-sync-gateway/data",
+        "users": {
+            "GUEST": {
+                "disabled": COUCHBASE_SYNC_GATEWAY_DISABLE_GUEST_USER,
+                "admin_channels": ["*"],
+            }
+        },
+    }
+
+# JS sync function
+logging.info("Checking JavaScript sync function file")
+js_function_path = "/sync/sync-function.js"
+sync_function = ""
+logging.info("Checking JS sync function from {}".format(js_function_path))
+if os.path.isfile(js_function_path):
+    logging.info("Reading JavaScript sync function file")
+    with open(js_function_path) as f:
+        sync_function = f.read()
+if sync_function:
+    logging.info("Generating JavaScript sync function config")
+    config_dict["databases"][COUCHBASE_SYNC_GATEWAY_DATABASE]["sync"] = sync_function
+
+# Generate JSON config
+logging.info("Writing final config JSON file")
+with open("/etc/sync_gateway/config.json", "w") as f:
+    json.dump(config_dict, f, indent=2)
+logging.info("Done")

--- a/community/sync-gateway/2.0.0/scripts/entrypoint.sh
+++ b/community/sync-gateway/2.0.0/scripts/entrypoint.sh
@@ -1,6 +1,52 @@
 #!/bin/bash
 set -e
 
+# Check connection in a separate function, that way, when 
+# there's no connection available yet and the return of the command
+# is non-zero, the script doesn't exit yet
+check_connection() {
+    curl -Is http://${COUCHBASE_SYNC_GATEWAY_USER}:${COUCHBASE_SYNC_GATEWAY_PASSWORD}@${COUCHBASE_HOST}:${COUCHBASE_PORT}/pools/default/buckets/${COUCHBASE_BUCKET_NAME} 2>&1 | grep "HTTP/1.1 200 OK" > /dev/null
+    if [ $? -eq 0 ]; then
+        echo "success";
+    else
+        echo "error";
+    fi;
+}
+
+# Try to connect to Couchbase only if COUCHBASE_HOST was declared as an env var
+if [ ! -z $COUCHBASE_HOST ]; then
+    # Try once per second, up to 300 times (5 min)
+    SECONDS_TO_TRY=300
+    for i in $(seq 1 $SECONDS_TO_TRY); do
+        echo "Checking connection, trial ${i}";
+        result=$(check_connection);
+        if [ $result == "success" ]; then
+            echo "Success: connection checked";
+            sleep 1;
+            break;
+        else
+            echo "Connection not available yet, sleeping 1 sec...";
+            sleep 1;
+            echo "----------";
+        fi;
+    done;
+fi;
+
+config="/etc/sync_gateway/config.json"
+
+if [ ! -z $@ ]; then
+    echo "Using config provided as command parameter: $@"
+    config=$@
+else
+    if [ -f /sync/config.json ]; then
+        echo "Using provided config in: /sync/config.json";
+        config="/sync/config.json"
+    else
+        echo "No config provided in /sync/config.json, generating one from environment variables";
+        python create_config.py
+    fi;
+fi;
+
 LOGFILE_DIR=/var/log/sync_gateway
 mkdir -p $LOGFILE_DIR
 
@@ -9,4 +55,4 @@ LOGFILE_ERROR=$LOGFILE_DIR/sync_gateway_error.log
 
 # Run SG and use tee to append stdout and stderr to separate logfiles
 # Process substitution described here: https://stackoverflow.com/a/692407
-exec sync_gateway "$@" > >(tee -a $LOGFILE_ACCESS) 2> >(tee -a $LOGFILE_ERROR >&2)
+exec sync_gateway "$config" > >(tee -a $LOGFILE_ACCESS) 2> >(tee -a $LOGFILE_ERROR >&2)

--- a/community/sync-gateway/2.1.0/Dockerfile
+++ b/community/sync-gateway/2.1.0/Dockerfile
@@ -19,15 +19,15 @@ RUN wget http://packages.couchbase.com/releases/couchbase-sync-gateway/2.1.0/cou
 # Create directory where the default config stores memory snapshots to disk
 RUN mkdir /opt/couchbase-sync-gateway/data
 
-# copy the default config into the container
-COPY config/sync_gateway_config.json /etc/sync_gateway/config.json
+# Create sync file for custom config.json or generated from env vars config.json
+RUN mkdir /sync
+
+# Copy config generator from environment variables
+COPY /scripts/create_config.py /
 
 # Add bootstrap script
 COPY scripts/entrypoint.sh /
 ENTRYPOINT ["/entrypoint.sh"]
-
-# If user doesn't specify any args, use the default config
-CMD ["/etc/sync_gateway/config.json"]
 
 # Expose ports
 #  port 4984: public port

--- a/community/sync-gateway/2.1.0/scripts/create_config.py
+++ b/community/sync-gateway/2.1.0/scripts/create_config.py
@@ -1,0 +1,116 @@
+from __future__ import print_function
+import os
+import json
+import logging
+
+logging.basicConfig(level=logging.INFO)
+
+
+def getenv_boolean(var_name, default_value=False):
+    result = default_value
+    env_value = os.getenv(var_name)
+    if env_value is not None:
+        result = env_value.upper() in ("TRUE", "1")
+    return result
+
+
+# Env vars for configs
+COUCHBASE_HOST = os.getenv(
+    "COUCHBASE_HOST", ""
+)  # e.g.: "couchbase". Leave empty to use default Walrus
+COUCHBASE_PORT = os.getenv("COUCHBASE_PORT", "8091")
+COUCHBASE_BUCKET_NAME = os.getenv("COUCHBASE_BUCKET_NAME", "app")
+COUCHBASE_SYNC_GATEWAY_LOG = os.getenv(
+    "COUCHBASE_SYNC_GATEWAY_LOG", "HTTP+"
+)  # e.g.: "*"
+COUCHBASE_SYNC_GATEWAY_ADMIN_INTERFACE = os.getenv(
+    "COUCHBASE_SYNC_GATEWAY_ADMIN_INTERFACE", ""
+)  # e.g.: ":4985", leave empty to disable
+COUCHBASE_SYNC_GATEWAY_USER = os.getenv("COUCHBASE_SYNC_GATEWAY_USER", "")
+COUCHBASE_SYNC_GATEWAY_PASSWORD = os.getenv("COUCHBASE_SYNC_GATEWAY_PASSWORD", "")
+COUCHBASE_SYNC_GATEWAY_DATABASE = os.getenv("COUCHBASE_SYNC_GATEWAY_DATABASE", "db")
+COUCHBASE_SYNC_GATEWAY_CORS_ORIGINS = os.getenv(
+    "COUCHBASE_SYNC_GATEWAY_CORS_ORIGINS", ""
+)
+COUCHBASE_SYNC_GATEWAY_NUM_INDEX_REPLICAS = int(
+    os.getenv("COUCHBASE_SYNC_GATEWAY_NUM_INDEX_REPLICAS", "0")
+)
+COUCHBASE_SYNC_GATEWAY_DISABLE_GUEST_USER = getenv_boolean(
+    "COUCHBASE_SYNC_GATEWAY_DISABLE_GUEST_USER", default_value=False
+)
+
+# Base config
+logging.info("Generating base config")
+config_dict = {
+    "interface": ":4984",
+    "logging": {"console": {"log_keys": [COUCHBASE_SYNC_GATEWAY_LOG]}},
+    "databases": {},
+}
+
+# Admin interface
+logging.info("Checking adminInterface config config")
+if COUCHBASE_SYNC_GATEWAY_ADMIN_INTERFACE:
+    logging.info("Generating adminInterface config config")
+    config_dict["adminInterface"] = COUCHBASE_SYNC_GATEWAY_ADMIN_INTERFACE
+
+# CORS
+logging.info("Checking CORS config")
+if COUCHBASE_SYNC_GATEWAY_CORS_ORIGINS:
+    cors_list = COUCHBASE_SYNC_GATEWAY_CORS_ORIGINS.split(",")
+    use_cors = [origin.strip() for origin in cors_list]
+
+    logging.info("Generating CORS config")
+    config_dict["CORS"] = {
+        "Origin": use_cors,
+        "LoginOrigin": use_cors,
+        "Headers": ["Content-Type"],
+        "MaxAge": 17280000,
+    }
+
+# Couchbase
+logging.info("Checking Couchbase config")
+if COUCHBASE_HOST and COUCHBASE_SYNC_GATEWAY_USER and COUCHBASE_SYNC_GATEWAY_PASSWORD:
+    logging.info("Generating Couchbase config")
+    use_server = "http://{COUCHBASE_HOST}:{COUCHBASE_PORT}".format(
+        COUCHBASE_HOST=COUCHBASE_HOST, COUCHBASE_PORT=COUCHBASE_PORT
+    )
+
+    config_dict["databases"][COUCHBASE_SYNC_GATEWAY_DATABASE] = {
+        "server": use_server,
+        "bucket": COUCHBASE_BUCKET_NAME,
+        "username": COUCHBASE_SYNC_GATEWAY_USER,
+        "password": COUCHBASE_SYNC_GATEWAY_PASSWORD,
+        "num_index_replicas": COUCHBASE_SYNC_GATEWAY_NUM_INDEX_REPLICAS,
+        "enable_shared_bucket_access": True,
+        "import_docs": "continuous",
+        "users": {"GUEST": {"disabled": COUCHBASE_SYNC_GATEWAY_DISABLE_GUEST_USER}},
+    }
+else:
+    config_dict["databases"][COUCHBASE_SYNC_GATEWAY_DATABASE] = {
+        "server": "walrus:/opt/couchbase-sync-gateway/data",
+        "users": {
+            "GUEST": {
+                "disabled": COUCHBASE_SYNC_GATEWAY_DISABLE_GUEST_USER,
+                "admin_channels": ["*"],
+            }
+        },
+    }
+
+# JS sync function
+logging.info("Checking JavaScript sync function file")
+js_function_path = "/sync/sync-function.js"
+sync_function = ""
+logging.info("Checking JS sync function from {}".format(js_function_path))
+if os.path.isfile(js_function_path):
+    logging.info("Reading JavaScript sync function file")
+    with open(js_function_path) as f:
+        sync_function = f.read()
+if sync_function:
+    logging.info("Generating JavaScript sync function config")
+    config_dict["databases"][COUCHBASE_SYNC_GATEWAY_DATABASE]["sync"] = sync_function
+
+# Generate JSON config
+logging.info("Writing final config JSON file")
+with open("/etc/sync_gateway/config.json", "w") as f:
+    json.dump(config_dict, f, indent=2)
+logging.info("Done")

--- a/community/sync-gateway/2.1.0/scripts/entrypoint.sh
+++ b/community/sync-gateway/2.1.0/scripts/entrypoint.sh
@@ -1,6 +1,52 @@
 #!/bin/bash
 set -e
 
+# Check connection in a separate function, that way, when 
+# there's no connection available yet and the return of the command
+# is non-zero, the script doesn't exit yet
+check_connection() {
+    curl -Is http://${COUCHBASE_SYNC_GATEWAY_USER}:${COUCHBASE_SYNC_GATEWAY_PASSWORD}@${COUCHBASE_HOST}:${COUCHBASE_PORT}/pools/default/buckets/${COUCHBASE_BUCKET_NAME} 2>&1 | grep "HTTP/1.1 200 OK" > /dev/null
+    if [ $? -eq 0 ]; then
+        echo "success";
+    else
+        echo "error";
+    fi;
+}
+
+# Try to connect to Couchbase only if COUCHBASE_HOST was declared as an env var
+if [ ! -z $COUCHBASE_HOST ]; then
+    # Try once per second, up to 300 times (5 min)
+    SECONDS_TO_TRY=300
+    for i in $(seq 1 $SECONDS_TO_TRY); do
+        echo "Checking connection, trial ${i}";
+        result=$(check_connection);
+        if [ $result == "success" ]; then
+            echo "Success: connection checked";
+            sleep 1;
+            break;
+        else
+            echo "Connection not available yet, sleeping 1 sec...";
+            sleep 1;
+            echo "----------";
+        fi;
+    done;
+fi;
+
+config="/etc/sync_gateway/config.json"
+
+if [ ! -z $@ ]; then
+    echo "Using config provided as command parameter: $@"
+    config=$@
+else
+    if [ -f /sync/config.json ]; then
+        echo "Using provided config in: /sync/config.json";
+        config="/sync/config.json"
+    else
+        echo "No config provided in /sync/config.json, generating one from environment variables";
+        python create_config.py
+    fi;
+fi;
+
 LOGFILE_DIR=/var/log/sync_gateway
 mkdir -p $LOGFILE_DIR
 
@@ -9,4 +55,4 @@ LOGFILE_ERROR=$LOGFILE_DIR/sync_gateway_error.log
 
 # Run SG and use tee to append stdout and stderr to separate logfiles
 # Process substitution described here: https://stackoverflow.com/a/692407
-exec sync_gateway "$@" > >(tee -a $LOGFILE_ACCESS) 2> >(tee -a $LOGFILE_ERROR >&2)
+exec sync_gateway "$config" > >(tee -a $LOGFILE_ACCESS) 2> >(tee -a $LOGFILE_ERROR >&2)

--- a/community/sync-gateway/2.1.1/Dockerfile
+++ b/community/sync-gateway/2.1.1/Dockerfile
@@ -19,15 +19,15 @@ RUN wget http://packages.couchbase.com/releases/couchbase-sync-gateway/2.1.1/cou
 # Create directory where the default config stores memory snapshots to disk
 RUN mkdir /opt/couchbase-sync-gateway/data
 
-# copy the default config into the container
-COPY config/sync_gateway_config.json /etc/sync_gateway/config.json
+# Create sync file for custom config.json or generated from env vars config.json
+RUN mkdir /sync
+
+# Copy config generator from environment variables
+COPY /scripts/create_config.py /
 
 # Add bootstrap script
 COPY scripts/entrypoint.sh /
 ENTRYPOINT ["/entrypoint.sh"]
-
-# If user doesn't specify any args, use the default config
-CMD ["/etc/sync_gateway/config.json"]
 
 # Expose ports
 #  port 4984: public port

--- a/community/sync-gateway/2.1.1/scripts/create_config.py
+++ b/community/sync-gateway/2.1.1/scripts/create_config.py
@@ -1,0 +1,116 @@
+from __future__ import print_function
+import os
+import json
+import logging
+
+logging.basicConfig(level=logging.INFO)
+
+
+def getenv_boolean(var_name, default_value=False):
+    result = default_value
+    env_value = os.getenv(var_name)
+    if env_value is not None:
+        result = env_value.upper() in ("TRUE", "1")
+    return result
+
+
+# Env vars for configs
+COUCHBASE_HOST = os.getenv(
+    "COUCHBASE_HOST", ""
+)  # e.g.: "couchbase". Leave empty to use default Walrus
+COUCHBASE_PORT = os.getenv("COUCHBASE_PORT", "8091")
+COUCHBASE_BUCKET_NAME = os.getenv("COUCHBASE_BUCKET_NAME", "app")
+COUCHBASE_SYNC_GATEWAY_LOG = os.getenv(
+    "COUCHBASE_SYNC_GATEWAY_LOG", "HTTP+"
+)  # e.g.: "*"
+COUCHBASE_SYNC_GATEWAY_ADMIN_INTERFACE = os.getenv(
+    "COUCHBASE_SYNC_GATEWAY_ADMIN_INTERFACE", ""
+)  # e.g.: ":4985", leave empty to disable
+COUCHBASE_SYNC_GATEWAY_USER = os.getenv("COUCHBASE_SYNC_GATEWAY_USER", "")
+COUCHBASE_SYNC_GATEWAY_PASSWORD = os.getenv("COUCHBASE_SYNC_GATEWAY_PASSWORD", "")
+COUCHBASE_SYNC_GATEWAY_DATABASE = os.getenv("COUCHBASE_SYNC_GATEWAY_DATABASE", "db")
+COUCHBASE_SYNC_GATEWAY_CORS_ORIGINS = os.getenv(
+    "COUCHBASE_SYNC_GATEWAY_CORS_ORIGINS", ""
+)
+COUCHBASE_SYNC_GATEWAY_NUM_INDEX_REPLICAS = int(
+    os.getenv("COUCHBASE_SYNC_GATEWAY_NUM_INDEX_REPLICAS", "0")
+)
+COUCHBASE_SYNC_GATEWAY_DISABLE_GUEST_USER = getenv_boolean(
+    "COUCHBASE_SYNC_GATEWAY_DISABLE_GUEST_USER", default_value=False
+)
+
+# Base config
+logging.info("Generating base config")
+config_dict = {
+    "interface": ":4984",
+    "logging": {"console": {"log_keys": [COUCHBASE_SYNC_GATEWAY_LOG]}},
+    "databases": {},
+}
+
+# Admin interface
+logging.info("Checking adminInterface config config")
+if COUCHBASE_SYNC_GATEWAY_ADMIN_INTERFACE:
+    logging.info("Generating adminInterface config config")
+    config_dict["adminInterface"] = COUCHBASE_SYNC_GATEWAY_ADMIN_INTERFACE
+
+# CORS
+logging.info("Checking CORS config")
+if COUCHBASE_SYNC_GATEWAY_CORS_ORIGINS:
+    cors_list = COUCHBASE_SYNC_GATEWAY_CORS_ORIGINS.split(",")
+    use_cors = [origin.strip() for origin in cors_list]
+
+    logging.info("Generating CORS config")
+    config_dict["CORS"] = {
+        "Origin": use_cors,
+        "LoginOrigin": use_cors,
+        "Headers": ["Content-Type"],
+        "MaxAge": 17280000,
+    }
+
+# Couchbase
+logging.info("Checking Couchbase config")
+if COUCHBASE_HOST and COUCHBASE_SYNC_GATEWAY_USER and COUCHBASE_SYNC_GATEWAY_PASSWORD:
+    logging.info("Generating Couchbase config")
+    use_server = "http://{COUCHBASE_HOST}:{COUCHBASE_PORT}".format(
+        COUCHBASE_HOST=COUCHBASE_HOST, COUCHBASE_PORT=COUCHBASE_PORT
+    )
+
+    config_dict["databases"][COUCHBASE_SYNC_GATEWAY_DATABASE] = {
+        "server": use_server,
+        "bucket": COUCHBASE_BUCKET_NAME,
+        "username": COUCHBASE_SYNC_GATEWAY_USER,
+        "password": COUCHBASE_SYNC_GATEWAY_PASSWORD,
+        "num_index_replicas": COUCHBASE_SYNC_GATEWAY_NUM_INDEX_REPLICAS,
+        "enable_shared_bucket_access": True,
+        "import_docs": "continuous",
+        "users": {"GUEST": {"disabled": COUCHBASE_SYNC_GATEWAY_DISABLE_GUEST_USER}},
+    }
+else:
+    config_dict["databases"][COUCHBASE_SYNC_GATEWAY_DATABASE] = {
+        "server": "walrus:/opt/couchbase-sync-gateway/data",
+        "users": {
+            "GUEST": {
+                "disabled": COUCHBASE_SYNC_GATEWAY_DISABLE_GUEST_USER,
+                "admin_channels": ["*"],
+            }
+        },
+    }
+
+# JS sync function
+logging.info("Checking JavaScript sync function file")
+js_function_path = "/sync/sync-function.js"
+sync_function = ""
+logging.info("Checking JS sync function from {}".format(js_function_path))
+if os.path.isfile(js_function_path):
+    logging.info("Reading JavaScript sync function file")
+    with open(js_function_path) as f:
+        sync_function = f.read()
+if sync_function:
+    logging.info("Generating JavaScript sync function config")
+    config_dict["databases"][COUCHBASE_SYNC_GATEWAY_DATABASE]["sync"] = sync_function
+
+# Generate JSON config
+logging.info("Writing final config JSON file")
+with open("/etc/sync_gateway/config.json", "w") as f:
+    json.dump(config_dict, f, indent=2)
+logging.info("Done")

--- a/community/sync-gateway/2.1.1/scripts/entrypoint.sh
+++ b/community/sync-gateway/2.1.1/scripts/entrypoint.sh
@@ -1,6 +1,52 @@
 #!/bin/bash
 set -e
 
+# Check connection in a separate function, that way, when 
+# there's no connection available yet and the return of the command
+# is non-zero, the script doesn't exit yet
+check_connection() {
+    curl -Is http://${COUCHBASE_SYNC_GATEWAY_USER}:${COUCHBASE_SYNC_GATEWAY_PASSWORD}@${COUCHBASE_HOST}:${COUCHBASE_PORT}/pools/default/buckets/${COUCHBASE_BUCKET_NAME} 2>&1 | grep "HTTP/1.1 200 OK" > /dev/null
+    if [ $? -eq 0 ]; then
+        echo "success";
+    else
+        echo "error";
+    fi;
+}
+
+# Try to connect to Couchbase only if COUCHBASE_HOST was declared as an env var
+if [ ! -z $COUCHBASE_HOST ]; then
+    # Try once per second, up to 300 times (5 min)
+    SECONDS_TO_TRY=300
+    for i in $(seq 1 $SECONDS_TO_TRY); do
+        echo "Checking connection, trial ${i}";
+        result=$(check_connection);
+        if [ $result == "success" ]; then
+            echo "Success: connection checked";
+            sleep 1;
+            break;
+        else
+            echo "Connection not available yet, sleeping 1 sec...";
+            sleep 1;
+            echo "----------";
+        fi;
+    done;
+fi;
+
+config="/etc/sync_gateway/config.json"
+
+if [ ! -z $@ ]; then
+    echo "Using config provided as command parameter: $@"
+    config=$@
+else
+    if [ -f /sync/config.json ]; then
+        echo "Using provided config in: /sync/config.json";
+        config="/sync/config.json"
+    else
+        echo "No config provided in /sync/config.json, generating one from environment variables";
+        python create_config.py
+    fi;
+fi;
+
 LOGFILE_DIR=/var/log/sync_gateway
 mkdir -p $LOGFILE_DIR
 
@@ -9,4 +55,4 @@ LOGFILE_ERROR=$LOGFILE_DIR/sync_gateway_error.log
 
 # Run SG and use tee to append stdout and stderr to separate logfiles
 # Process substitution described here: https://stackoverflow.com/a/692407
-exec sync_gateway "$@" > >(tee -a $LOGFILE_ACCESS) 2> >(tee -a $LOGFILE_ERROR >&2)
+exec sync_gateway "$config" > >(tee -a $LOGFILE_ACCESS) 2> >(tee -a $LOGFILE_ERROR >&2)

--- a/enterprise/sync-gateway/1.3.0-274/Dockerfile
+++ b/enterprise/sync-gateway/1.3.0-274/Dockerfile
@@ -19,15 +19,15 @@ RUN wget http://packages.couchbase.com/releases/couchbase-sync-gateway/1.3.0/cou
 # Create directory where the default config stores memory snapshots to disk
 RUN mkdir /opt/couchbase-sync-gateway/data
 
-# copy the default config into the container
-COPY config/sync_gateway_config.json /etc/sync_gateway/config.json
+# Create sync file for custom config.json or generated from env vars config.json
+RUN mkdir /sync
+
+# Copy config generator from environment variables
+COPY /scripts/create_config.py /
 
 # Add bootstrap script
 COPY scripts/entrypoint.sh /
 ENTRYPOINT ["/entrypoint.sh"]
-
-# If user doesn't specify any args, use the default config
-CMD ["/etc/sync_gateway/config.json"]
 
 # Expose ports
 #  port 4984: public port

--- a/enterprise/sync-gateway/1.3.0-274/scripts/create_config.py
+++ b/enterprise/sync-gateway/1.3.0-274/scripts/create_config.py
@@ -1,0 +1,116 @@
+from __future__ import print_function
+import os
+import json
+import logging
+
+logging.basicConfig(level=logging.INFO)
+
+
+def getenv_boolean(var_name, default_value=False):
+    result = default_value
+    env_value = os.getenv(var_name)
+    if env_value is not None:
+        result = env_value.upper() in ("TRUE", "1")
+    return result
+
+
+# Env vars for configs
+COUCHBASE_HOST = os.getenv(
+    "COUCHBASE_HOST", ""
+)  # e.g.: "couchbase". Leave empty to use default Walrus
+COUCHBASE_PORT = os.getenv("COUCHBASE_PORT", "8091")
+COUCHBASE_BUCKET_NAME = os.getenv("COUCHBASE_BUCKET_NAME", "app")
+COUCHBASE_SYNC_GATEWAY_LOG = os.getenv(
+    "COUCHBASE_SYNC_GATEWAY_LOG", "HTTP+"
+)  # e.g.: "*"
+COUCHBASE_SYNC_GATEWAY_ADMIN_INTERFACE = os.getenv(
+    "COUCHBASE_SYNC_GATEWAY_ADMIN_INTERFACE", ""
+)  # e.g.: ":4985", leave empty to disable
+COUCHBASE_SYNC_GATEWAY_USER = os.getenv("COUCHBASE_SYNC_GATEWAY_USER", "")
+COUCHBASE_SYNC_GATEWAY_PASSWORD = os.getenv("COUCHBASE_SYNC_GATEWAY_PASSWORD", "")
+COUCHBASE_SYNC_GATEWAY_DATABASE = os.getenv("COUCHBASE_SYNC_GATEWAY_DATABASE", "db")
+COUCHBASE_SYNC_GATEWAY_CORS_ORIGINS = os.getenv(
+    "COUCHBASE_SYNC_GATEWAY_CORS_ORIGINS", ""
+)
+COUCHBASE_SYNC_GATEWAY_NUM_INDEX_REPLICAS = int(
+    os.getenv("COUCHBASE_SYNC_GATEWAY_NUM_INDEX_REPLICAS", "0")
+)
+COUCHBASE_SYNC_GATEWAY_DISABLE_GUEST_USER = getenv_boolean(
+    "COUCHBASE_SYNC_GATEWAY_DISABLE_GUEST_USER", default_value=False
+)
+
+# Base config
+logging.info("Generating base config")
+config_dict = {
+    "interface": ":4984",
+    "logging": {"console": {"log_keys": [COUCHBASE_SYNC_GATEWAY_LOG]}},
+    "databases": {},
+}
+
+# Admin interface
+logging.info("Checking adminInterface config config")
+if COUCHBASE_SYNC_GATEWAY_ADMIN_INTERFACE:
+    logging.info("Generating adminInterface config config")
+    config_dict["adminInterface"] = COUCHBASE_SYNC_GATEWAY_ADMIN_INTERFACE
+
+# CORS
+logging.info("Checking CORS config")
+if COUCHBASE_SYNC_GATEWAY_CORS_ORIGINS:
+    cors_list = COUCHBASE_SYNC_GATEWAY_CORS_ORIGINS.split(",")
+    use_cors = [origin.strip() for origin in cors_list]
+
+    logging.info("Generating CORS config")
+    config_dict["CORS"] = {
+        "Origin": use_cors,
+        "LoginOrigin": use_cors,
+        "Headers": ["Content-Type"],
+        "MaxAge": 17280000,
+    }
+
+# Couchbase
+logging.info("Checking Couchbase config")
+if COUCHBASE_HOST and COUCHBASE_SYNC_GATEWAY_USER and COUCHBASE_SYNC_GATEWAY_PASSWORD:
+    logging.info("Generating Couchbase config")
+    use_server = "http://{COUCHBASE_HOST}:{COUCHBASE_PORT}".format(
+        COUCHBASE_HOST=COUCHBASE_HOST, COUCHBASE_PORT=COUCHBASE_PORT
+    )
+
+    config_dict["databases"][COUCHBASE_SYNC_GATEWAY_DATABASE] = {
+        "server": use_server,
+        "bucket": COUCHBASE_BUCKET_NAME,
+        "username": COUCHBASE_SYNC_GATEWAY_USER,
+        "password": COUCHBASE_SYNC_GATEWAY_PASSWORD,
+        "num_index_replicas": COUCHBASE_SYNC_GATEWAY_NUM_INDEX_REPLICAS,
+        "enable_shared_bucket_access": True,
+        "import_docs": "continuous",
+        "users": {"GUEST": {"disabled": COUCHBASE_SYNC_GATEWAY_DISABLE_GUEST_USER}},
+    }
+else:
+    config_dict["databases"][COUCHBASE_SYNC_GATEWAY_DATABASE] = {
+        "server": "walrus:/opt/couchbase-sync-gateway/data",
+        "users": {
+            "GUEST": {
+                "disabled": COUCHBASE_SYNC_GATEWAY_DISABLE_GUEST_USER,
+                "admin_channels": ["*"],
+            }
+        },
+    }
+
+# JS sync function
+logging.info("Checking JavaScript sync function file")
+js_function_path = "/sync/sync-function.js"
+sync_function = ""
+logging.info("Checking JS sync function from {}".format(js_function_path))
+if os.path.isfile(js_function_path):
+    logging.info("Reading JavaScript sync function file")
+    with open(js_function_path) as f:
+        sync_function = f.read()
+if sync_function:
+    logging.info("Generating JavaScript sync function config")
+    config_dict["databases"][COUCHBASE_SYNC_GATEWAY_DATABASE]["sync"] = sync_function
+
+# Generate JSON config
+logging.info("Writing final config JSON file")
+with open("/etc/sync_gateway/config.json", "w") as f:
+    json.dump(config_dict, f, indent=2)
+logging.info("Done")

--- a/enterprise/sync-gateway/1.3.0-274/scripts/entrypoint.sh
+++ b/enterprise/sync-gateway/1.3.0-274/scripts/entrypoint.sh
@@ -1,6 +1,52 @@
 #!/bin/bash
 set -e
 
+# Check connection in a separate function, that way, when 
+# there's no connection available yet and the return of the command
+# is non-zero, the script doesn't exit yet
+check_connection() {
+    curl -Is http://${COUCHBASE_SYNC_GATEWAY_USER}:${COUCHBASE_SYNC_GATEWAY_PASSWORD}@${COUCHBASE_HOST}:${COUCHBASE_PORT}/pools/default/buckets/${COUCHBASE_BUCKET_NAME} 2>&1 | grep "HTTP/1.1 200 OK" > /dev/null
+    if [ $? -eq 0 ]; then
+        echo "success";
+    else
+        echo "error";
+    fi;
+}
+
+# Try to connect to Couchbase only if COUCHBASE_HOST was declared as an env var
+if [ ! -z $COUCHBASE_HOST ]; then
+    # Try once per second, up to 300 times (5 min)
+    SECONDS_TO_TRY=300
+    for i in $(seq 1 $SECONDS_TO_TRY); do
+        echo "Checking connection, trial ${i}";
+        result=$(check_connection);
+        if [ $result == "success" ]; then
+            echo "Success: connection checked";
+            sleep 1;
+            break;
+        else
+            echo "Connection not available yet, sleeping 1 sec...";
+            sleep 1;
+            echo "----------";
+        fi;
+    done;
+fi;
+
+config="/etc/sync_gateway/config.json"
+
+if [ ! -z $@ ]; then
+    echo "Using config provided as command parameter: $@"
+    config=$@
+else
+    if [ -f /sync/config.json ]; then
+        echo "Using provided config in: /sync/config.json";
+        config="/sync/config.json"
+    else
+        echo "No config provided in /sync/config.json, generating one from environment variables";
+        python create_config.py
+    fi;
+fi;
+
 LOGFILE_DIR=/var/log/sync_gateway
 mkdir -p $LOGFILE_DIR
 
@@ -9,4 +55,4 @@ LOGFILE_ERROR=$LOGFILE_DIR/sync_gateway_error.log
 
 # Run SG and use tee to append stdout and stderr to separate logfiles
 # Process substitution described here: https://stackoverflow.com/a/692407
-exec sync_gateway "$@" > >(tee -a $LOGFILE_ACCESS) 2> >(tee -a $LOGFILE_ERROR >&2)
+exec sync_gateway "$config" > >(tee -a $LOGFILE_ACCESS) 2> >(tee -a $LOGFILE_ERROR >&2)

--- a/enterprise/sync-gateway/1.3.1-16/Dockerfile
+++ b/enterprise/sync-gateway/1.3.1-16/Dockerfile
@@ -19,15 +19,15 @@ RUN wget http://packages.couchbase.com/releases/couchbase-sync-gateway/1.3.1/cou
 # Create directory where the default config stores memory snapshots to disk
 RUN mkdir /opt/couchbase-sync-gateway/data
 
-# copy the default config into the container
-COPY config/sync_gateway_config.json /etc/sync_gateway/config.json
+# Create sync file for custom config.json or generated from env vars config.json
+RUN mkdir /sync
+
+# Copy config generator from environment variables
+COPY /scripts/create_config.py /
 
 # Add bootstrap script
 COPY scripts/entrypoint.sh /
 ENTRYPOINT ["/entrypoint.sh"]
-
-# If user doesn't specify any args, use the default config
-CMD ["/etc/sync_gateway/config.json"]
 
 # Expose ports
 #  port 4984: public port

--- a/enterprise/sync-gateway/1.3.1-16/scripts/create_config.py
+++ b/enterprise/sync-gateway/1.3.1-16/scripts/create_config.py
@@ -1,0 +1,116 @@
+from __future__ import print_function
+import os
+import json
+import logging
+
+logging.basicConfig(level=logging.INFO)
+
+
+def getenv_boolean(var_name, default_value=False):
+    result = default_value
+    env_value = os.getenv(var_name)
+    if env_value is not None:
+        result = env_value.upper() in ("TRUE", "1")
+    return result
+
+
+# Env vars for configs
+COUCHBASE_HOST = os.getenv(
+    "COUCHBASE_HOST", ""
+)  # e.g.: "couchbase". Leave empty to use default Walrus
+COUCHBASE_PORT = os.getenv("COUCHBASE_PORT", "8091")
+COUCHBASE_BUCKET_NAME = os.getenv("COUCHBASE_BUCKET_NAME", "app")
+COUCHBASE_SYNC_GATEWAY_LOG = os.getenv(
+    "COUCHBASE_SYNC_GATEWAY_LOG", "HTTP+"
+)  # e.g.: "*"
+COUCHBASE_SYNC_GATEWAY_ADMIN_INTERFACE = os.getenv(
+    "COUCHBASE_SYNC_GATEWAY_ADMIN_INTERFACE", ""
+)  # e.g.: ":4985", leave empty to disable
+COUCHBASE_SYNC_GATEWAY_USER = os.getenv("COUCHBASE_SYNC_GATEWAY_USER", "")
+COUCHBASE_SYNC_GATEWAY_PASSWORD = os.getenv("COUCHBASE_SYNC_GATEWAY_PASSWORD", "")
+COUCHBASE_SYNC_GATEWAY_DATABASE = os.getenv("COUCHBASE_SYNC_GATEWAY_DATABASE", "db")
+COUCHBASE_SYNC_GATEWAY_CORS_ORIGINS = os.getenv(
+    "COUCHBASE_SYNC_GATEWAY_CORS_ORIGINS", ""
+)
+COUCHBASE_SYNC_GATEWAY_NUM_INDEX_REPLICAS = int(
+    os.getenv("COUCHBASE_SYNC_GATEWAY_NUM_INDEX_REPLICAS", "0")
+)
+COUCHBASE_SYNC_GATEWAY_DISABLE_GUEST_USER = getenv_boolean(
+    "COUCHBASE_SYNC_GATEWAY_DISABLE_GUEST_USER", default_value=False
+)
+
+# Base config
+logging.info("Generating base config")
+config_dict = {
+    "interface": ":4984",
+    "logging": {"console": {"log_keys": [COUCHBASE_SYNC_GATEWAY_LOG]}},
+    "databases": {},
+}
+
+# Admin interface
+logging.info("Checking adminInterface config config")
+if COUCHBASE_SYNC_GATEWAY_ADMIN_INTERFACE:
+    logging.info("Generating adminInterface config config")
+    config_dict["adminInterface"] = COUCHBASE_SYNC_GATEWAY_ADMIN_INTERFACE
+
+# CORS
+logging.info("Checking CORS config")
+if COUCHBASE_SYNC_GATEWAY_CORS_ORIGINS:
+    cors_list = COUCHBASE_SYNC_GATEWAY_CORS_ORIGINS.split(",")
+    use_cors = [origin.strip() for origin in cors_list]
+
+    logging.info("Generating CORS config")
+    config_dict["CORS"] = {
+        "Origin": use_cors,
+        "LoginOrigin": use_cors,
+        "Headers": ["Content-Type"],
+        "MaxAge": 17280000,
+    }
+
+# Couchbase
+logging.info("Checking Couchbase config")
+if COUCHBASE_HOST and COUCHBASE_SYNC_GATEWAY_USER and COUCHBASE_SYNC_GATEWAY_PASSWORD:
+    logging.info("Generating Couchbase config")
+    use_server = "http://{COUCHBASE_HOST}:{COUCHBASE_PORT}".format(
+        COUCHBASE_HOST=COUCHBASE_HOST, COUCHBASE_PORT=COUCHBASE_PORT
+    )
+
+    config_dict["databases"][COUCHBASE_SYNC_GATEWAY_DATABASE] = {
+        "server": use_server,
+        "bucket": COUCHBASE_BUCKET_NAME,
+        "username": COUCHBASE_SYNC_GATEWAY_USER,
+        "password": COUCHBASE_SYNC_GATEWAY_PASSWORD,
+        "num_index_replicas": COUCHBASE_SYNC_GATEWAY_NUM_INDEX_REPLICAS,
+        "enable_shared_bucket_access": True,
+        "import_docs": "continuous",
+        "users": {"GUEST": {"disabled": COUCHBASE_SYNC_GATEWAY_DISABLE_GUEST_USER}},
+    }
+else:
+    config_dict["databases"][COUCHBASE_SYNC_GATEWAY_DATABASE] = {
+        "server": "walrus:/opt/couchbase-sync-gateway/data",
+        "users": {
+            "GUEST": {
+                "disabled": COUCHBASE_SYNC_GATEWAY_DISABLE_GUEST_USER,
+                "admin_channels": ["*"],
+            }
+        },
+    }
+
+# JS sync function
+logging.info("Checking JavaScript sync function file")
+js_function_path = "/sync/sync-function.js"
+sync_function = ""
+logging.info("Checking JS sync function from {}".format(js_function_path))
+if os.path.isfile(js_function_path):
+    logging.info("Reading JavaScript sync function file")
+    with open(js_function_path) as f:
+        sync_function = f.read()
+if sync_function:
+    logging.info("Generating JavaScript sync function config")
+    config_dict["databases"][COUCHBASE_SYNC_GATEWAY_DATABASE]["sync"] = sync_function
+
+# Generate JSON config
+logging.info("Writing final config JSON file")
+with open("/etc/sync_gateway/config.json", "w") as f:
+    json.dump(config_dict, f, indent=2)
+logging.info("Done")

--- a/enterprise/sync-gateway/1.3.1-16/scripts/entrypoint.sh
+++ b/enterprise/sync-gateway/1.3.1-16/scripts/entrypoint.sh
@@ -1,6 +1,52 @@
 #!/bin/bash
 set -e
 
+# Check connection in a separate function, that way, when 
+# there's no connection available yet and the return of the command
+# is non-zero, the script doesn't exit yet
+check_connection() {
+    curl -Is http://${COUCHBASE_SYNC_GATEWAY_USER}:${COUCHBASE_SYNC_GATEWAY_PASSWORD}@${COUCHBASE_HOST}:${COUCHBASE_PORT}/pools/default/buckets/${COUCHBASE_BUCKET_NAME} 2>&1 | grep "HTTP/1.1 200 OK" > /dev/null
+    if [ $? -eq 0 ]; then
+        echo "success";
+    else
+        echo "error";
+    fi;
+}
+
+# Try to connect to Couchbase only if COUCHBASE_HOST was declared as an env var
+if [ ! -z $COUCHBASE_HOST ]; then
+    # Try once per second, up to 300 times (5 min)
+    SECONDS_TO_TRY=300
+    for i in $(seq 1 $SECONDS_TO_TRY); do
+        echo "Checking connection, trial ${i}";
+        result=$(check_connection);
+        if [ $result == "success" ]; then
+            echo "Success: connection checked";
+            sleep 1;
+            break;
+        else
+            echo "Connection not available yet, sleeping 1 sec...";
+            sleep 1;
+            echo "----------";
+        fi;
+    done;
+fi;
+
+config="/etc/sync_gateway/config.json"
+
+if [ ! -z $@ ]; then
+    echo "Using config provided as command parameter: $@"
+    config=$@
+else
+    if [ -f /sync/config.json ]; then
+        echo "Using provided config in: /sync/config.json";
+        config="/sync/config.json"
+    else
+        echo "No config provided in /sync/config.json, generating one from environment variables";
+        python create_config.py
+    fi;
+fi;
+
 LOGFILE_DIR=/var/log/sync_gateway
 mkdir -p $LOGFILE_DIR
 
@@ -9,4 +55,4 @@ LOGFILE_ERROR=$LOGFILE_DIR/sync_gateway_error.log
 
 # Run SG and use tee to append stdout and stderr to separate logfiles
 # Process substitution described here: https://stackoverflow.com/a/692407
-exec sync_gateway "$@" > >(tee -a $LOGFILE_ACCESS) 2> >(tee -a $LOGFILE_ERROR >&2)
+exec sync_gateway "$config" > >(tee -a $LOGFILE_ACCESS) 2> >(tee -a $LOGFILE_ERROR >&2)

--- a/enterprise/sync-gateway/1.4.1-3/Dockerfile
+++ b/enterprise/sync-gateway/1.4.1-3/Dockerfile
@@ -19,15 +19,15 @@ RUN wget http://packages.couchbase.com/releases/couchbase-sync-gateway/1.4.1/cou
 # Create directory where the default config stores memory snapshots to disk
 RUN mkdir /opt/couchbase-sync-gateway/data
 
-# copy the default config into the container
-COPY config/sync_gateway_config.json /etc/sync_gateway/config.json
+# Create sync file for custom config.json or generated from env vars config.json
+RUN mkdir /sync
+
+# Copy config generator from environment variables
+COPY /scripts/create_config.py /
 
 # Add bootstrap script
 COPY scripts/entrypoint.sh /
 ENTRYPOINT ["/entrypoint.sh"]
-
-# If user doesn't specify any args, use the default config
-CMD ["/etc/sync_gateway/config.json"]
 
 # Expose ports
 #  port 4984: public port

--- a/enterprise/sync-gateway/1.4.1-3/scripts/create_config.py
+++ b/enterprise/sync-gateway/1.4.1-3/scripts/create_config.py
@@ -1,0 +1,116 @@
+from __future__ import print_function
+import os
+import json
+import logging
+
+logging.basicConfig(level=logging.INFO)
+
+
+def getenv_boolean(var_name, default_value=False):
+    result = default_value
+    env_value = os.getenv(var_name)
+    if env_value is not None:
+        result = env_value.upper() in ("TRUE", "1")
+    return result
+
+
+# Env vars for configs
+COUCHBASE_HOST = os.getenv(
+    "COUCHBASE_HOST", ""
+)  # e.g.: "couchbase". Leave empty to use default Walrus
+COUCHBASE_PORT = os.getenv("COUCHBASE_PORT", "8091")
+COUCHBASE_BUCKET_NAME = os.getenv("COUCHBASE_BUCKET_NAME", "app")
+COUCHBASE_SYNC_GATEWAY_LOG = os.getenv(
+    "COUCHBASE_SYNC_GATEWAY_LOG", "HTTP+"
+)  # e.g.: "*"
+COUCHBASE_SYNC_GATEWAY_ADMIN_INTERFACE = os.getenv(
+    "COUCHBASE_SYNC_GATEWAY_ADMIN_INTERFACE", ""
+)  # e.g.: ":4985", leave empty to disable
+COUCHBASE_SYNC_GATEWAY_USER = os.getenv("COUCHBASE_SYNC_GATEWAY_USER", "")
+COUCHBASE_SYNC_GATEWAY_PASSWORD = os.getenv("COUCHBASE_SYNC_GATEWAY_PASSWORD", "")
+COUCHBASE_SYNC_GATEWAY_DATABASE = os.getenv("COUCHBASE_SYNC_GATEWAY_DATABASE", "db")
+COUCHBASE_SYNC_GATEWAY_CORS_ORIGINS = os.getenv(
+    "COUCHBASE_SYNC_GATEWAY_CORS_ORIGINS", ""
+)
+COUCHBASE_SYNC_GATEWAY_NUM_INDEX_REPLICAS = int(
+    os.getenv("COUCHBASE_SYNC_GATEWAY_NUM_INDEX_REPLICAS", "0")
+)
+COUCHBASE_SYNC_GATEWAY_DISABLE_GUEST_USER = getenv_boolean(
+    "COUCHBASE_SYNC_GATEWAY_DISABLE_GUEST_USER", default_value=False
+)
+
+# Base config
+logging.info("Generating base config")
+config_dict = {
+    "interface": ":4984",
+    "logging": {"console": {"log_keys": [COUCHBASE_SYNC_GATEWAY_LOG]}},
+    "databases": {},
+}
+
+# Admin interface
+logging.info("Checking adminInterface config config")
+if COUCHBASE_SYNC_GATEWAY_ADMIN_INTERFACE:
+    logging.info("Generating adminInterface config config")
+    config_dict["adminInterface"] = COUCHBASE_SYNC_GATEWAY_ADMIN_INTERFACE
+
+# CORS
+logging.info("Checking CORS config")
+if COUCHBASE_SYNC_GATEWAY_CORS_ORIGINS:
+    cors_list = COUCHBASE_SYNC_GATEWAY_CORS_ORIGINS.split(",")
+    use_cors = [origin.strip() for origin in cors_list]
+
+    logging.info("Generating CORS config")
+    config_dict["CORS"] = {
+        "Origin": use_cors,
+        "LoginOrigin": use_cors,
+        "Headers": ["Content-Type"],
+        "MaxAge": 17280000,
+    }
+
+# Couchbase
+logging.info("Checking Couchbase config")
+if COUCHBASE_HOST and COUCHBASE_SYNC_GATEWAY_USER and COUCHBASE_SYNC_GATEWAY_PASSWORD:
+    logging.info("Generating Couchbase config")
+    use_server = "http://{COUCHBASE_HOST}:{COUCHBASE_PORT}".format(
+        COUCHBASE_HOST=COUCHBASE_HOST, COUCHBASE_PORT=COUCHBASE_PORT
+    )
+
+    config_dict["databases"][COUCHBASE_SYNC_GATEWAY_DATABASE] = {
+        "server": use_server,
+        "bucket": COUCHBASE_BUCKET_NAME,
+        "username": COUCHBASE_SYNC_GATEWAY_USER,
+        "password": COUCHBASE_SYNC_GATEWAY_PASSWORD,
+        "num_index_replicas": COUCHBASE_SYNC_GATEWAY_NUM_INDEX_REPLICAS,
+        "enable_shared_bucket_access": True,
+        "import_docs": "continuous",
+        "users": {"GUEST": {"disabled": COUCHBASE_SYNC_GATEWAY_DISABLE_GUEST_USER}},
+    }
+else:
+    config_dict["databases"][COUCHBASE_SYNC_GATEWAY_DATABASE] = {
+        "server": "walrus:/opt/couchbase-sync-gateway/data",
+        "users": {
+            "GUEST": {
+                "disabled": COUCHBASE_SYNC_GATEWAY_DISABLE_GUEST_USER,
+                "admin_channels": ["*"],
+            }
+        },
+    }
+
+# JS sync function
+logging.info("Checking JavaScript sync function file")
+js_function_path = "/sync/sync-function.js"
+sync_function = ""
+logging.info("Checking JS sync function from {}".format(js_function_path))
+if os.path.isfile(js_function_path):
+    logging.info("Reading JavaScript sync function file")
+    with open(js_function_path) as f:
+        sync_function = f.read()
+if sync_function:
+    logging.info("Generating JavaScript sync function config")
+    config_dict["databases"][COUCHBASE_SYNC_GATEWAY_DATABASE]["sync"] = sync_function
+
+# Generate JSON config
+logging.info("Writing final config JSON file")
+with open("/etc/sync_gateway/config.json", "w") as f:
+    json.dump(config_dict, f, indent=2)
+logging.info("Done")

--- a/enterprise/sync-gateway/1.4.1-3/scripts/entrypoint.sh
+++ b/enterprise/sync-gateway/1.4.1-3/scripts/entrypoint.sh
@@ -1,6 +1,52 @@
 #!/bin/bash
 set -e
 
+# Check connection in a separate function, that way, when 
+# there's no connection available yet and the return of the command
+# is non-zero, the script doesn't exit yet
+check_connection() {
+    curl -Is http://${COUCHBASE_SYNC_GATEWAY_USER}:${COUCHBASE_SYNC_GATEWAY_PASSWORD}@${COUCHBASE_HOST}:${COUCHBASE_PORT}/pools/default/buckets/${COUCHBASE_BUCKET_NAME} 2>&1 | grep "HTTP/1.1 200 OK" > /dev/null
+    if [ $? -eq 0 ]; then
+        echo "success";
+    else
+        echo "error";
+    fi;
+}
+
+# Try to connect to Couchbase only if COUCHBASE_HOST was declared as an env var
+if [ ! -z $COUCHBASE_HOST ]; then
+    # Try once per second, up to 300 times (5 min)
+    SECONDS_TO_TRY=300
+    for i in $(seq 1 $SECONDS_TO_TRY); do
+        echo "Checking connection, trial ${i}";
+        result=$(check_connection);
+        if [ $result == "success" ]; then
+            echo "Success: connection checked";
+            sleep 1;
+            break;
+        else
+            echo "Connection not available yet, sleeping 1 sec...";
+            sleep 1;
+            echo "----------";
+        fi;
+    done;
+fi;
+
+config="/etc/sync_gateway/config.json"
+
+if [ ! -z $@ ]; then
+    echo "Using config provided as command parameter: $@"
+    config=$@
+else
+    if [ -f /sync/config.json ]; then
+        echo "Using provided config in: /sync/config.json";
+        config="/sync/config.json"
+    else
+        echo "No config provided in /sync/config.json, generating one from environment variables";
+        python create_config.py
+    fi;
+fi;
+
 LOGFILE_DIR=/var/log/sync_gateway
 mkdir -p $LOGFILE_DIR
 
@@ -9,4 +55,4 @@ LOGFILE_ERROR=$LOGFILE_DIR/sync_gateway_error.log
 
 # Run SG and use tee to append stdout and stderr to separate logfiles
 # Process substitution described here: https://stackoverflow.com/a/692407
-exec sync_gateway "$@" > >(tee -a $LOGFILE_ACCESS) 2> >(tee -a $LOGFILE_ERROR >&2)
+exec sync_gateway "$config" > >(tee -a $LOGFILE_ACCESS) 2> >(tee -a $LOGFILE_ERROR >&2)

--- a/enterprise/sync-gateway/1.5.0-377/Dockerfile
+++ b/enterprise/sync-gateway/1.5.0-377/Dockerfile
@@ -19,15 +19,15 @@ RUN wget http://packages.couchbase.com/releases/couchbase-sync-gateway/1.5.0/cou
 # Create directory where the default config stores memory snapshots to disk
 RUN mkdir /opt/couchbase-sync-gateway/data
 
-# copy the default config into the container
-COPY config/sync_gateway_config.json /etc/sync_gateway/config.json
+# Create sync file for custom config.json or generated from env vars config.json
+RUN mkdir /sync
+
+# Copy config generator from environment variables
+COPY /scripts/create_config.py /
 
 # Add bootstrap script
 COPY scripts/entrypoint.sh /
 ENTRYPOINT ["/entrypoint.sh"]
-
-# If user doesn't specify any args, use the default config
-CMD ["/etc/sync_gateway/config.json"]
 
 # Expose ports
 #  port 4984: public port

--- a/enterprise/sync-gateway/1.5.0-377/scripts/create_config.py
+++ b/enterprise/sync-gateway/1.5.0-377/scripts/create_config.py
@@ -1,0 +1,116 @@
+from __future__ import print_function
+import os
+import json
+import logging
+
+logging.basicConfig(level=logging.INFO)
+
+
+def getenv_boolean(var_name, default_value=False):
+    result = default_value
+    env_value = os.getenv(var_name)
+    if env_value is not None:
+        result = env_value.upper() in ("TRUE", "1")
+    return result
+
+
+# Env vars for configs
+COUCHBASE_HOST = os.getenv(
+    "COUCHBASE_HOST", ""
+)  # e.g.: "couchbase". Leave empty to use default Walrus
+COUCHBASE_PORT = os.getenv("COUCHBASE_PORT", "8091")
+COUCHBASE_BUCKET_NAME = os.getenv("COUCHBASE_BUCKET_NAME", "app")
+COUCHBASE_SYNC_GATEWAY_LOG = os.getenv(
+    "COUCHBASE_SYNC_GATEWAY_LOG", "HTTP+"
+)  # e.g.: "*"
+COUCHBASE_SYNC_GATEWAY_ADMIN_INTERFACE = os.getenv(
+    "COUCHBASE_SYNC_GATEWAY_ADMIN_INTERFACE", ""
+)  # e.g.: ":4985", leave empty to disable
+COUCHBASE_SYNC_GATEWAY_USER = os.getenv("COUCHBASE_SYNC_GATEWAY_USER", "")
+COUCHBASE_SYNC_GATEWAY_PASSWORD = os.getenv("COUCHBASE_SYNC_GATEWAY_PASSWORD", "")
+COUCHBASE_SYNC_GATEWAY_DATABASE = os.getenv("COUCHBASE_SYNC_GATEWAY_DATABASE", "db")
+COUCHBASE_SYNC_GATEWAY_CORS_ORIGINS = os.getenv(
+    "COUCHBASE_SYNC_GATEWAY_CORS_ORIGINS", ""
+)
+COUCHBASE_SYNC_GATEWAY_NUM_INDEX_REPLICAS = int(
+    os.getenv("COUCHBASE_SYNC_GATEWAY_NUM_INDEX_REPLICAS", "0")
+)
+COUCHBASE_SYNC_GATEWAY_DISABLE_GUEST_USER = getenv_boolean(
+    "COUCHBASE_SYNC_GATEWAY_DISABLE_GUEST_USER", default_value=False
+)
+
+# Base config
+logging.info("Generating base config")
+config_dict = {
+    "interface": ":4984",
+    "logging": {"console": {"log_keys": [COUCHBASE_SYNC_GATEWAY_LOG]}},
+    "databases": {},
+}
+
+# Admin interface
+logging.info("Checking adminInterface config config")
+if COUCHBASE_SYNC_GATEWAY_ADMIN_INTERFACE:
+    logging.info("Generating adminInterface config config")
+    config_dict["adminInterface"] = COUCHBASE_SYNC_GATEWAY_ADMIN_INTERFACE
+
+# CORS
+logging.info("Checking CORS config")
+if COUCHBASE_SYNC_GATEWAY_CORS_ORIGINS:
+    cors_list = COUCHBASE_SYNC_GATEWAY_CORS_ORIGINS.split(",")
+    use_cors = [origin.strip() for origin in cors_list]
+
+    logging.info("Generating CORS config")
+    config_dict["CORS"] = {
+        "Origin": use_cors,
+        "LoginOrigin": use_cors,
+        "Headers": ["Content-Type"],
+        "MaxAge": 17280000,
+    }
+
+# Couchbase
+logging.info("Checking Couchbase config")
+if COUCHBASE_HOST and COUCHBASE_SYNC_GATEWAY_USER and COUCHBASE_SYNC_GATEWAY_PASSWORD:
+    logging.info("Generating Couchbase config")
+    use_server = "http://{COUCHBASE_HOST}:{COUCHBASE_PORT}".format(
+        COUCHBASE_HOST=COUCHBASE_HOST, COUCHBASE_PORT=COUCHBASE_PORT
+    )
+
+    config_dict["databases"][COUCHBASE_SYNC_GATEWAY_DATABASE] = {
+        "server": use_server,
+        "bucket": COUCHBASE_BUCKET_NAME,
+        "username": COUCHBASE_SYNC_GATEWAY_USER,
+        "password": COUCHBASE_SYNC_GATEWAY_PASSWORD,
+        "num_index_replicas": COUCHBASE_SYNC_GATEWAY_NUM_INDEX_REPLICAS,
+        "enable_shared_bucket_access": True,
+        "import_docs": "continuous",
+        "users": {"GUEST": {"disabled": COUCHBASE_SYNC_GATEWAY_DISABLE_GUEST_USER}},
+    }
+else:
+    config_dict["databases"][COUCHBASE_SYNC_GATEWAY_DATABASE] = {
+        "server": "walrus:/opt/couchbase-sync-gateway/data",
+        "users": {
+            "GUEST": {
+                "disabled": COUCHBASE_SYNC_GATEWAY_DISABLE_GUEST_USER,
+                "admin_channels": ["*"],
+            }
+        },
+    }
+
+# JS sync function
+logging.info("Checking JavaScript sync function file")
+js_function_path = "/sync/sync-function.js"
+sync_function = ""
+logging.info("Checking JS sync function from {}".format(js_function_path))
+if os.path.isfile(js_function_path):
+    logging.info("Reading JavaScript sync function file")
+    with open(js_function_path) as f:
+        sync_function = f.read()
+if sync_function:
+    logging.info("Generating JavaScript sync function config")
+    config_dict["databases"][COUCHBASE_SYNC_GATEWAY_DATABASE]["sync"] = sync_function
+
+# Generate JSON config
+logging.info("Writing final config JSON file")
+with open("/etc/sync_gateway/config.json", "w") as f:
+    json.dump(config_dict, f, indent=2)
+logging.info("Done")

--- a/enterprise/sync-gateway/1.5.0-377/scripts/entrypoint.sh
+++ b/enterprise/sync-gateway/1.5.0-377/scripts/entrypoint.sh
@@ -1,6 +1,52 @@
 #!/bin/bash
 set -e
 
+# Check connection in a separate function, that way, when 
+# there's no connection available yet and the return of the command
+# is non-zero, the script doesn't exit yet
+check_connection() {
+    curl -Is http://${COUCHBASE_SYNC_GATEWAY_USER}:${COUCHBASE_SYNC_GATEWAY_PASSWORD}@${COUCHBASE_HOST}:${COUCHBASE_PORT}/pools/default/buckets/${COUCHBASE_BUCKET_NAME} 2>&1 | grep "HTTP/1.1 200 OK" > /dev/null
+    if [ $? -eq 0 ]; then
+        echo "success";
+    else
+        echo "error";
+    fi;
+}
+
+# Try to connect to Couchbase only if COUCHBASE_HOST was declared as an env var
+if [ ! -z $COUCHBASE_HOST ]; then
+    # Try once per second, up to 300 times (5 min)
+    SECONDS_TO_TRY=300
+    for i in $(seq 1 $SECONDS_TO_TRY); do
+        echo "Checking connection, trial ${i}";
+        result=$(check_connection);
+        if [ $result == "success" ]; then
+            echo "Success: connection checked";
+            sleep 1;
+            break;
+        else
+            echo "Connection not available yet, sleeping 1 sec...";
+            sleep 1;
+            echo "----------";
+        fi;
+    done;
+fi;
+
+config="/etc/sync_gateway/config.json"
+
+if [ ! -z $@ ]; then
+    echo "Using config provided as command parameter: $@"
+    config=$@
+else
+    if [ -f /sync/config.json ]; then
+        echo "Using provided config in: /sync/config.json";
+        config="/sync/config.json"
+    else
+        echo "No config provided in /sync/config.json, generating one from environment variables";
+        python create_config.py
+    fi;
+fi;
+
 LOGFILE_DIR=/var/log/sync_gateway
 mkdir -p $LOGFILE_DIR
 
@@ -9,4 +55,4 @@ LOGFILE_ERROR=$LOGFILE_DIR/sync_gateway_error.log
 
 # Run SG and use tee to append stdout and stderr to separate logfiles
 # Process substitution described here: https://stackoverflow.com/a/692407
-exec sync_gateway "$@" > >(tee -a $LOGFILE_ACCESS) 2> >(tee -a $LOGFILE_ERROR >&2)
+exec sync_gateway "$config" > >(tee -a $LOGFILE_ACCESS) 2> >(tee -a $LOGFILE_ERROR >&2)

--- a/enterprise/sync-gateway/1.5.1/Dockerfile
+++ b/enterprise/sync-gateway/1.5.1/Dockerfile
@@ -19,15 +19,15 @@ RUN wget http://packages.couchbase.com/releases/couchbase-sync-gateway/1.5.1/cou
 # Create directory where the default config stores memory snapshots to disk
 RUN mkdir /opt/couchbase-sync-gateway/data
 
-# copy the default config into the container
-COPY config/sync_gateway_config.json /etc/sync_gateway/config.json
+# Create sync file for custom config.json or generated from env vars config.json
+RUN mkdir /sync
+
+# Copy config generator from environment variables
+COPY /scripts/create_config.py /
 
 # Add bootstrap script
 COPY scripts/entrypoint.sh /
 ENTRYPOINT ["/entrypoint.sh"]
-
-# If user doesn't specify any args, use the default config
-CMD ["/etc/sync_gateway/config.json"]
 
 # Expose ports
 #  port 4984: public port

--- a/enterprise/sync-gateway/1.5.1/scripts/create_config.py
+++ b/enterprise/sync-gateway/1.5.1/scripts/create_config.py
@@ -1,0 +1,116 @@
+from __future__ import print_function
+import os
+import json
+import logging
+
+logging.basicConfig(level=logging.INFO)
+
+
+def getenv_boolean(var_name, default_value=False):
+    result = default_value
+    env_value = os.getenv(var_name)
+    if env_value is not None:
+        result = env_value.upper() in ("TRUE", "1")
+    return result
+
+
+# Env vars for configs
+COUCHBASE_HOST = os.getenv(
+    "COUCHBASE_HOST", ""
+)  # e.g.: "couchbase". Leave empty to use default Walrus
+COUCHBASE_PORT = os.getenv("COUCHBASE_PORT", "8091")
+COUCHBASE_BUCKET_NAME = os.getenv("COUCHBASE_BUCKET_NAME", "app")
+COUCHBASE_SYNC_GATEWAY_LOG = os.getenv(
+    "COUCHBASE_SYNC_GATEWAY_LOG", "HTTP+"
+)  # e.g.: "*"
+COUCHBASE_SYNC_GATEWAY_ADMIN_INTERFACE = os.getenv(
+    "COUCHBASE_SYNC_GATEWAY_ADMIN_INTERFACE", ""
+)  # e.g.: ":4985", leave empty to disable
+COUCHBASE_SYNC_GATEWAY_USER = os.getenv("COUCHBASE_SYNC_GATEWAY_USER", "")
+COUCHBASE_SYNC_GATEWAY_PASSWORD = os.getenv("COUCHBASE_SYNC_GATEWAY_PASSWORD", "")
+COUCHBASE_SYNC_GATEWAY_DATABASE = os.getenv("COUCHBASE_SYNC_GATEWAY_DATABASE", "db")
+COUCHBASE_SYNC_GATEWAY_CORS_ORIGINS = os.getenv(
+    "COUCHBASE_SYNC_GATEWAY_CORS_ORIGINS", ""
+)
+COUCHBASE_SYNC_GATEWAY_NUM_INDEX_REPLICAS = int(
+    os.getenv("COUCHBASE_SYNC_GATEWAY_NUM_INDEX_REPLICAS", "0")
+)
+COUCHBASE_SYNC_GATEWAY_DISABLE_GUEST_USER = getenv_boolean(
+    "COUCHBASE_SYNC_GATEWAY_DISABLE_GUEST_USER", default_value=False
+)
+
+# Base config
+logging.info("Generating base config")
+config_dict = {
+    "interface": ":4984",
+    "logging": {"console": {"log_keys": [COUCHBASE_SYNC_GATEWAY_LOG]}},
+    "databases": {},
+}
+
+# Admin interface
+logging.info("Checking adminInterface config config")
+if COUCHBASE_SYNC_GATEWAY_ADMIN_INTERFACE:
+    logging.info("Generating adminInterface config config")
+    config_dict["adminInterface"] = COUCHBASE_SYNC_GATEWAY_ADMIN_INTERFACE
+
+# CORS
+logging.info("Checking CORS config")
+if COUCHBASE_SYNC_GATEWAY_CORS_ORIGINS:
+    cors_list = COUCHBASE_SYNC_GATEWAY_CORS_ORIGINS.split(",")
+    use_cors = [origin.strip() for origin in cors_list]
+
+    logging.info("Generating CORS config")
+    config_dict["CORS"] = {
+        "Origin": use_cors,
+        "LoginOrigin": use_cors,
+        "Headers": ["Content-Type"],
+        "MaxAge": 17280000,
+    }
+
+# Couchbase
+logging.info("Checking Couchbase config")
+if COUCHBASE_HOST and COUCHBASE_SYNC_GATEWAY_USER and COUCHBASE_SYNC_GATEWAY_PASSWORD:
+    logging.info("Generating Couchbase config")
+    use_server = "http://{COUCHBASE_HOST}:{COUCHBASE_PORT}".format(
+        COUCHBASE_HOST=COUCHBASE_HOST, COUCHBASE_PORT=COUCHBASE_PORT
+    )
+
+    config_dict["databases"][COUCHBASE_SYNC_GATEWAY_DATABASE] = {
+        "server": use_server,
+        "bucket": COUCHBASE_BUCKET_NAME,
+        "username": COUCHBASE_SYNC_GATEWAY_USER,
+        "password": COUCHBASE_SYNC_GATEWAY_PASSWORD,
+        "num_index_replicas": COUCHBASE_SYNC_GATEWAY_NUM_INDEX_REPLICAS,
+        "enable_shared_bucket_access": True,
+        "import_docs": "continuous",
+        "users": {"GUEST": {"disabled": COUCHBASE_SYNC_GATEWAY_DISABLE_GUEST_USER}},
+    }
+else:
+    config_dict["databases"][COUCHBASE_SYNC_GATEWAY_DATABASE] = {
+        "server": "walrus:/opt/couchbase-sync-gateway/data",
+        "users": {
+            "GUEST": {
+                "disabled": COUCHBASE_SYNC_GATEWAY_DISABLE_GUEST_USER,
+                "admin_channels": ["*"],
+            }
+        },
+    }
+
+# JS sync function
+logging.info("Checking JavaScript sync function file")
+js_function_path = "/sync/sync-function.js"
+sync_function = ""
+logging.info("Checking JS sync function from {}".format(js_function_path))
+if os.path.isfile(js_function_path):
+    logging.info("Reading JavaScript sync function file")
+    with open(js_function_path) as f:
+        sync_function = f.read()
+if sync_function:
+    logging.info("Generating JavaScript sync function config")
+    config_dict["databases"][COUCHBASE_SYNC_GATEWAY_DATABASE]["sync"] = sync_function
+
+# Generate JSON config
+logging.info("Writing final config JSON file")
+with open("/etc/sync_gateway/config.json", "w") as f:
+    json.dump(config_dict, f, indent=2)
+logging.info("Done")

--- a/enterprise/sync-gateway/1.5.1/scripts/entrypoint.sh
+++ b/enterprise/sync-gateway/1.5.1/scripts/entrypoint.sh
@@ -1,6 +1,52 @@
 #!/bin/bash
 set -e
 
+# Check connection in a separate function, that way, when 
+# there's no connection available yet and the return of the command
+# is non-zero, the script doesn't exit yet
+check_connection() {
+    curl -Is http://${COUCHBASE_SYNC_GATEWAY_USER}:${COUCHBASE_SYNC_GATEWAY_PASSWORD}@${COUCHBASE_HOST}:${COUCHBASE_PORT}/pools/default/buckets/${COUCHBASE_BUCKET_NAME} 2>&1 | grep "HTTP/1.1 200 OK" > /dev/null
+    if [ $? -eq 0 ]; then
+        echo "success";
+    else
+        echo "error";
+    fi;
+}
+
+# Try to connect to Couchbase only if COUCHBASE_HOST was declared as an env var
+if [ ! -z $COUCHBASE_HOST ]; then
+    # Try once per second, up to 300 times (5 min)
+    SECONDS_TO_TRY=300
+    for i in $(seq 1 $SECONDS_TO_TRY); do
+        echo "Checking connection, trial ${i}";
+        result=$(check_connection);
+        if [ $result == "success" ]; then
+            echo "Success: connection checked";
+            sleep 1;
+            break;
+        else
+            echo "Connection not available yet, sleeping 1 sec...";
+            sleep 1;
+            echo "----------";
+        fi;
+    done;
+fi;
+
+config="/etc/sync_gateway/config.json"
+
+if [ ! -z $@ ]; then
+    echo "Using config provided as command parameter: $@"
+    config=$@
+else
+    if [ -f /sync/config.json ]; then
+        echo "Using provided config in: /sync/config.json";
+        config="/sync/config.json"
+    else
+        echo "No config provided in /sync/config.json, generating one from environment variables";
+        python create_config.py
+    fi;
+fi;
+
 LOGFILE_DIR=/var/log/sync_gateway
 mkdir -p $LOGFILE_DIR
 
@@ -9,4 +55,4 @@ LOGFILE_ERROR=$LOGFILE_DIR/sync_gateway_error.log
 
 # Run SG and use tee to append stdout and stderr to separate logfiles
 # Process substitution described here: https://stackoverflow.com/a/692407
-exec sync_gateway "$@" > >(tee -a $LOGFILE_ACCESS) 2> >(tee -a $LOGFILE_ERROR >&2)
+exec sync_gateway "$config" > >(tee -a $LOGFILE_ACCESS) 2> >(tee -a $LOGFILE_ERROR >&2)

--- a/enterprise/sync-gateway/2.0.0-devbuild/Dockerfile
+++ b/enterprise/sync-gateway/2.0.0-devbuild/Dockerfile
@@ -19,15 +19,15 @@ RUN wget http://cbmobile-packages.s3.amazonaws.com/couchbase-sync-gateway-enterp
 # Create directory where the default config stores memory snapshots to disk
 RUN mkdir /opt/couchbase-sync-gateway/data
 
-# copy the default config into the container
-COPY config/sync_gateway_config.json /etc/sync_gateway/config.json
+# Create sync file for custom config.json or generated from env vars config.json
+RUN mkdir /sync
+
+# Copy config generator from environment variables
+COPY /scripts/create_config.py /
 
 # Add bootstrap script
 COPY scripts/entrypoint.sh /
 ENTRYPOINT ["/entrypoint.sh"]
-
-# If user doesn't specify any args, use the default config
-CMD ["/etc/sync_gateway/config.json"]
 
 # Expose ports
 #  port 4984: public port

--- a/enterprise/sync-gateway/2.0.0-devbuild/scripts/create_config.py
+++ b/enterprise/sync-gateway/2.0.0-devbuild/scripts/create_config.py
@@ -1,0 +1,116 @@
+from __future__ import print_function
+import os
+import json
+import logging
+
+logging.basicConfig(level=logging.INFO)
+
+
+def getenv_boolean(var_name, default_value=False):
+    result = default_value
+    env_value = os.getenv(var_name)
+    if env_value is not None:
+        result = env_value.upper() in ("TRUE", "1")
+    return result
+
+
+# Env vars for configs
+COUCHBASE_HOST = os.getenv(
+    "COUCHBASE_HOST", ""
+)  # e.g.: "couchbase". Leave empty to use default Walrus
+COUCHBASE_PORT = os.getenv("COUCHBASE_PORT", "8091")
+COUCHBASE_BUCKET_NAME = os.getenv("COUCHBASE_BUCKET_NAME", "app")
+COUCHBASE_SYNC_GATEWAY_LOG = os.getenv(
+    "COUCHBASE_SYNC_GATEWAY_LOG", "HTTP+"
+)  # e.g.: "*"
+COUCHBASE_SYNC_GATEWAY_ADMIN_INTERFACE = os.getenv(
+    "COUCHBASE_SYNC_GATEWAY_ADMIN_INTERFACE", ""
+)  # e.g.: ":4985", leave empty to disable
+COUCHBASE_SYNC_GATEWAY_USER = os.getenv("COUCHBASE_SYNC_GATEWAY_USER", "")
+COUCHBASE_SYNC_GATEWAY_PASSWORD = os.getenv("COUCHBASE_SYNC_GATEWAY_PASSWORD", "")
+COUCHBASE_SYNC_GATEWAY_DATABASE = os.getenv("COUCHBASE_SYNC_GATEWAY_DATABASE", "db")
+COUCHBASE_SYNC_GATEWAY_CORS_ORIGINS = os.getenv(
+    "COUCHBASE_SYNC_GATEWAY_CORS_ORIGINS", ""
+)
+COUCHBASE_SYNC_GATEWAY_NUM_INDEX_REPLICAS = int(
+    os.getenv("COUCHBASE_SYNC_GATEWAY_NUM_INDEX_REPLICAS", "0")
+)
+COUCHBASE_SYNC_GATEWAY_DISABLE_GUEST_USER = getenv_boolean(
+    "COUCHBASE_SYNC_GATEWAY_DISABLE_GUEST_USER", default_value=False
+)
+
+# Base config
+logging.info("Generating base config")
+config_dict = {
+    "interface": ":4984",
+    "logging": {"console": {"log_keys": [COUCHBASE_SYNC_GATEWAY_LOG]}},
+    "databases": {},
+}
+
+# Admin interface
+logging.info("Checking adminInterface config config")
+if COUCHBASE_SYNC_GATEWAY_ADMIN_INTERFACE:
+    logging.info("Generating adminInterface config config")
+    config_dict["adminInterface"] = COUCHBASE_SYNC_GATEWAY_ADMIN_INTERFACE
+
+# CORS
+logging.info("Checking CORS config")
+if COUCHBASE_SYNC_GATEWAY_CORS_ORIGINS:
+    cors_list = COUCHBASE_SYNC_GATEWAY_CORS_ORIGINS.split(",")
+    use_cors = [origin.strip() for origin in cors_list]
+
+    logging.info("Generating CORS config")
+    config_dict["CORS"] = {
+        "Origin": use_cors,
+        "LoginOrigin": use_cors,
+        "Headers": ["Content-Type"],
+        "MaxAge": 17280000,
+    }
+
+# Couchbase
+logging.info("Checking Couchbase config")
+if COUCHBASE_HOST and COUCHBASE_SYNC_GATEWAY_USER and COUCHBASE_SYNC_GATEWAY_PASSWORD:
+    logging.info("Generating Couchbase config")
+    use_server = "http://{COUCHBASE_HOST}:{COUCHBASE_PORT}".format(
+        COUCHBASE_HOST=COUCHBASE_HOST, COUCHBASE_PORT=COUCHBASE_PORT
+    )
+
+    config_dict["databases"][COUCHBASE_SYNC_GATEWAY_DATABASE] = {
+        "server": use_server,
+        "bucket": COUCHBASE_BUCKET_NAME,
+        "username": COUCHBASE_SYNC_GATEWAY_USER,
+        "password": COUCHBASE_SYNC_GATEWAY_PASSWORD,
+        "num_index_replicas": COUCHBASE_SYNC_GATEWAY_NUM_INDEX_REPLICAS,
+        "enable_shared_bucket_access": True,
+        "import_docs": "continuous",
+        "users": {"GUEST": {"disabled": COUCHBASE_SYNC_GATEWAY_DISABLE_GUEST_USER}},
+    }
+else:
+    config_dict["databases"][COUCHBASE_SYNC_GATEWAY_DATABASE] = {
+        "server": "walrus:/opt/couchbase-sync-gateway/data",
+        "users": {
+            "GUEST": {
+                "disabled": COUCHBASE_SYNC_GATEWAY_DISABLE_GUEST_USER,
+                "admin_channels": ["*"],
+            }
+        },
+    }
+
+# JS sync function
+logging.info("Checking JavaScript sync function file")
+js_function_path = "/sync/sync-function.js"
+sync_function = ""
+logging.info("Checking JS sync function from {}".format(js_function_path))
+if os.path.isfile(js_function_path):
+    logging.info("Reading JavaScript sync function file")
+    with open(js_function_path) as f:
+        sync_function = f.read()
+if sync_function:
+    logging.info("Generating JavaScript sync function config")
+    config_dict["databases"][COUCHBASE_SYNC_GATEWAY_DATABASE]["sync"] = sync_function
+
+# Generate JSON config
+logging.info("Writing final config JSON file")
+with open("/etc/sync_gateway/config.json", "w") as f:
+    json.dump(config_dict, f, indent=2)
+logging.info("Done")

--- a/enterprise/sync-gateway/2.0.0-devbuild/scripts/entrypoint.sh
+++ b/enterprise/sync-gateway/2.0.0-devbuild/scripts/entrypoint.sh
@@ -1,6 +1,52 @@
 #!/bin/bash
 set -e
 
+# Check connection in a separate function, that way, when 
+# there's no connection available yet and the return of the command
+# is non-zero, the script doesn't exit yet
+check_connection() {
+    curl -Is http://${COUCHBASE_SYNC_GATEWAY_USER}:${COUCHBASE_SYNC_GATEWAY_PASSWORD}@${COUCHBASE_HOST}:${COUCHBASE_PORT}/pools/default/buckets/${COUCHBASE_BUCKET_NAME} 2>&1 | grep "HTTP/1.1 200 OK" > /dev/null
+    if [ $? -eq 0 ]; then
+        echo "success";
+    else
+        echo "error";
+    fi;
+}
+
+# Try to connect to Couchbase only if COUCHBASE_HOST was declared as an env var
+if [ ! -z $COUCHBASE_HOST ]; then
+    # Try once per second, up to 300 times (5 min)
+    SECONDS_TO_TRY=300
+    for i in $(seq 1 $SECONDS_TO_TRY); do
+        echo "Checking connection, trial ${i}";
+        result=$(check_connection);
+        if [ $result == "success" ]; then
+            echo "Success: connection checked";
+            sleep 1;
+            break;
+        else
+            echo "Connection not available yet, sleeping 1 sec...";
+            sleep 1;
+            echo "----------";
+        fi;
+    done;
+fi;
+
+config="/etc/sync_gateway/config.json"
+
+if [ ! -z $@ ]; then
+    echo "Using config provided as command parameter: $@"
+    config=$@
+else
+    if [ -f /sync/config.json ]; then
+        echo "Using provided config in: /sync/config.json";
+        config="/sync/config.json"
+    else
+        echo "No config provided in /sync/config.json, generating one from environment variables";
+        python create_config.py
+    fi;
+fi;
+
 LOGFILE_DIR=/var/log/sync_gateway
 mkdir -p $LOGFILE_DIR
 
@@ -9,4 +55,4 @@ LOGFILE_ERROR=$LOGFILE_DIR/sync_gateway_error.log
 
 # Run SG and use tee to append stdout and stderr to separate logfiles
 # Process substitution described here: https://stackoverflow.com/a/692407
-exec sync_gateway "$@" > >(tee -a $LOGFILE_ACCESS) 2> >(tee -a $LOGFILE_ERROR >&2)
+exec sync_gateway "$config" > >(tee -a $LOGFILE_ACCESS) 2> >(tee -a $LOGFILE_ERROR >&2)

--- a/enterprise/sync-gateway/2.0.0/Dockerfile
+++ b/enterprise/sync-gateway/2.0.0/Dockerfile
@@ -19,15 +19,15 @@ RUN wget http://packages.couchbase.com/releases/couchbase-sync-gateway/2.0.0/cou
 # Create directory where the default config stores memory snapshots to disk
 RUN mkdir /opt/couchbase-sync-gateway/data
 
-# copy the default config into the container
-COPY config/sync_gateway_config.json /etc/sync_gateway/config.json
+# Create sync file for custom config.json or generated from env vars config.json
+RUN mkdir /sync
+
+# Copy config generator from environment variables
+COPY /scripts/create_config.py /
 
 # Add bootstrap script
 COPY scripts/entrypoint.sh /
 ENTRYPOINT ["/entrypoint.sh"]
-
-# If user doesn't specify any args, use the default config
-CMD ["/etc/sync_gateway/config.json"]
 
 # Expose ports
 #  port 4984: public port

--- a/enterprise/sync-gateway/2.0.0/scripts/create_config.py
+++ b/enterprise/sync-gateway/2.0.0/scripts/create_config.py
@@ -1,0 +1,116 @@
+from __future__ import print_function
+import os
+import json
+import logging
+
+logging.basicConfig(level=logging.INFO)
+
+
+def getenv_boolean(var_name, default_value=False):
+    result = default_value
+    env_value = os.getenv(var_name)
+    if env_value is not None:
+        result = env_value.upper() in ("TRUE", "1")
+    return result
+
+
+# Env vars for configs
+COUCHBASE_HOST = os.getenv(
+    "COUCHBASE_HOST", ""
+)  # e.g.: "couchbase". Leave empty to use default Walrus
+COUCHBASE_PORT = os.getenv("COUCHBASE_PORT", "8091")
+COUCHBASE_BUCKET_NAME = os.getenv("COUCHBASE_BUCKET_NAME", "app")
+COUCHBASE_SYNC_GATEWAY_LOG = os.getenv(
+    "COUCHBASE_SYNC_GATEWAY_LOG", "HTTP+"
+)  # e.g.: "*"
+COUCHBASE_SYNC_GATEWAY_ADMIN_INTERFACE = os.getenv(
+    "COUCHBASE_SYNC_GATEWAY_ADMIN_INTERFACE", ""
+)  # e.g.: ":4985", leave empty to disable
+COUCHBASE_SYNC_GATEWAY_USER = os.getenv("COUCHBASE_SYNC_GATEWAY_USER", "")
+COUCHBASE_SYNC_GATEWAY_PASSWORD = os.getenv("COUCHBASE_SYNC_GATEWAY_PASSWORD", "")
+COUCHBASE_SYNC_GATEWAY_DATABASE = os.getenv("COUCHBASE_SYNC_GATEWAY_DATABASE", "db")
+COUCHBASE_SYNC_GATEWAY_CORS_ORIGINS = os.getenv(
+    "COUCHBASE_SYNC_GATEWAY_CORS_ORIGINS", ""
+)
+COUCHBASE_SYNC_GATEWAY_NUM_INDEX_REPLICAS = int(
+    os.getenv("COUCHBASE_SYNC_GATEWAY_NUM_INDEX_REPLICAS", "0")
+)
+COUCHBASE_SYNC_GATEWAY_DISABLE_GUEST_USER = getenv_boolean(
+    "COUCHBASE_SYNC_GATEWAY_DISABLE_GUEST_USER", default_value=False
+)
+
+# Base config
+logging.info("Generating base config")
+config_dict = {
+    "interface": ":4984",
+    "logging": {"console": {"log_keys": [COUCHBASE_SYNC_GATEWAY_LOG]}},
+    "databases": {},
+}
+
+# Admin interface
+logging.info("Checking adminInterface config config")
+if COUCHBASE_SYNC_GATEWAY_ADMIN_INTERFACE:
+    logging.info("Generating adminInterface config config")
+    config_dict["adminInterface"] = COUCHBASE_SYNC_GATEWAY_ADMIN_INTERFACE
+
+# CORS
+logging.info("Checking CORS config")
+if COUCHBASE_SYNC_GATEWAY_CORS_ORIGINS:
+    cors_list = COUCHBASE_SYNC_GATEWAY_CORS_ORIGINS.split(",")
+    use_cors = [origin.strip() for origin in cors_list]
+
+    logging.info("Generating CORS config")
+    config_dict["CORS"] = {
+        "Origin": use_cors,
+        "LoginOrigin": use_cors,
+        "Headers": ["Content-Type"],
+        "MaxAge": 17280000,
+    }
+
+# Couchbase
+logging.info("Checking Couchbase config")
+if COUCHBASE_HOST and COUCHBASE_SYNC_GATEWAY_USER and COUCHBASE_SYNC_GATEWAY_PASSWORD:
+    logging.info("Generating Couchbase config")
+    use_server = "http://{COUCHBASE_HOST}:{COUCHBASE_PORT}".format(
+        COUCHBASE_HOST=COUCHBASE_HOST, COUCHBASE_PORT=COUCHBASE_PORT
+    )
+
+    config_dict["databases"][COUCHBASE_SYNC_GATEWAY_DATABASE] = {
+        "server": use_server,
+        "bucket": COUCHBASE_BUCKET_NAME,
+        "username": COUCHBASE_SYNC_GATEWAY_USER,
+        "password": COUCHBASE_SYNC_GATEWAY_PASSWORD,
+        "num_index_replicas": COUCHBASE_SYNC_GATEWAY_NUM_INDEX_REPLICAS,
+        "enable_shared_bucket_access": True,
+        "import_docs": "continuous",
+        "users": {"GUEST": {"disabled": COUCHBASE_SYNC_GATEWAY_DISABLE_GUEST_USER}},
+    }
+else:
+    config_dict["databases"][COUCHBASE_SYNC_GATEWAY_DATABASE] = {
+        "server": "walrus:/opt/couchbase-sync-gateway/data",
+        "users": {
+            "GUEST": {
+                "disabled": COUCHBASE_SYNC_GATEWAY_DISABLE_GUEST_USER,
+                "admin_channels": ["*"],
+            }
+        },
+    }
+
+# JS sync function
+logging.info("Checking JavaScript sync function file")
+js_function_path = "/sync/sync-function.js"
+sync_function = ""
+logging.info("Checking JS sync function from {}".format(js_function_path))
+if os.path.isfile(js_function_path):
+    logging.info("Reading JavaScript sync function file")
+    with open(js_function_path) as f:
+        sync_function = f.read()
+if sync_function:
+    logging.info("Generating JavaScript sync function config")
+    config_dict["databases"][COUCHBASE_SYNC_GATEWAY_DATABASE]["sync"] = sync_function
+
+# Generate JSON config
+logging.info("Writing final config JSON file")
+with open("/etc/sync_gateway/config.json", "w") as f:
+    json.dump(config_dict, f, indent=2)
+logging.info("Done")

--- a/enterprise/sync-gateway/2.0.0/scripts/entrypoint.sh
+++ b/enterprise/sync-gateway/2.0.0/scripts/entrypoint.sh
@@ -1,6 +1,52 @@
 #!/bin/bash
 set -e
 
+# Check connection in a separate function, that way, when 
+# there's no connection available yet and the return of the command
+# is non-zero, the script doesn't exit yet
+check_connection() {
+    curl -Is http://${COUCHBASE_SYNC_GATEWAY_USER}:${COUCHBASE_SYNC_GATEWAY_PASSWORD}@${COUCHBASE_HOST}:${COUCHBASE_PORT}/pools/default/buckets/${COUCHBASE_BUCKET_NAME} 2>&1 | grep "HTTP/1.1 200 OK" > /dev/null
+    if [ $? -eq 0 ]; then
+        echo "success";
+    else
+        echo "error";
+    fi;
+}
+
+# Try to connect to Couchbase only if COUCHBASE_HOST was declared as an env var
+if [ ! -z $COUCHBASE_HOST ]; then
+    # Try once per second, up to 300 times (5 min)
+    SECONDS_TO_TRY=300
+    for i in $(seq 1 $SECONDS_TO_TRY); do
+        echo "Checking connection, trial ${i}";
+        result=$(check_connection);
+        if [ $result == "success" ]; then
+            echo "Success: connection checked";
+            sleep 1;
+            break;
+        else
+            echo "Connection not available yet, sleeping 1 sec...";
+            sleep 1;
+            echo "----------";
+        fi;
+    done;
+fi;
+
+config="/etc/sync_gateway/config.json"
+
+if [ ! -z $@ ]; then
+    echo "Using config provided as command parameter: $@"
+    config=$@
+else
+    if [ -f /sync/config.json ]; then
+        echo "Using provided config in: /sync/config.json";
+        config="/sync/config.json"
+    else
+        echo "No config provided in /sync/config.json, generating one from environment variables";
+        python create_config.py
+    fi;
+fi;
+
 LOGFILE_DIR=/var/log/sync_gateway
 mkdir -p $LOGFILE_DIR
 
@@ -9,4 +55,4 @@ LOGFILE_ERROR=$LOGFILE_DIR/sync_gateway_error.log
 
 # Run SG and use tee to append stdout and stderr to separate logfiles
 # Process substitution described here: https://stackoverflow.com/a/692407
-exec sync_gateway "$@" > >(tee -a $LOGFILE_ACCESS) 2> >(tee -a $LOGFILE_ERROR >&2)
+exec sync_gateway "$config" > >(tee -a $LOGFILE_ACCESS) 2> >(tee -a $LOGFILE_ERROR >&2)

--- a/enterprise/sync-gateway/2.1.0/Dockerfile
+++ b/enterprise/sync-gateway/2.1.0/Dockerfile
@@ -19,15 +19,15 @@ RUN wget http://packages.couchbase.com/releases/couchbase-sync-gateway/2.1.0/cou
 # Create directory where the default config stores memory snapshots to disk
 RUN mkdir /opt/couchbase-sync-gateway/data
 
-# copy the default config into the container
-COPY config/sync_gateway_config.json /etc/sync_gateway/config.json
+# Create sync file for custom config.json or generated from env vars config.json
+RUN mkdir /sync
+
+# Copy config generator from environment variables
+COPY /scripts/create_config.py /
 
 # Add bootstrap script
 COPY scripts/entrypoint.sh /
 ENTRYPOINT ["/entrypoint.sh"]
-
-# If user doesn't specify any args, use the default config
-CMD ["/etc/sync_gateway/config.json"]
 
 # Expose ports
 #  port 4984: public port

--- a/enterprise/sync-gateway/2.1.0/scripts/create_config.py
+++ b/enterprise/sync-gateway/2.1.0/scripts/create_config.py
@@ -1,0 +1,116 @@
+from __future__ import print_function
+import os
+import json
+import logging
+
+logging.basicConfig(level=logging.INFO)
+
+
+def getenv_boolean(var_name, default_value=False):
+    result = default_value
+    env_value = os.getenv(var_name)
+    if env_value is not None:
+        result = env_value.upper() in ("TRUE", "1")
+    return result
+
+
+# Env vars for configs
+COUCHBASE_HOST = os.getenv(
+    "COUCHBASE_HOST", ""
+)  # e.g.: "couchbase". Leave empty to use default Walrus
+COUCHBASE_PORT = os.getenv("COUCHBASE_PORT", "8091")
+COUCHBASE_BUCKET_NAME = os.getenv("COUCHBASE_BUCKET_NAME", "app")
+COUCHBASE_SYNC_GATEWAY_LOG = os.getenv(
+    "COUCHBASE_SYNC_GATEWAY_LOG", "HTTP+"
+)  # e.g.: "*"
+COUCHBASE_SYNC_GATEWAY_ADMIN_INTERFACE = os.getenv(
+    "COUCHBASE_SYNC_GATEWAY_ADMIN_INTERFACE", ""
+)  # e.g.: ":4985", leave empty to disable
+COUCHBASE_SYNC_GATEWAY_USER = os.getenv("COUCHBASE_SYNC_GATEWAY_USER", "")
+COUCHBASE_SYNC_GATEWAY_PASSWORD = os.getenv("COUCHBASE_SYNC_GATEWAY_PASSWORD", "")
+COUCHBASE_SYNC_GATEWAY_DATABASE = os.getenv("COUCHBASE_SYNC_GATEWAY_DATABASE", "db")
+COUCHBASE_SYNC_GATEWAY_CORS_ORIGINS = os.getenv(
+    "COUCHBASE_SYNC_GATEWAY_CORS_ORIGINS", ""
+)
+COUCHBASE_SYNC_GATEWAY_NUM_INDEX_REPLICAS = int(
+    os.getenv("COUCHBASE_SYNC_GATEWAY_NUM_INDEX_REPLICAS", "0")
+)
+COUCHBASE_SYNC_GATEWAY_DISABLE_GUEST_USER = getenv_boolean(
+    "COUCHBASE_SYNC_GATEWAY_DISABLE_GUEST_USER", default_value=False
+)
+
+# Base config
+logging.info("Generating base config")
+config_dict = {
+    "interface": ":4984",
+    "logging": {"console": {"log_keys": [COUCHBASE_SYNC_GATEWAY_LOG]}},
+    "databases": {},
+}
+
+# Admin interface
+logging.info("Checking adminInterface config config")
+if COUCHBASE_SYNC_GATEWAY_ADMIN_INTERFACE:
+    logging.info("Generating adminInterface config config")
+    config_dict["adminInterface"] = COUCHBASE_SYNC_GATEWAY_ADMIN_INTERFACE
+
+# CORS
+logging.info("Checking CORS config")
+if COUCHBASE_SYNC_GATEWAY_CORS_ORIGINS:
+    cors_list = COUCHBASE_SYNC_GATEWAY_CORS_ORIGINS.split(",")
+    use_cors = [origin.strip() for origin in cors_list]
+
+    logging.info("Generating CORS config")
+    config_dict["CORS"] = {
+        "Origin": use_cors,
+        "LoginOrigin": use_cors,
+        "Headers": ["Content-Type"],
+        "MaxAge": 17280000,
+    }
+
+# Couchbase
+logging.info("Checking Couchbase config")
+if COUCHBASE_HOST and COUCHBASE_SYNC_GATEWAY_USER and COUCHBASE_SYNC_GATEWAY_PASSWORD:
+    logging.info("Generating Couchbase config")
+    use_server = "http://{COUCHBASE_HOST}:{COUCHBASE_PORT}".format(
+        COUCHBASE_HOST=COUCHBASE_HOST, COUCHBASE_PORT=COUCHBASE_PORT
+    )
+
+    config_dict["databases"][COUCHBASE_SYNC_GATEWAY_DATABASE] = {
+        "server": use_server,
+        "bucket": COUCHBASE_BUCKET_NAME,
+        "username": COUCHBASE_SYNC_GATEWAY_USER,
+        "password": COUCHBASE_SYNC_GATEWAY_PASSWORD,
+        "num_index_replicas": COUCHBASE_SYNC_GATEWAY_NUM_INDEX_REPLICAS,
+        "enable_shared_bucket_access": True,
+        "import_docs": "continuous",
+        "users": {"GUEST": {"disabled": COUCHBASE_SYNC_GATEWAY_DISABLE_GUEST_USER}},
+    }
+else:
+    config_dict["databases"][COUCHBASE_SYNC_GATEWAY_DATABASE] = {
+        "server": "walrus:/opt/couchbase-sync-gateway/data",
+        "users": {
+            "GUEST": {
+                "disabled": COUCHBASE_SYNC_GATEWAY_DISABLE_GUEST_USER,
+                "admin_channels": ["*"],
+            }
+        },
+    }
+
+# JS sync function
+logging.info("Checking JavaScript sync function file")
+js_function_path = "/sync/sync-function.js"
+sync_function = ""
+logging.info("Checking JS sync function from {}".format(js_function_path))
+if os.path.isfile(js_function_path):
+    logging.info("Reading JavaScript sync function file")
+    with open(js_function_path) as f:
+        sync_function = f.read()
+if sync_function:
+    logging.info("Generating JavaScript sync function config")
+    config_dict["databases"][COUCHBASE_SYNC_GATEWAY_DATABASE]["sync"] = sync_function
+
+# Generate JSON config
+logging.info("Writing final config JSON file")
+with open("/etc/sync_gateway/config.json", "w") as f:
+    json.dump(config_dict, f, indent=2)
+logging.info("Done")

--- a/enterprise/sync-gateway/2.1.0/scripts/entrypoint.sh
+++ b/enterprise/sync-gateway/2.1.0/scripts/entrypoint.sh
@@ -1,6 +1,52 @@
 #!/bin/bash
 set -e
 
+# Check connection in a separate function, that way, when 
+# there's no connection available yet and the return of the command
+# is non-zero, the script doesn't exit yet
+check_connection() {
+    curl -Is http://${COUCHBASE_SYNC_GATEWAY_USER}:${COUCHBASE_SYNC_GATEWAY_PASSWORD}@${COUCHBASE_HOST}:${COUCHBASE_PORT}/pools/default/buckets/${COUCHBASE_BUCKET_NAME} 2>&1 | grep "HTTP/1.1 200 OK" > /dev/null
+    if [ $? -eq 0 ]; then
+        echo "success";
+    else
+        echo "error";
+    fi;
+}
+
+# Try to connect to Couchbase only if COUCHBASE_HOST was declared as an env var
+if [ ! -z $COUCHBASE_HOST ]; then
+    # Try once per second, up to 300 times (5 min)
+    SECONDS_TO_TRY=300
+    for i in $(seq 1 $SECONDS_TO_TRY); do
+        echo "Checking connection, trial ${i}";
+        result=$(check_connection);
+        if [ $result == "success" ]; then
+            echo "Success: connection checked";
+            sleep 1;
+            break;
+        else
+            echo "Connection not available yet, sleeping 1 sec...";
+            sleep 1;
+            echo "----------";
+        fi;
+    done;
+fi;
+
+config="/etc/sync_gateway/config.json"
+
+if [ ! -z $@ ]; then
+    echo "Using config provided as command parameter: $@"
+    config=$@
+else
+    if [ -f /sync/config.json ]; then
+        echo "Using provided config in: /sync/config.json";
+        config="/sync/config.json"
+    else
+        echo "No config provided in /sync/config.json, generating one from environment variables";
+        python create_config.py
+    fi;
+fi;
+
 LOGFILE_DIR=/var/log/sync_gateway
 mkdir -p $LOGFILE_DIR
 
@@ -9,4 +55,4 @@ LOGFILE_ERROR=$LOGFILE_DIR/sync_gateway_error.log
 
 # Run SG and use tee to append stdout and stderr to separate logfiles
 # Process substitution described here: https://stackoverflow.com/a/692407
-exec sync_gateway "$@" > >(tee -a $LOGFILE_ACCESS) 2> >(tee -a $LOGFILE_ERROR >&2)
+exec sync_gateway "$config" > >(tee -a $LOGFILE_ACCESS) 2> >(tee -a $LOGFILE_ERROR >&2)

--- a/enterprise/sync-gateway/2.1.1/Dockerfile
+++ b/enterprise/sync-gateway/2.1.1/Dockerfile
@@ -19,15 +19,15 @@ RUN wget http://packages.couchbase.com/releases/couchbase-sync-gateway/2.1.1/cou
 # Create directory where the default config stores memory snapshots to disk
 RUN mkdir /opt/couchbase-sync-gateway/data
 
-# copy the default config into the container
-COPY config/sync_gateway_config.json /etc/sync_gateway/config.json
+# Create sync file for custom config.json or generated from env vars config.json
+RUN mkdir /sync
+
+# Copy config generator from environment variables
+COPY /scripts/create_config.py /
 
 # Add bootstrap script
 COPY scripts/entrypoint.sh /
 ENTRYPOINT ["/entrypoint.sh"]
-
-# If user doesn't specify any args, use the default config
-CMD ["/etc/sync_gateway/config.json"]
 
 # Expose ports
 #  port 4984: public port

--- a/enterprise/sync-gateway/2.1.1/scripts/create_config.py
+++ b/enterprise/sync-gateway/2.1.1/scripts/create_config.py
@@ -1,0 +1,116 @@
+from __future__ import print_function
+import os
+import json
+import logging
+
+logging.basicConfig(level=logging.INFO)
+
+
+def getenv_boolean(var_name, default_value=False):
+    result = default_value
+    env_value = os.getenv(var_name)
+    if env_value is not None:
+        result = env_value.upper() in ("TRUE", "1")
+    return result
+
+
+# Env vars for configs
+COUCHBASE_HOST = os.getenv(
+    "COUCHBASE_HOST", ""
+)  # e.g.: "couchbase". Leave empty to use default Walrus
+COUCHBASE_PORT = os.getenv("COUCHBASE_PORT", "8091")
+COUCHBASE_BUCKET_NAME = os.getenv("COUCHBASE_BUCKET_NAME", "app")
+COUCHBASE_SYNC_GATEWAY_LOG = os.getenv(
+    "COUCHBASE_SYNC_GATEWAY_LOG", "HTTP+"
+)  # e.g.: "*"
+COUCHBASE_SYNC_GATEWAY_ADMIN_INTERFACE = os.getenv(
+    "COUCHBASE_SYNC_GATEWAY_ADMIN_INTERFACE", ""
+)  # e.g.: ":4985", leave empty to disable
+COUCHBASE_SYNC_GATEWAY_USER = os.getenv("COUCHBASE_SYNC_GATEWAY_USER", "")
+COUCHBASE_SYNC_GATEWAY_PASSWORD = os.getenv("COUCHBASE_SYNC_GATEWAY_PASSWORD", "")
+COUCHBASE_SYNC_GATEWAY_DATABASE = os.getenv("COUCHBASE_SYNC_GATEWAY_DATABASE", "db")
+COUCHBASE_SYNC_GATEWAY_CORS_ORIGINS = os.getenv(
+    "COUCHBASE_SYNC_GATEWAY_CORS_ORIGINS", ""
+)
+COUCHBASE_SYNC_GATEWAY_NUM_INDEX_REPLICAS = int(
+    os.getenv("COUCHBASE_SYNC_GATEWAY_NUM_INDEX_REPLICAS", "0")
+)
+COUCHBASE_SYNC_GATEWAY_DISABLE_GUEST_USER = getenv_boolean(
+    "COUCHBASE_SYNC_GATEWAY_DISABLE_GUEST_USER", default_value=False
+)
+
+# Base config
+logging.info("Generating base config")
+config_dict = {
+    "interface": ":4984",
+    "logging": {"console": {"log_keys": [COUCHBASE_SYNC_GATEWAY_LOG]}},
+    "databases": {},
+}
+
+# Admin interface
+logging.info("Checking adminInterface config config")
+if COUCHBASE_SYNC_GATEWAY_ADMIN_INTERFACE:
+    logging.info("Generating adminInterface config config")
+    config_dict["adminInterface"] = COUCHBASE_SYNC_GATEWAY_ADMIN_INTERFACE
+
+# CORS
+logging.info("Checking CORS config")
+if COUCHBASE_SYNC_GATEWAY_CORS_ORIGINS:
+    cors_list = COUCHBASE_SYNC_GATEWAY_CORS_ORIGINS.split(",")
+    use_cors = [origin.strip() for origin in cors_list]
+
+    logging.info("Generating CORS config")
+    config_dict["CORS"] = {
+        "Origin": use_cors,
+        "LoginOrigin": use_cors,
+        "Headers": ["Content-Type"],
+        "MaxAge": 17280000,
+    }
+
+# Couchbase
+logging.info("Checking Couchbase config")
+if COUCHBASE_HOST and COUCHBASE_SYNC_GATEWAY_USER and COUCHBASE_SYNC_GATEWAY_PASSWORD:
+    logging.info("Generating Couchbase config")
+    use_server = "http://{COUCHBASE_HOST}:{COUCHBASE_PORT}".format(
+        COUCHBASE_HOST=COUCHBASE_HOST, COUCHBASE_PORT=COUCHBASE_PORT
+    )
+
+    config_dict["databases"][COUCHBASE_SYNC_GATEWAY_DATABASE] = {
+        "server": use_server,
+        "bucket": COUCHBASE_BUCKET_NAME,
+        "username": COUCHBASE_SYNC_GATEWAY_USER,
+        "password": COUCHBASE_SYNC_GATEWAY_PASSWORD,
+        "num_index_replicas": COUCHBASE_SYNC_GATEWAY_NUM_INDEX_REPLICAS,
+        "enable_shared_bucket_access": True,
+        "import_docs": "continuous",
+        "users": {"GUEST": {"disabled": COUCHBASE_SYNC_GATEWAY_DISABLE_GUEST_USER}},
+    }
+else:
+    config_dict["databases"][COUCHBASE_SYNC_GATEWAY_DATABASE] = {
+        "server": "walrus:/opt/couchbase-sync-gateway/data",
+        "users": {
+            "GUEST": {
+                "disabled": COUCHBASE_SYNC_GATEWAY_DISABLE_GUEST_USER,
+                "admin_channels": ["*"],
+            }
+        },
+    }
+
+# JS sync function
+logging.info("Checking JavaScript sync function file")
+js_function_path = "/sync/sync-function.js"
+sync_function = ""
+logging.info("Checking JS sync function from {}".format(js_function_path))
+if os.path.isfile(js_function_path):
+    logging.info("Reading JavaScript sync function file")
+    with open(js_function_path) as f:
+        sync_function = f.read()
+if sync_function:
+    logging.info("Generating JavaScript sync function config")
+    config_dict["databases"][COUCHBASE_SYNC_GATEWAY_DATABASE]["sync"] = sync_function
+
+# Generate JSON config
+logging.info("Writing final config JSON file")
+with open("/etc/sync_gateway/config.json", "w") as f:
+    json.dump(config_dict, f, indent=2)
+logging.info("Done")

--- a/enterprise/sync-gateway/2.1.1/scripts/entrypoint.sh
+++ b/enterprise/sync-gateway/2.1.1/scripts/entrypoint.sh
@@ -1,6 +1,52 @@
 #!/bin/bash
 set -e
 
+# Check connection in a separate function, that way, when 
+# there's no connection available yet and the return of the command
+# is non-zero, the script doesn't exit yet
+check_connection() {
+    curl -Is http://${COUCHBASE_SYNC_GATEWAY_USER}:${COUCHBASE_SYNC_GATEWAY_PASSWORD}@${COUCHBASE_HOST}:${COUCHBASE_PORT}/pools/default/buckets/${COUCHBASE_BUCKET_NAME} 2>&1 | grep "HTTP/1.1 200 OK" > /dev/null
+    if [ $? -eq 0 ]; then
+        echo "success";
+    else
+        echo "error";
+    fi;
+}
+
+# Try to connect to Couchbase only if COUCHBASE_HOST was declared as an env var
+if [ ! -z $COUCHBASE_HOST ]; then
+    # Try once per second, up to 300 times (5 min)
+    SECONDS_TO_TRY=300
+    for i in $(seq 1 $SECONDS_TO_TRY); do
+        echo "Checking connection, trial ${i}";
+        result=$(check_connection);
+        if [ $result == "success" ]; then
+            echo "Success: connection checked";
+            sleep 1;
+            break;
+        else
+            echo "Connection not available yet, sleeping 1 sec...";
+            sleep 1;
+            echo "----------";
+        fi;
+    done;
+fi;
+
+config="/etc/sync_gateway/config.json"
+
+if [ ! -z $@ ]; then
+    echo "Using config provided as command parameter: $@"
+    config=$@
+else
+    if [ -f /sync/config.json ]; then
+        echo "Using provided config in: /sync/config.json";
+        config="/sync/config.json"
+    else
+        echo "No config provided in /sync/config.json, generating one from environment variables";
+        python create_config.py
+    fi;
+fi;
+
 LOGFILE_DIR=/var/log/sync_gateway
 mkdir -p $LOGFILE_DIR
 
@@ -9,4 +55,4 @@ LOGFILE_ERROR=$LOGFILE_DIR/sync_gateway_error.log
 
 # Run SG and use tee to append stdout and stderr to separate logfiles
 # Process substitution described here: https://stackoverflow.com/a/692407
-exec sync_gateway "$@" > >(tee -a $LOGFILE_ACCESS) 2> >(tee -a $LOGFILE_ERROR >&2)
+exec sync_gateway "$config" > >(tee -a $LOGFILE_ACCESS) 2> >(tee -a $LOGFILE_ERROR >&2)

--- a/generate/resources/sync-gateway/scripts/create_config.py
+++ b/generate/resources/sync-gateway/scripts/create_config.py
@@ -1,0 +1,116 @@
+from __future__ import print_function
+import os
+import json
+import logging
+
+logging.basicConfig(level=logging.INFO)
+
+
+def getenv_boolean(var_name, default_value=False):
+    result = default_value
+    env_value = os.getenv(var_name)
+    if env_value is not None:
+        result = env_value.upper() in ("TRUE", "1")
+    return result
+
+
+# Env vars for configs
+COUCHBASE_HOST = os.getenv(
+    "COUCHBASE_HOST", ""
+)  # e.g.: "couchbase". Leave empty to use default Walrus
+COUCHBASE_PORT = os.getenv("COUCHBASE_PORT", "8091")
+COUCHBASE_BUCKET_NAME = os.getenv("COUCHBASE_BUCKET_NAME", "app")
+COUCHBASE_SYNC_GATEWAY_LOG = os.getenv(
+    "COUCHBASE_SYNC_GATEWAY_LOG", "HTTP+"
+)  # e.g.: "*"
+COUCHBASE_SYNC_GATEWAY_ADMIN_INTERFACE = os.getenv(
+    "COUCHBASE_SYNC_GATEWAY_ADMIN_INTERFACE", ""
+)  # e.g.: ":4985", leave empty to disable
+COUCHBASE_SYNC_GATEWAY_USER = os.getenv("COUCHBASE_SYNC_GATEWAY_USER", "")
+COUCHBASE_SYNC_GATEWAY_PASSWORD = os.getenv("COUCHBASE_SYNC_GATEWAY_PASSWORD", "")
+COUCHBASE_SYNC_GATEWAY_DATABASE = os.getenv("COUCHBASE_SYNC_GATEWAY_DATABASE", "db")
+COUCHBASE_SYNC_GATEWAY_CORS_ORIGINS = os.getenv(
+    "COUCHBASE_SYNC_GATEWAY_CORS_ORIGINS", ""
+)
+COUCHBASE_SYNC_GATEWAY_NUM_INDEX_REPLICAS = int(
+    os.getenv("COUCHBASE_SYNC_GATEWAY_NUM_INDEX_REPLICAS", "0")
+)
+COUCHBASE_SYNC_GATEWAY_DISABLE_GUEST_USER = getenv_boolean(
+    "COUCHBASE_SYNC_GATEWAY_DISABLE_GUEST_USER", default_value=False
+)
+
+# Base config
+logging.info("Generating base config")
+config_dict = {
+    "interface": ":4984",
+    "logging": {"console": {"log_keys": [COUCHBASE_SYNC_GATEWAY_LOG]}},
+    "databases": {},
+}
+
+# Admin interface
+logging.info("Checking adminInterface config config")
+if COUCHBASE_SYNC_GATEWAY_ADMIN_INTERFACE:
+    logging.info("Generating adminInterface config config")
+    config_dict["adminInterface"] = COUCHBASE_SYNC_GATEWAY_ADMIN_INTERFACE
+
+# CORS
+logging.info("Checking CORS config")
+if COUCHBASE_SYNC_GATEWAY_CORS_ORIGINS:
+    cors_list = COUCHBASE_SYNC_GATEWAY_CORS_ORIGINS.split(",")
+    use_cors = [origin.strip() for origin in cors_list]
+
+    logging.info("Generating CORS config")
+    config_dict["CORS"] = {
+        "Origin": use_cors,
+        "LoginOrigin": use_cors,
+        "Headers": ["Content-Type"],
+        "MaxAge": 17280000,
+    }
+
+# Couchbase
+logging.info("Checking Couchbase config")
+if COUCHBASE_HOST and COUCHBASE_SYNC_GATEWAY_USER and COUCHBASE_SYNC_GATEWAY_PASSWORD:
+    logging.info("Generating Couchbase config")
+    use_server = "http://{COUCHBASE_HOST}:{COUCHBASE_PORT}".format(
+        COUCHBASE_HOST=COUCHBASE_HOST, COUCHBASE_PORT=COUCHBASE_PORT
+    )
+
+    config_dict["databases"][COUCHBASE_SYNC_GATEWAY_DATABASE] = {
+        "server": use_server,
+        "bucket": COUCHBASE_BUCKET_NAME,
+        "username": COUCHBASE_SYNC_GATEWAY_USER,
+        "password": COUCHBASE_SYNC_GATEWAY_PASSWORD,
+        "num_index_replicas": COUCHBASE_SYNC_GATEWAY_NUM_INDEX_REPLICAS,
+        "enable_shared_bucket_access": True,
+        "import_docs": "continuous",
+        "users": {"GUEST": {"disabled": COUCHBASE_SYNC_GATEWAY_DISABLE_GUEST_USER}},
+    }
+else:
+    config_dict["databases"][COUCHBASE_SYNC_GATEWAY_DATABASE] = {
+        "server": "walrus:/opt/couchbase-sync-gateway/data",
+        "users": {
+            "GUEST": {
+                "disabled": COUCHBASE_SYNC_GATEWAY_DISABLE_GUEST_USER,
+                "admin_channels": ["*"],
+            }
+        },
+    }
+
+# JS sync function
+logging.info("Checking JavaScript sync function file")
+js_function_path = "/sync/sync-function.js"
+sync_function = ""
+logging.info("Checking JS sync function from {}".format(js_function_path))
+if os.path.isfile(js_function_path):
+    logging.info("Reading JavaScript sync function file")
+    with open(js_function_path) as f:
+        sync_function = f.read()
+if sync_function:
+    logging.info("Generating JavaScript sync function config")
+    config_dict["databases"][COUCHBASE_SYNC_GATEWAY_DATABASE]["sync"] = sync_function
+
+# Generate JSON config
+logging.info("Writing final config JSON file")
+with open("/etc/sync_gateway/config.json", "w") as f:
+    json.dump(config_dict, f, indent=2)
+logging.info("Done")

--- a/generate/resources/sync-gateway/scripts/entrypoint.sh
+++ b/generate/resources/sync-gateway/scripts/entrypoint.sh
@@ -1,6 +1,52 @@
 #!/bin/bash
 set -e
 
+# Check connection in a separate function, that way, when 
+# there's no connection available yet and the return of the command
+# is non-zero, the script doesn't exit yet
+check_connection() {
+    curl -Is http://${COUCHBASE_SYNC_GATEWAY_USER}:${COUCHBASE_SYNC_GATEWAY_PASSWORD}@${COUCHBASE_HOST}:${COUCHBASE_PORT}/pools/default/buckets/${COUCHBASE_BUCKET_NAME} 2>&1 | grep "HTTP/1.1 200 OK" > /dev/null
+    if [ $? -eq 0 ]; then
+        echo "success";
+    else
+        echo "error";
+    fi;
+}
+
+# Try to connect to Couchbase only if COUCHBASE_HOST was declared as an env var
+if [ ! -z $COUCHBASE_HOST ]; then
+    # Try once per second, up to 300 times (5 min)
+    SECONDS_TO_TRY=300
+    for i in $(seq 1 $SECONDS_TO_TRY); do
+        echo "Checking connection, trial ${i}";
+        result=$(check_connection);
+        if [ $result == "success" ]; then
+            echo "Success: connection checked";
+            sleep 1;
+            break;
+        else
+            echo "Connection not available yet, sleeping 1 sec...";
+            sleep 1;
+            echo "----------";
+        fi;
+    done;
+fi;
+
+config="/etc/sync_gateway/config.json"
+
+if [ ! -z $@ ]; then
+    echo "Using config provided as command parameter: $@"
+    config=$@
+else
+    if [ -f /sync/config.json ]; then
+        echo "Using provided config in: /sync/config.json";
+        config="/sync/config.json"
+    else
+        echo "No config provided in /sync/config.json, generating one from environment variables";
+        python create_config.py
+    fi;
+fi;
+
 LOGFILE_DIR=/var/log/sync_gateway
 mkdir -p $LOGFILE_DIR
 
@@ -9,4 +55,4 @@ LOGFILE_ERROR=$LOGFILE_DIR/sync_gateway_error.log
 
 # Run SG and use tee to append stdout and stderr to separate logfiles
 # Process substitution described here: https://stackoverflow.com/a/692407
-exec sync_gateway "$@" > >(tee -a $LOGFILE_ACCESS) 2> >(tee -a $LOGFILE_ERROR >&2)
+exec sync_gateway "$config" > >(tee -a $LOGFILE_ACCESS) 2> >(tee -a $LOGFILE_ERROR >&2)

--- a/generate/templates/sync-gateway/Dockerfile.template
+++ b/generate/templates/sync-gateway/Dockerfile.template
@@ -19,15 +19,15 @@ RUN wget {{ .SYNC_GATEWAY_PACKAGE_URL }} && \
 # Create directory where the default config stores memory snapshots to disk
 RUN mkdir /opt/couchbase-sync-gateway/data
 
-# copy the default config into the container
-COPY config/sync_gateway_config.json /etc/sync_gateway/config.json
+# Create sync file for custom config.json or generated from env vars config.json
+RUN mkdir /sync
+
+# Copy config generator from environment variables
+COPY /scripts/create_config.py /
 
 # Add bootstrap script
 COPY scripts/entrypoint.sh /
 ENTRYPOINT ["/entrypoint.sh"]
-
-# If user doesn't specify any args, use the default config
-CMD ["/etc/sync_gateway/config.json"]
 
 # Expose ports
 #  port 4984: public port


### PR DESCRIPTION
This PR adds several features to the Sync Gateway image:

## By default, if not changing anything, the result is the same as the current image, except for the section:

```JSON
"log": ["HTTP+"],
```

that seems to be now deprecated (appears as deprecated in the container logs), so the generated config now would end up having the equivalent:

```JSON
"logging": {"console": {"log_keys": ["HTTP+"]}},
```

## Environment variables based JSON config generation

As is common in other Docker images, this allows setting configurations to cover several common cases, as specifying a Couchbase database, a Sync Gateway user and password, etc.

The `config.json` is then generated based on these environment variables.

The environment variables added are (taken from the generated `README.md`):

* `COUCHBASE_HOST`: set it to the name of your Couchbase server container, e.g. `couchbase-server`.
* `COUCHBASE_PORT`: the Couchbase port if you use a different one. The default value is: `8091`.
* `COUCHBASE_BUCKET_NAME`: the bucket name you want to use Sync Gateway with. The default value is: `app`.
* `COUCHBASE_SYNC_GATEWAY_USER`: set it to the RBAC user you created for Sync Gateway.
* `COUCHBASE_SYNC_GATEWAY_PASSWORD`: set it to the RBAC user password you created for Sync Gateway.
* `COUCHBASE_SYNC_GATEWAY_DATABASE`: the database JSON config field. The default value is: `db`.
* `COUCHBASE_SYNC_GATEWAY_CORS_ORIGINS`: the origins that you want to allow for CORS (cross origin resource sharing). Use it if you are connecting pure browser, web based, frontend applications directly. Set it to a list of origins separated by commas. E.g.: `http://localhost,https://example.com,https://web.example.com`
* `COUCHBASE_SYNC_GATEWAY_DISABLE_GUEST_USER`: set it to `true` or `1` to disable the guest user.
* `COUCHBASE_SYNC_GATEWAY_NUM_INDEX_REPLICAS`: the number of replicas for the Sync Gateway indexes. If you are connecting it to a single Couchbase node, you have to leave it at `0`, you can increase it only with a multi-node cluster. The default value is `0`.
* `COUCHBASE_SYNC_GATEWAY_LOG`: set the type of log for the config. The default value is: `HTTP+`.
* `COUCHBASE_SYNC_GATEWAY_ADMIN_INTERFACE`: to enable the admin interface (only for local development) set it to `:4985`. By default it is disabled.

## Wait for Couchbase to be ready

By setting the `COUCHBASE_HOST`, `COUCHBASE_SYNC_GATEWAY_USER` and `COUCHBASE_SYNC_GATEWAY_PASSWORD` environment variables, the image tries to connect to Couchbase, waits, and re-tries until Couchbase is ready. This allows starting the full stack at the same time and Sync Gateway won't just crash because Couchbase is not ready yet.

## Inject a JavaScript function file in the JSON config

A pure JavaScript file can be created at `/sync/sync-function.js`, if the image sees a file there, it will pick it up and add it to the JSON. 

By being able to have a separate JS file instead of having to put it on a string in a JSON file it's possible to take advantage of the full JS editor support, error checks, etc.

## Override the generated config file

By putting a file at `/sync/config.json` there is no longer a generated config based on environment variables and this file is used instead.

## Keep the command overrides

If a specific file is defined as the command of the container run (as is the current behavior), it overrides any of the previous options.

This makes it compatible with the actual implementation that expects declaring a specific file by hand or a URL.

## Motivation

All these ideas allow fully automatizing a deployment based on Couchbase. Including CI / CD integration. And simplify the development for several use cases.

They come from and are implemented in my [Couchbase-based full-stack project generator](https://github.com/tiangolo/full-stack-flask-couchbase). I modified the options slightly from my full-stack generator to make them fully compatible with the current version.