### PR TITLE
Protect against running as unknown user in the "run" script

### DIFF
--- a/community/couchbase-server/6.0.0/scripts/run
+++ b/community/couchbase-server/6.0.0/scripts/run
@@ -12,7 +12,7 @@ mkdir -p var/lib/couchbase \
          var/lib/moxi
 
 chown -R couchbase:couchbase var
-if [ $(whoami) = "couchbase" ]; then
+if [ "$(whoami)" = "couchbase" ]; then
   exec /opt/couchbase/bin/couchbase-server -- -kernel global_enable_tracing false -noinput
 else
   exec chpst -ucouchbase  /opt/couchbase/bin/couchbase-server -- -kernel global_enable_tracing false -noinput


### PR DESCRIPTION
This fixes a problem related to #68, when the container is run as an unknown user. It has been already fixed in ce6c7796 for the entrypoint script, but not for this one.