### PR TITLE
CBD-4059: Resolve issues with docker generator

### DIFF
--- a/generate/templates/couchbase-operator/Dockerfile.template
+++ b/generate/templates/couchbase-operator/Dockerfile.template
@@ -1,6 +1,6 @@
 FROM alpine:3.8
 
-MAINTAINER Couchbase Docker Team <docker@couchbase.com>
+LABEL maintainer="docker@couchbase.com"
 
 ARG CO_SHA256={{ .CO_SHA256 }}
 ARG CO_VERSION={{ .CO_VERSION }}

--- a/generate/templates/couchbase-server/Dockerfile.template
+++ b/generate/templates/couchbase-server/Dockerfile.template
@@ -1,6 +1,6 @@
 FROM {{ .DOCKER_BASE_IMAGE }}
 
-MAINTAINER Couchbase Docker Team <docker@couchbase.com>
+LABEL maintainer="docker@couchbase.com"
 
 # Install dependencies:
 #  runit: for container process management

--- a/generate/templates/sync-gateway/Dockerfile.template
+++ b/generate/templates/sync-gateway/Dockerfile.template
@@ -1,6 +1,6 @@
 FROM {{ .DOCKER_BASE_IMAGE }}
 
-MAINTAINER Couchbase Docker Team <docker@couchbase.com>
+LABEL maintainer="docker@couchbase.com"
 
 ENV PATH $PATH:/opt/couchbase-sync-gateway/bin
 


### PR DESCRIPTION
- Change 6.x (>6.0.0) base image to ubuntu18
- Exit with error code on failure to retrieve sha
- Move dockerfile creation after param retrieval
- Change deprecated MAINTAINER instructions to LABELs