### PR TITLE
CBD-4059: Use apt-get rather than dpkg to install

### DIFF
--- a/enterprise/couchbase-server/6.0.1/Dockerfile
+++ b/enterprise/couchbase-server/6.0.1/Dockerfile
@@ -14,7 +14,8 @@ LABEL maintainer="docker@couchbase.com"
 #  sysstat: iostat, sar, mpstat
 #  net-tools: ifconfig, arp, netstat
 #  numactl: numactl
-RUN apt-get update && \
+RUN set -x && \
+    apt-get update && \
     apt-get install -yq runit wget chrpath tzdata man \
     lsof lshw sysstat net-tools numactl python-httplib2 && \
     apt-get autoremove && apt-get clean && \
@@ -40,10 +41,15 @@ ENV PATH=$PATH:/opt/couchbase/bin:/opt/couchbase/bin/tools:/opt/couchbase/bin/in
 RUN groupadd -g 1000 couchbase && useradd couchbase -u 1000 -g couchbase -M
 
 # Install couchbase
-RUN export INSTALL_DONT_START_SERVER=1 && \
+RUN set -x && \
+    export INSTALL_DONT_START_SERVER=1 && \
     wget -N --no-verbose $CB_RELEASE_URL/$CB_PACKAGE && \
     echo "$CB_SHA256  $CB_PACKAGE" | sha256sum -c - && \
-    dpkg -i ./$CB_PACKAGE && rm -f ./$CB_PACKAGE
+    apt-get update && \
+    apt-get install -y ./$CB_PACKAGE && \
+    rm -f ./$CB_PACKAGE && \
+    apt-get autoremove && apt-get clean && \
+    rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 # Update VARIANT.txt to indicate we're running in our Docker image
 RUN sed -i -e '1 s/$/\/docker/' /opt/couchbase/VARIANT.txt

--- a/enterprise/couchbase-server/6.0.2/Dockerfile
+++ b/enterprise/couchbase-server/6.0.2/Dockerfile
@@ -14,7 +14,8 @@ LABEL maintainer="docker@couchbase.com"
 #  sysstat: iostat, sar, mpstat
 #  net-tools: ifconfig, arp, netstat
 #  numactl: numactl
-RUN apt-get update && \
+RUN set -x && \
+    apt-get update && \
     apt-get install -yq runit wget chrpath tzdata man \
     lsof lshw sysstat net-tools numactl python-httplib2 && \
     apt-get autoremove && apt-get clean && \
@@ -40,10 +41,15 @@ ENV PATH=$PATH:/opt/couchbase/bin:/opt/couchbase/bin/tools:/opt/couchbase/bin/in
 RUN groupadd -g 1000 couchbase && useradd couchbase -u 1000 -g couchbase -M
 
 # Install couchbase
-RUN export INSTALL_DONT_START_SERVER=1 && \
+RUN set -x && \
+    export INSTALL_DONT_START_SERVER=1 && \
     wget -N --no-verbose $CB_RELEASE_URL/$CB_PACKAGE && \
     echo "$CB_SHA256  $CB_PACKAGE" | sha256sum -c - && \
-    dpkg -i ./$CB_PACKAGE && rm -f ./$CB_PACKAGE
+    apt-get update && \
+    apt-get install -y ./$CB_PACKAGE && \
+    rm -f ./$CB_PACKAGE && \
+    apt-get autoremove && apt-get clean && \
+    rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 # Update VARIANT.txt to indicate we're running in our Docker image
 RUN sed -i -e '1 s/$/\/docker/' /opt/couchbase/VARIANT.txt

--- a/enterprise/couchbase-server/6.0.3/Dockerfile
+++ b/enterprise/couchbase-server/6.0.3/Dockerfile
@@ -14,7 +14,8 @@ LABEL maintainer="docker@couchbase.com"
 #  sysstat: iostat, sar, mpstat
 #  net-tools: ifconfig, arp, netstat
 #  numactl: numactl
-RUN apt-get update && \
+RUN set -x && \
+    apt-get update && \
     apt-get install -yq runit wget chrpath tzdata man \
     lsof lshw sysstat net-tools numactl python-httplib2 && \
     apt-get autoremove && apt-get clean && \
@@ -40,10 +41,15 @@ ENV PATH=$PATH:/opt/couchbase/bin:/opt/couchbase/bin/tools:/opt/couchbase/bin/in
 RUN groupadd -g 1000 couchbase && useradd couchbase -u 1000 -g couchbase -M
 
 # Install couchbase
-RUN export INSTALL_DONT_START_SERVER=1 && \
+RUN set -x && \
+    export INSTALL_DONT_START_SERVER=1 && \
     wget -N --no-verbose $CB_RELEASE_URL/$CB_PACKAGE && \
     echo "$CB_SHA256  $CB_PACKAGE" | sha256sum -c - && \
-    dpkg -i ./$CB_PACKAGE && rm -f ./$CB_PACKAGE
+    apt-get update && \
+    apt-get install -y ./$CB_PACKAGE && \
+    rm -f ./$CB_PACKAGE && \
+    apt-get autoremove && apt-get clean && \
+    rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 # Update VARIANT.txt to indicate we're running in our Docker image
 RUN sed -i -e '1 s/$/\/docker/' /opt/couchbase/VARIANT.txt

--- a/enterprise/couchbase-server/6.0.4/Dockerfile
+++ b/enterprise/couchbase-server/6.0.4/Dockerfile
@@ -14,7 +14,8 @@ LABEL maintainer="docker@couchbase.com"
 #  sysstat: iostat, sar, mpstat
 #  net-tools: ifconfig, arp, netstat
 #  numactl: numactl
-RUN apt-get update && \
+RUN set -x && \
+    apt-get update && \
     apt-get install -yq runit wget chrpath tzdata man \
     lsof lshw sysstat net-tools numactl python-httplib2 && \
     apt-get autoremove && apt-get clean && \
@@ -40,10 +41,15 @@ ENV PATH=$PATH:/opt/couchbase/bin:/opt/couchbase/bin/tools:/opt/couchbase/bin/in
 RUN groupadd -g 1000 couchbase && useradd couchbase -u 1000 -g couchbase -M
 
 # Install couchbase
-RUN export INSTALL_DONT_START_SERVER=1 && \
+RUN set -x && \
+    export INSTALL_DONT_START_SERVER=1 && \
     wget -N --no-verbose $CB_RELEASE_URL/$CB_PACKAGE && \
     echo "$CB_SHA256  $CB_PACKAGE" | sha256sum -c - && \
-    dpkg -i ./$CB_PACKAGE && rm -f ./$CB_PACKAGE
+    apt-get update && \
+    apt-get install -y ./$CB_PACKAGE && \
+    rm -f ./$CB_PACKAGE && \
+    apt-get autoremove && apt-get clean && \
+    rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 # Update VARIANT.txt to indicate we're running in our Docker image
 RUN sed -i -e '1 s/$/\/docker/' /opt/couchbase/VARIANT.txt

--- a/enterprise/couchbase-server/6.0.5/Dockerfile
+++ b/enterprise/couchbase-server/6.0.5/Dockerfile
@@ -14,7 +14,8 @@ LABEL maintainer="docker@couchbase.com"
 #  sysstat: iostat, sar, mpstat
 #  net-tools: ifconfig, arp, netstat
 #  numactl: numactl
-RUN apt-get update && \
+RUN set -x && \
+    apt-get update && \
     apt-get install -yq runit wget chrpath tzdata man \
     lsof lshw sysstat net-tools numactl python-httplib2 && \
     apt-get autoremove && apt-get clean && \
@@ -40,10 +41,15 @@ ENV PATH=$PATH:/opt/couchbase/bin:/opt/couchbase/bin/tools:/opt/couchbase/bin/in
 RUN groupadd -g 1000 couchbase && useradd couchbase -u 1000 -g couchbase -M
 
 # Install couchbase
-RUN export INSTALL_DONT_START_SERVER=1 && \
+RUN set -x && \
+    export INSTALL_DONT_START_SERVER=1 && \
     wget -N --no-verbose $CB_RELEASE_URL/$CB_PACKAGE && \
     echo "$CB_SHA256  $CB_PACKAGE" | sha256sum -c - && \
-    dpkg -i ./$CB_PACKAGE && rm -f ./$CB_PACKAGE
+    apt-get update && \
+    apt-get install -y ./$CB_PACKAGE && \
+    rm -f ./$CB_PACKAGE && \
+    apt-get autoremove && apt-get clean && \
+    rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 # Update VARIANT.txt to indicate we're running in our Docker image
 RUN sed -i -e '1 s/$/\/docker/' /opt/couchbase/VARIANT.txt

--- a/generate/generator/generate.go
+++ b/generate/generator/generate.go
@@ -436,19 +436,17 @@ func (variant DockerfileVariant) getSHA256() string {
 	}
 
 	resp, err := http.Get(sha256url)
-	log.Printf(sha256url)
+	log.Print(sha256url)
 
 	if err != nil || resp.StatusCode != 200 {
 		log.Printf("Error downloading SHA256 file")
-		os.Exit(1)
-		return "MISSING SHA256 ERROR"
+		return "MISSING_SHA256_ERROR"
 	} else {
 		defer resp.Body.Close()
 		body, err := ioutil.ReadAll(resp.Body)
 		if err != nil {
 			log.Printf("Error download content of SHA256 file")
-			os.Exit(1)
-			return "HTTP ERROR"
+			return "HTTP_ERROR"
 		}
 		return strings.Fields(fmt.Sprintf("%s", body))[0]
 	}

--- a/generate/templates/couchbase-server/Dockerfile.template
+++ b/generate/templates/couchbase-server/Dockerfile.template
@@ -14,7 +14,8 @@ LABEL maintainer="docker@couchbase.com"
 #  sysstat: iostat, sar, mpstat
 #  net-tools: ifconfig, arp, netstat
 #  numactl: numactl
-RUN apt-get update && \
+RUN set -x && \
+    apt-get update && \
     apt-get install -yq runit wget chrpath tzdata man \
     lsof lshw sysstat net-tools numactl {{ .CB_EXTRA_DEPS }} && \
     apt-get autoremove && apt-get clean && \
@@ -40,10 +41,15 @@ ENV PATH=$PATH:/opt/couchbase/bin:/opt/couchbase/bin/tools:/opt/couchbase/bin/in
 RUN groupadd -g 1000 couchbase && useradd couchbase -u 1000 -g couchbase -M
 
 # Install couchbase
-RUN export INSTALL_DONT_START_SERVER=1 && \
+RUN set -x && \
+    export INSTALL_DONT_START_SERVER=1 && \
     wget -N --no-verbose $CB_RELEASE_URL/$CB_PACKAGE && \
     echo "$CB_SHA256  $CB_PACKAGE" | sha256sum -c - && \
-    dpkg -i ./$CB_PACKAGE && rm -f ./$CB_PACKAGE
+    apt-get update && \
+    apt-get install -y ./$CB_PACKAGE && \
+    rm -f ./$CB_PACKAGE && \
+    apt-get autoremove && apt-get clean && \
+    rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 # Update VARIANT.txt to indicate we're running in our Docker image
 RUN sed -i -e '1 s/$/\/docker/' /opt/couchbase/VARIANT.txt


### PR DESCRIPTION
6.0.x depended on a package (libssl1.0.0) which wasn't available by default in ubuntu:18.04. Using "apt-get" rather than "dpkg" to install is a general solution for these kinds of problems and should have been done all along.