### PR TITLE
CBD-4603: Tweak generation to allow building from a different version

### DIFF
--- a/enterprise/couchbase-server/7.0.3/Dockerfile
+++ b/enterprise/couchbase-server/7.0.3/Dockerfile
@@ -1,6 +1,12 @@
+
+
 FROM ubuntu:20.04
 
 LABEL maintainer="docker@couchbase.com"
+
+
+ARG UPDATE_COMMAND="apt-get update -y -q"
+ARG CLEANUP_COMMAND="rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*"
 
 # Install dependencies:
 #  runit: for container process management
@@ -12,17 +18,15 @@ LABEL maintainer="docker@couchbase.com"
 #  sysstat: iostat, sar, mpstat
 #  net-tools: ifconfig, arp, netstat
 #  numactl: numactl
-RUN set -x && \
-    apt-get update && \
-    apt-get install -yq runit wget tzdata \
-    lsof lshw sysstat net-tools numactl bzip2 && \
-    apt-get autoremove && apt-get clean && \
-    rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+RUN set -x \
+    && ${UPDATE_COMMAND} \
+    && apt-get install -y -q wget tzdata \
+      lsof lshw sysstat net-tools numactl bzip2 runit \
+    && ${CLEANUP_COMMAND}
 
-ARG CB_VERSION=7.0.3
-ARG CB_RELEASE_URL=https://packages.couchbase.com/releases/7.0.3
-ARG CB_PACKAGE=couchbase-server-enterprise_7.0.3-ubuntu20.04_amd64.deb
-ARG CB_SHA256=efacf9923a7203771fc342ec010d1baf9325c01f284b22c703b10e5dc9b38d2c
+ARG CB_RELEASE_URL=https://packages.couchbase.com/releases/7.0.3-MP1
+ARG CB_PACKAGE=couchbase-server-enterprise_7.0.3-MP1-ubuntu20.04_amd64.deb
+ARG CB_SHA256=a1bfcc476e01c71a212c2ed5026f24f3df01b3591c24dcf45678fdb2625cfc0f
 
 ENV PATH=$PATH:/opt/couchbase/bin:/opt/couchbase/bin/tools:/opt/couchbase/bin/install
 
@@ -31,22 +35,23 @@ ENV PATH=$PATH:/opt/couchbase/bin:/opt/couchbase/bin/tools:/opt/couchbase/bin/in
 RUN groupadd -g 1000 couchbase && useradd couchbase -u 1000 -g couchbase -M
 
 # Install couchbase
-RUN set -x && \
-    export INSTALL_DONT_START_SERVER=1 && \
-    wget -N --no-verbose $CB_RELEASE_URL/$CB_PACKAGE && \
-    echo "$CB_SHA256  $CB_PACKAGE" | sha256sum -c - && \
-    apt-get update && \
-    apt-get install -y ./$CB_PACKAGE && \
-    rm -f ./$CB_PACKAGE && \
-    apt-get autoremove && apt-get clean && \
-    rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+RUN set -x \
+    && export INSTALL_DONT_START_SERVER=1 \
+    && wget -N --no-verbose $CB_RELEASE_URL/$CB_PACKAGE \
+    && echo "$CB_SHA256  $CB_PACKAGE" | sha256sum -c - \
+    && ${UPDATE_COMMAND} \
+    && apt-get install -y ./$CB_PACKAGE \
+    && rm -f ./$CB_PACKAGE \
+    && ${CLEANUP_COMMAND} \
+    && rm -rf /tmp/* /var/tmp/*
 
 # Update VARIANT.txt to indicate we're running in our Docker image
 RUN sed -i -e '1 s/$/\/docker/' /opt/couchbase/VARIANT.txt
 
 # Add runit script for couchbase-server
 COPY scripts/run /etc/service/couchbase-server/run
-RUN mkdir -p /etc/runit/runsvdir/default/couchbase-server/supervise \
+RUN set -x \
+    && mkdir -p /etc/runit/runsvdir/default/couchbase-server/supervise \
     && chown -R couchbase:couchbase \
                 /etc/service \
                 /etc/runit/runsvdir/default/couchbase-server/supervise
@@ -54,22 +59,23 @@ RUN mkdir -p /etc/runit/runsvdir/default/couchbase-server/supervise \
 # Add dummy script for commands invoked by cbcollect_info that
 # make no sense in a Docker container
 COPY scripts/dummy.sh /usr/local/bin/
-RUN ln -s dummy.sh /usr/local/bin/iptables-save && \
-    ln -s dummy.sh /usr/local/bin/lvdisplay && \
-    ln -s dummy.sh /usr/local/bin/vgdisplay && \
-    ln -s dummy.sh /usr/local/bin/pvdisplay
+RUN set -x \
+    && ln -s dummy.sh /usr/local/bin/iptables-save \
+    && ln -s dummy.sh /usr/local/bin/lvdisplay \
+    && ln -s dummy.sh /usr/local/bin/vgdisplay \
+    && ln -s dummy.sh /usr/local/bin/pvdisplay
 
 # Fix curl RPATH if necessary - if curl.real exists, it's a new
 # enough package that we don't need to do anything. If not, it
 # may be OK, but just fix it
 RUN set -ex \
     &&  if [ ! -e /opt/couchbase/bin/curl.real ]; then \
-            apt-get update; \
+            ${UPDATE_COMMAND}; \
             apt-get install -y chrpath; \
             chrpath -r '$ORIGIN/../lib' /opt/couchbase/bin/curl; \
-            apt-get purge -y chrpath; \
-            apt-get autoremove; \
-            apt-get clean; \
+            apt-get remove -y chrpath; \
+            apt-get autoremove -y; \
+            ${CLEANUP_COMMAND}; \
         fi
 
 # Add bootstrap script

--- a/generate/templates/couchbase-server/Dockerfile.template
+++ b/generate/templates/couchbase-server/Dockerfile.template
@@ -60,7 +60,6 @@ RUN set -x \
       lsof lshw sysstat net-tools numactl {{ .CB_EXTRA_DEPS }} \
     && ${CLEANUP_COMMAND}
 
-ARG CB_VERSION={{ .CB_VERSION }}
 ARG CB_RELEASE_URL={{ .CB_RELEASE_URL }}/{{ .CB_VERSION }}
 ARG CB_PACKAGE={{ .CB_PACKAGE }}
 ARG CB_SHA256={{ .CB_SHA256 }}


### PR DESCRIPTION
Introduced DockerfileVariant.TargetVersion, which is the name of the
directory under enterprise/PRODUCT. This will generally be the same
as Version, but occasionally we must build the Docker image with
version X from a released product with a slightly different version.

Also simplified generateVersions() to make it easier to add in
specific exception cases.