### PR TITLE
MB-51605: Patch install process for Server < 7.0.0

### DIFF
--- a/enterprise/couchbase-server/6.5.2/Dockerfile
+++ b/enterprise/couchbase-server/6.5.2/Dockerfile
@@ -1,37 +1,32 @@
+
+
 FROM ubuntu:18.04
 
 LABEL maintainer="docker@couchbase.com"
 
+
+ARG UPDATE_COMMAND="apt-get update -y -q"
+ARG CLEANUP_COMMAND="rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*"
+
 # Install dependencies:
 #  runit: for container process management
 #  wget: for downloading .deb
-#  chrpath: for fixing curl, below
 #  tzdata: timezone info used by some N1QL functions
-#  man: so couchbase-cli help works
 # Additional dependencies for system commands used by cbcollect_info:
 #  lsof: lsof
 #  lshw: lshw
 #  sysstat: iostat, sar, mpstat
 #  net-tools: ifconfig, arp, netstat
 #  numactl: numactl
-RUN set -x && \
-    apt-get update && \
-    apt-get install -yq runit wget chrpath tzdata man \
-    lsof lshw sysstat net-tools numactl bzip2 && \
-    apt-get autoremove && apt-get clean && \
-    rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+RUN set -x \
+    && ${UPDATE_COMMAND} \
+    && apt-get install -y -q wget tzdata \
+      lsof lshw sysstat net-tools numactl bzip2 runit \
+    && ${CLEANUP_COMMAND}
 
-# http://smarden.org/runit/useinit.html#sysv - at some point the script
-# runsvdir-start was moved/renamed to this odd name, so we put it back
-# somewhere sensible. This appears to be necessary for Ubuntu 20 but
-# not Ubuntu 16.
-RUN if [ ! -x /usr/sbin/runsvdir-start ]; then \
-        cp -a /etc/runit/2 /usr/sbin/runsvdir-start; \
-    fi
-
-ARG CB_VERSION=6.5.2
 ARG CB_RELEASE_URL=https://packages.couchbase.com/releases/6.5.2
 ARG CB_PACKAGE=couchbase-server-enterprise_6.5.2-ubuntu18.04_amd64.deb
+ARG CB_PACKAGE_NAME=couchbase-server
 ARG CB_SHA256=62f9ffad86eab90137701baab421586af49fe0e7c458bb047b6c364c6ad11684
 
 ENV PATH=$PATH:/opt/couchbase/bin:/opt/couchbase/bin/tools:/opt/couchbase/bin/install
@@ -41,22 +36,30 @@ ENV PATH=$PATH:/opt/couchbase/bin:/opt/couchbase/bin/tools:/opt/couchbase/bin/in
 RUN groupadd -g 1000 couchbase && useradd couchbase -u 1000 -g couchbase -M
 
 # Install couchbase
-RUN set -x && \
-    export INSTALL_DONT_START_SERVER=1 && \
-    wget -N --no-verbose $CB_RELEASE_URL/$CB_PACKAGE && \
-    echo "$CB_SHA256  $CB_PACKAGE" | sha256sum -c - && \
-    apt-get update && \
-    apt-get install -y ./$CB_PACKAGE && \
-    rm -f ./$CB_PACKAGE && \
-    apt-get autoremove && apt-get clean && \
-    rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+# Note: installers for Server prior to 7.0.0 used a method for detecting
+# if they were running in a container that caused installation to fail
+# in some environments, such as some GitHub actions. Below we patch the
+# detection mid-install to work around this issue.
+RUN set -x \
+    && export INSTALL_DONT_START_SERVER=1 \
+    && wget -N --no-verbose $CB_RELEASE_URL/$CB_PACKAGE \
+    && echo "$CB_SHA256  $CB_PACKAGE" | sha256sum -c - \
+    && ${UPDATE_COMMAND} \
+    && dpkg --unpack ./$CB_PACKAGE \
+    && sed -i -e '/Best heuristic/ a \ \ \ \ [ -d /run/systemd/system ] && return 1; return 0' /opt/couchbase/bin/install/systemd-ctl \
+    && dpkg --configure couchbase-server \
+    && apt-get install -yf \
+    && rm -f ./$CB_PACKAGE \
+    && ${CLEANUP_COMMAND} \
+    && rm -rf /tmp/* /var/tmp/*
 
 # Update VARIANT.txt to indicate we're running in our Docker image
 RUN sed -i -e '1 s/$/\/docker/' /opt/couchbase/VARIANT.txt
 
 # Add runit script for couchbase-server
 COPY scripts/run /etc/service/couchbase-server/run
-RUN mkdir -p /etc/runit/runsvdir/default/couchbase-server/supervise \
+RUN set -x \
+    && mkdir -p /etc/runit/runsvdir/default/couchbase-server/supervise \
     && chown -R couchbase:couchbase \
                 /etc/service \
                 /etc/runit/runsvdir/default/couchbase-server/supervise
@@ -64,13 +67,24 @@ RUN mkdir -p /etc/runit/runsvdir/default/couchbase-server/supervise \
 # Add dummy script for commands invoked by cbcollect_info that
 # make no sense in a Docker container
 COPY scripts/dummy.sh /usr/local/bin/
-RUN ln -s dummy.sh /usr/local/bin/iptables-save && \
-    ln -s dummy.sh /usr/local/bin/lvdisplay && \
-    ln -s dummy.sh /usr/local/bin/vgdisplay && \
-    ln -s dummy.sh /usr/local/bin/pvdisplay
+RUN set -x \
+    && ln -s dummy.sh /usr/local/bin/iptables-save \
+    && ln -s dummy.sh /usr/local/bin/lvdisplay \
+    && ln -s dummy.sh /usr/local/bin/vgdisplay \
+    && ln -s dummy.sh /usr/local/bin/pvdisplay
 
-# Fix curl RPATH
-RUN chrpath -r '$ORIGIN/../lib' /opt/couchbase/bin/curl
+# Fix curl RPATH if necessary - if curl.real exists, it's a new
+# enough package that we don't need to do anything. If not, it
+# may be OK, but just fix it
+RUN set -ex \
+    &&  if [ ! -e /opt/couchbase/bin/curl.real ]; then \
+            ${UPDATE_COMMAND}; \
+            apt-get install -y chrpath; \
+            chrpath -r '$ORIGIN/../lib' /opt/couchbase/bin/curl; \
+            apt-get remove -y chrpath; \
+            apt-get autoremove -y; \
+            ${CLEANUP_COMMAND}; \
+        fi
 
 # Add bootstrap script
 COPY scripts/entrypoint.sh /

--- a/enterprise/couchbase-server/6.5.2/scripts/entrypoint.sh
+++ b/enterprise/couchbase-server/6.5.2/scripts/entrypoint.sh
@@ -53,7 +53,7 @@ overridePort "ssl_proxy_upstream_port"
     fi
     echo "Starting Couchbase Server -- Web UI available at http://<ip>:$restPortValue"
     echo "and logs available in /opt/couchbase/var/lib/couchbase/logs"
-    exec /usr/sbin/runsvdir-start
+    exec runsvdir -P /etc/service 'log: ...........................................................................................................................................................................................................................................................................................................................................................................................................'
 }
 
 exec "$@"

--- a/enterprise/couchbase-server/6.5.2/scripts/run
+++ b/enterprise/couchbase-server/6.5.2/scripts/run
@@ -1,5 +1,11 @@
 #!/bin/sh
 
+# If HOME is set, Erlang requires that it be a writable directory.
+# We can't guarantee that as it depends on which UID the container
+# is started as. The couchbase-server script will handle it being
+# unset, though, so do that for safety.
+unset HOME
+
 exec 2>&1
 
 # Create directories where couchbase stores its data
@@ -11,7 +17,11 @@ mkdir -p var/lib/couchbase \
          var/lib/couchbase/logs \
          var/lib/moxi
 
-chown -R couchbase:couchbase var
+# Ensure everything in var is owned and writable to Server.
+# Skip "inbox" as it may contain readonly-mounted things like k8s certs.
+find var -path var/lib/couchbase/inbox -prune -o -print0 | \
+  xargs -0 chown --no-dereference couchbase:couchbase
+
 if [ "$(whoami)" = "couchbase" ]; then
   exec /opt/couchbase/bin/couchbase-server -- -kernel global_enable_tracing false -noinput
 else

--- a/generate/templates/couchbase-server/Dockerfile.template
+++ b/generate/templates/couchbase-server/Dockerfile.template
@@ -62,6 +62,9 @@ RUN set -x \
 
 ARG CB_RELEASE_URL={{ .CB_RELEASE_URL }}/{{ .CB_VERSION }}
 ARG CB_PACKAGE={{ .CB_PACKAGE }}
+{{- if .SYSTEMD_WORKAROUND }}
+ARG CB_PACKAGE_NAME={{ .CB_PACKAGE_NAME }}
+{{- end }}
 ARG CB_SHA256={{ .CB_SHA256 }}
 
 ENV PATH=$PATH:/opt/couchbase/bin:/opt/couchbase/bin/tools:/opt/couchbase/bin/install
@@ -71,12 +74,25 @@ ENV PATH=$PATH:/opt/couchbase/bin:/opt/couchbase/bin/tools:/opt/couchbase/bin/in
 RUN groupadd -g 1000 couchbase && useradd couchbase -u 1000 -g couchbase -M
 
 # Install couchbase
+{{- if .SYSTEMD_WORKAROUND }}
+# Note: installers for Server prior to 7.0.0 used a method for detecting
+# if they were running in a container that caused installation to fail
+# in some environments, such as some GitHub actions. Below we patch the
+# detection mid-install to work around this issue.
+{{- end }}
 RUN set -x \
     && export INSTALL_DONT_START_SERVER=1 \
     && wget -N --no-verbose $CB_RELEASE_URL/$CB_PACKAGE \
     && echo "$CB_SHA256  $CB_PACKAGE" | sha256sum -c - \
     && ${UPDATE_COMMAND} \
+{{- if .SYSTEMD_WORKAROUND }}
+    && dpkg --unpack ./$CB_PACKAGE \
+    && sed -i -e '/Best heuristic/ a \ \ \ \ [ -d /run/systemd/system ] && return 1; return 0' /opt/couchbase/bin/install/systemd-ctl \
+    && dpkg --configure {{ .CB_PACKAGE_NAME }} \
+    && apt-get install -yf \
+{{- else }}
     && {{ .PKG_COMMAND }} install -y ./$CB_PACKAGE \
+{{- end }}
     && rm -f ./$CB_PACKAGE \
     && ${CLEANUP_COMMAND} \
     && rm -rf /tmp/* /var/tmp/*


### PR DESCRIPTION
The systemd-ctl script in Server (which is used by the installer to
start/stop server) includes a heuristic to detect whether it is running
inside a container or not, so it knows whether to invoke systemd
commands or start/stop server manually. In Server < 7.0.0, this
heuristic was flawed and could fail in some environments, including
GitHub actions. It now appears that this could cause failures on Docker
Hub's automated builds, including security rebuilds of the Official
Image.

This change splits the install process into two parts: first unpack all
the files, then configure the package. Between those two it
monkey-patches systemd-ctl to use the newer 7.0.0+ method of detecting
whether systemd is available, rather than attempting to detect "inside a
container".

The generation will only insert this method when creating a Dockerfile
for Server < 7.0.0. This change includes the fix for 6.5.2, which we are
in the process of adding an Official Image for since it was previously
overlooked. We will decide later whether to update and re-propose any
6.6.x images.