### PR TITLE
CBD-4857: Update screenshots to 7.1.0

### DIFF
--- a/community/couchbase-server/4.0.0/README.md
+++ b/community/couchbase-server/4.0.0/README.md
@@ -26,20 +26,20 @@ Here is how to get a single node Couchbase Server cluster running on Docker cont
 
 **Step - 2 :** Next, visit `http://localhost:8091` on the host machine to see the Web Console to start Couchbase Server setup.
 
-![Setup splash screen](https://d774lla4im6mk.cloudfront.net/6.6.2/setup-initial.jpg)
+![Setup splash screen](https://d774lla4im6mk.cloudfront.net/setup-initial.jpg)
 
 Walk through the Setup wizard and accept the default values.
 
 -	Note: You may need to lower the RAM allocated to various services to fit within the bounds of the resource of the containers.
 -	Enable the beer-sample bucket to load some sample data.
 
-![Creating a cluster](https://d774lla4im6mk.cloudfront.net/6.6.2/cluster-creation.jpg)
+![Creating a cluster](https://d774lla4im6mk.cloudfront.net/cluster-creation.jpg)
 
-![Completing the wizard](https://d774lla4im6mk.cloudfront.net/6.6.2/finish-wizard.jpg)
+![Completing the wizard](https://d774lla4im6mk.cloudfront.net/finish-wizard.jpg)
 
-![UI home](https://d774lla4im6mk.cloudfront.net/6.6.2/ui-home.jpg)
+![UI home](https://d774lla4im6mk.cloudfront.net/ui-home.jpg)
 
-![Loading sample data](https://d774lla4im6mk.cloudfront.net/6.6.2/load-sample-data.jpg)
+![Loading sample data](https://d774lla4im6mk.cloudfront.net/load-sample-data.jpg)
 
 **Note :** For detailed information on configuring the Server, see [Deployment Guidelines](https://docs.couchbase.com/server/current/install/install-production-deployment.html).
 

--- a/community/couchbase-server/4.1.0/README.md
+++ b/community/couchbase-server/4.1.0/README.md
@@ -26,20 +26,20 @@ Here is how to get a single node Couchbase Server cluster running on Docker cont
 
 **Step - 2 :** Next, visit `http://localhost:8091` on the host machine to see the Web Console to start Couchbase Server setup.
 
-![Setup splash screen](https://d774lla4im6mk.cloudfront.net/6.6.2/setup-initial.jpg)
+![Setup splash screen](https://d774lla4im6mk.cloudfront.net/setup-initial.jpg)
 
 Walk through the Setup wizard and accept the default values.
 
 -	Note: You may need to lower the RAM allocated to various services to fit within the bounds of the resource of the containers.
 -	Enable the beer-sample bucket to load some sample data.
 
-![Creating a cluster](https://d774lla4im6mk.cloudfront.net/6.6.2/cluster-creation.jpg)
+![Creating a cluster](https://d774lla4im6mk.cloudfront.net/cluster-creation.jpg)
 
-![Completing the wizard](https://d774lla4im6mk.cloudfront.net/6.6.2/finish-wizard.jpg)
+![Completing the wizard](https://d774lla4im6mk.cloudfront.net/finish-wizard.jpg)
 
-![UI home](https://d774lla4im6mk.cloudfront.net/6.6.2/ui-home.jpg)
+![UI home](https://d774lla4im6mk.cloudfront.net/ui-home.jpg)
 
-![Loading sample data](https://d774lla4im6mk.cloudfront.net/6.6.2/load-sample-data.jpg)
+![Loading sample data](https://d774lla4im6mk.cloudfront.net/load-sample-data.jpg)
 
 **Note :** For detailed information on configuring the Server, see [Deployment Guidelines](https://docs.couchbase.com/server/current/install/install-production-deployment.html).
 

--- a/community/couchbase-server/4.1.1/README.md
+++ b/community/couchbase-server/4.1.1/README.md
@@ -26,20 +26,20 @@ Here is how to get a single node Couchbase Server cluster running on Docker cont
 
 **Step - 2 :** Next, visit `http://localhost:8091` on the host machine to see the Web Console to start Couchbase Server setup.
 
-![Setup splash screen](https://d774lla4im6mk.cloudfront.net/6.6.2/setup-initial.jpg)
+![Setup splash screen](https://d774lla4im6mk.cloudfront.net/setup-initial.jpg)
 
 Walk through the Setup wizard and accept the default values.
 
 -	Note: You may need to lower the RAM allocated to various services to fit within the bounds of the resource of the containers.
 -	Enable the beer-sample bucket to load some sample data.
 
-![Creating a cluster](https://d774lla4im6mk.cloudfront.net/6.6.2/cluster-creation.jpg)
+![Creating a cluster](https://d774lla4im6mk.cloudfront.net/cluster-creation.jpg)
 
-![Completing the wizard](https://d774lla4im6mk.cloudfront.net/6.6.2/finish-wizard.jpg)
+![Completing the wizard](https://d774lla4im6mk.cloudfront.net/finish-wizard.jpg)
 
-![UI home](https://d774lla4im6mk.cloudfront.net/6.6.2/ui-home.jpg)
+![UI home](https://d774lla4im6mk.cloudfront.net/ui-home.jpg)
 
-![Loading sample data](https://d774lla4im6mk.cloudfront.net/6.6.2/load-sample-data.jpg)
+![Loading sample data](https://d774lla4im6mk.cloudfront.net/load-sample-data.jpg)
 
 **Note :** For detailed information on configuring the Server, see [Deployment Guidelines](https://docs.couchbase.com/server/current/install/install-production-deployment.html).
 

--- a/community/couchbase-server/4.5.0/README.md
+++ b/community/couchbase-server/4.5.0/README.md
@@ -26,20 +26,20 @@ Here is how to get a single node Couchbase Server cluster running on Docker cont
 
 **Step - 2 :** Next, visit `http://localhost:8091` on the host machine to see the Web Console to start Couchbase Server setup.
 
-![Setup splash screen](https://d774lla4im6mk.cloudfront.net/6.6.2/setup-initial.jpg)
+![Setup splash screen](https://d774lla4im6mk.cloudfront.net/setup-initial.jpg)
 
 Walk through the Setup wizard and accept the default values.
 
 -	Note: You may need to lower the RAM allocated to various services to fit within the bounds of the resource of the containers.
 -	Enable the beer-sample bucket to load some sample data.
 
-![Creating a cluster](https://d774lla4im6mk.cloudfront.net/6.6.2/cluster-creation.jpg)
+![Creating a cluster](https://d774lla4im6mk.cloudfront.net/cluster-creation.jpg)
 
-![Completing the wizard](https://d774lla4im6mk.cloudfront.net/6.6.2/finish-wizard.jpg)
+![Completing the wizard](https://d774lla4im6mk.cloudfront.net/finish-wizard.jpg)
 
-![UI home](https://d774lla4im6mk.cloudfront.net/6.6.2/ui-home.jpg)
+![UI home](https://d774lla4im6mk.cloudfront.net/ui-home.jpg)
 
-![Loading sample data](https://d774lla4im6mk.cloudfront.net/6.6.2/load-sample-data.jpg)
+![Loading sample data](https://d774lla4im6mk.cloudfront.net/load-sample-data.jpg)
 
 **Note :** For detailed information on configuring the Server, see [Deployment Guidelines](https://docs.couchbase.com/server/current/install/install-production-deployment.html).
 

--- a/community/couchbase-server/4.5.1/README.md
+++ b/community/couchbase-server/4.5.1/README.md
@@ -26,20 +26,20 @@ Here is how to get a single node Couchbase Server cluster running on Docker cont
 
 **Step - 2 :** Next, visit `http://localhost:8091` on the host machine to see the Web Console to start Couchbase Server setup.
 
-![Setup splash screen](https://d774lla4im6mk.cloudfront.net/6.6.2/setup-initial.jpg)
+![Setup splash screen](https://d774lla4im6mk.cloudfront.net/setup-initial.jpg)
 
 Walk through the Setup wizard and accept the default values.
 
 -	Note: You may need to lower the RAM allocated to various services to fit within the bounds of the resource of the containers.
 -	Enable the beer-sample bucket to load some sample data.
 
-![Creating a cluster](https://d774lla4im6mk.cloudfront.net/6.6.2/cluster-creation.jpg)
+![Creating a cluster](https://d774lla4im6mk.cloudfront.net/cluster-creation.jpg)
 
-![Completing the wizard](https://d774lla4im6mk.cloudfront.net/6.6.2/finish-wizard.jpg)
+![Completing the wizard](https://d774lla4im6mk.cloudfront.net/finish-wizard.jpg)
 
-![UI home](https://d774lla4im6mk.cloudfront.net/6.6.2/ui-home.jpg)
+![UI home](https://d774lla4im6mk.cloudfront.net/ui-home.jpg)
 
-![Loading sample data](https://d774lla4im6mk.cloudfront.net/6.6.2/load-sample-data.jpg)
+![Loading sample data](https://d774lla4im6mk.cloudfront.net/load-sample-data.jpg)
 
 **Note :** For detailed information on configuring the Server, see [Deployment Guidelines](https://docs.couchbase.com/server/current/install/install-production-deployment.html).
 

--- a/community/couchbase-server/5.0.1/README.md
+++ b/community/couchbase-server/5.0.1/README.md
@@ -26,20 +26,20 @@ Here is how to get a single node Couchbase Server cluster running on Docker cont
 
 **Step - 2 :** Next, visit `http://localhost:8091` on the host machine to see the Web Console to start Couchbase Server setup.
 
-![Setup splash screen](https://d774lla4im6mk.cloudfront.net/6.6.2/setup-initial.jpg)
+![Setup splash screen](https://d774lla4im6mk.cloudfront.net/setup-initial.jpg)
 
 Walk through the Setup wizard and accept the default values.
 
 -	Note: You may need to lower the RAM allocated to various services to fit within the bounds of the resource of the containers.
 -	Enable the beer-sample bucket to load some sample data.
 
-![Creating a cluster](https://d774lla4im6mk.cloudfront.net/6.6.2/cluster-creation.jpg)
+![Creating a cluster](https://d774lla4im6mk.cloudfront.net/cluster-creation.jpg)
 
-![Completing the wizard](https://d774lla4im6mk.cloudfront.net/6.6.2/finish-wizard.jpg)
+![Completing the wizard](https://d774lla4im6mk.cloudfront.net/finish-wizard.jpg)
 
-![UI home](https://d774lla4im6mk.cloudfront.net/6.6.2/ui-home.jpg)
+![UI home](https://d774lla4im6mk.cloudfront.net/ui-home.jpg)
 
-![Loading sample data](https://d774lla4im6mk.cloudfront.net/6.6.2/load-sample-data.jpg)
+![Loading sample data](https://d774lla4im6mk.cloudfront.net/load-sample-data.jpg)
 
 **Note :** For detailed information on configuring the Server, see [Deployment Guidelines](https://docs.couchbase.com/server/current/install/install-production-deployment.html).
 

--- a/community/couchbase-server/5.1.1/README.md
+++ b/community/couchbase-server/5.1.1/README.md
@@ -26,20 +26,20 @@ Here is how to get a single node Couchbase Server cluster running on Docker cont
 
 **Step - 2 :** Next, visit `http://localhost:8091` on the host machine to see the Web Console to start Couchbase Server setup.
 
-![Setup splash screen](https://d774lla4im6mk.cloudfront.net/6.6.2/setup-initial.jpg)
+![Setup splash screen](https://d774lla4im6mk.cloudfront.net/setup-initial.jpg)
 
 Walk through the Setup wizard and accept the default values.
 
 -	Note: You may need to lower the RAM allocated to various services to fit within the bounds of the resource of the containers.
 -	Enable the beer-sample bucket to load some sample data.
 
-![Creating a cluster](https://d774lla4im6mk.cloudfront.net/6.6.2/cluster-creation.jpg)
+![Creating a cluster](https://d774lla4im6mk.cloudfront.net/cluster-creation.jpg)
 
-![Completing the wizard](https://d774lla4im6mk.cloudfront.net/6.6.2/finish-wizard.jpg)
+![Completing the wizard](https://d774lla4im6mk.cloudfront.net/finish-wizard.jpg)
 
-![UI home](https://d774lla4im6mk.cloudfront.net/6.6.2/ui-home.jpg)
+![UI home](https://d774lla4im6mk.cloudfront.net/ui-home.jpg)
 
-![Loading sample data](https://d774lla4im6mk.cloudfront.net/6.6.2/load-sample-data.jpg)
+![Loading sample data](https://d774lla4im6mk.cloudfront.net/load-sample-data.jpg)
 
 **Note :** For detailed information on configuring the Server, see [Deployment Guidelines](https://docs.couchbase.com/server/current/install/install-production-deployment.html).
 

--- a/community/couchbase-server/6.0.0/README.md
+++ b/community/couchbase-server/6.0.0/README.md
@@ -26,20 +26,20 @@ Here is how to get a single node Couchbase Server cluster running on Docker cont
 
 **Step - 2 :** Next, visit `http://localhost:8091` on the host machine to see the Web Console to start Couchbase Server setup.
 
-![Setup splash screen](https://d774lla4im6mk.cloudfront.net/6.6.2/setup-initial.jpg)
+![Setup splash screen](https://d774lla4im6mk.cloudfront.net/setup-initial.jpg)
 
 Walk through the Setup wizard and accept the default values.
 
 -	Note: You may need to lower the RAM allocated to various services to fit within the bounds of the resource of the containers.
 -	Enable the beer-sample bucket to load some sample data.
 
-![Creating a cluster](https://d774lla4im6mk.cloudfront.net/6.6.2/cluster-creation.jpg)
+![Creating a cluster](https://d774lla4im6mk.cloudfront.net/cluster-creation.jpg)
 
-![Completing the wizard](https://d774lla4im6mk.cloudfront.net/6.6.2/finish-wizard.jpg)
+![Completing the wizard](https://d774lla4im6mk.cloudfront.net/finish-wizard.jpg)
 
-![UI home](https://d774lla4im6mk.cloudfront.net/6.6.2/ui-home.jpg)
+![UI home](https://d774lla4im6mk.cloudfront.net/ui-home.jpg)
 
-![Loading sample data](https://d774lla4im6mk.cloudfront.net/6.6.2/load-sample-data.jpg)
+![Loading sample data](https://d774lla4im6mk.cloudfront.net/load-sample-data.jpg)
 
 **Note :** For detailed information on configuring the Server, see [Deployment Guidelines](https://docs.couchbase.com/server/current/install/install-production-deployment.html).
 

--- a/community/couchbase-server/6.5.0/README.md
+++ b/community/couchbase-server/6.5.0/README.md
@@ -26,20 +26,20 @@ Here is how to get a single node Couchbase Server cluster running on Docker cont
 
 **Step - 2 :** Next, visit `http://localhost:8091` on the host machine to see the Web Console to start Couchbase Server setup.
 
-![Setup splash screen](https://d774lla4im6mk.cloudfront.net/6.6.2/setup-initial.jpg)
+![Setup splash screen](https://d774lla4im6mk.cloudfront.net/setup-initial.jpg)
 
 Walk through the Setup wizard and accept the default values.
 
 -	Note: You may need to lower the RAM allocated to various services to fit within the bounds of the resource of the containers.
 -	Enable the beer-sample bucket to load some sample data.
 
-![Creating a cluster](https://d774lla4im6mk.cloudfront.net/6.6.2/cluster-creation.jpg)
+![Creating a cluster](https://d774lla4im6mk.cloudfront.net/cluster-creation.jpg)
 
-![Completing the wizard](https://d774lla4im6mk.cloudfront.net/6.6.2/finish-wizard.jpg)
+![Completing the wizard](https://d774lla4im6mk.cloudfront.net/finish-wizard.jpg)
 
-![UI home](https://d774lla4im6mk.cloudfront.net/6.6.2/ui-home.jpg)
+![UI home](https://d774lla4im6mk.cloudfront.net/ui-home.jpg)
 
-![Loading sample data](https://d774lla4im6mk.cloudfront.net/6.6.2/load-sample-data.jpg)
+![Loading sample data](https://d774lla4im6mk.cloudfront.net/load-sample-data.jpg)
 
 **Note :** For detailed information on configuring the Server, see [Deployment Guidelines](https://docs.couchbase.com/server/current/install/install-production-deployment.html).
 

--- a/community/couchbase-server/6.5.1/README.md
+++ b/community/couchbase-server/6.5.1/README.md
@@ -26,20 +26,20 @@ Here is how to get a single node Couchbase Server cluster running on Docker cont
 
 **Step - 2 :** Next, visit `http://localhost:8091` on the host machine to see the Web Console to start Couchbase Server setup.
 
-![Setup splash screen](https://d774lla4im6mk.cloudfront.net/6.6.2/setup-initial.jpg)
+![Setup splash screen](https://d774lla4im6mk.cloudfront.net/setup-initial.jpg)
 
 Walk through the Setup wizard and accept the default values.
 
 -	Note: You may need to lower the RAM allocated to various services to fit within the bounds of the resource of the containers.
 -	Enable the beer-sample bucket to load some sample data.
 
-![Creating a cluster](https://d774lla4im6mk.cloudfront.net/6.6.2/cluster-creation.jpg)
+![Creating a cluster](https://d774lla4im6mk.cloudfront.net/cluster-creation.jpg)
 
-![Completing the wizard](https://d774lla4im6mk.cloudfront.net/6.6.2/finish-wizard.jpg)
+![Completing the wizard](https://d774lla4im6mk.cloudfront.net/finish-wizard.jpg)
 
-![UI home](https://d774lla4im6mk.cloudfront.net/6.6.2/ui-home.jpg)
+![UI home](https://d774lla4im6mk.cloudfront.net/ui-home.jpg)
 
-![Loading sample data](https://d774lla4im6mk.cloudfront.net/6.6.2/load-sample-data.jpg)
+![Loading sample data](https://d774lla4im6mk.cloudfront.net/load-sample-data.jpg)
 
 **Note :** For detailed information on configuring the Server, see [Deployment Guidelines](https://docs.couchbase.com/server/current/install/install-production-deployment.html).
 

--- a/community/couchbase-server/6.6.0/README.md
+++ b/community/couchbase-server/6.6.0/README.md
@@ -26,20 +26,20 @@ Here is how to get a single node Couchbase Server cluster running on Docker cont
 
 **Step - 2 :** Next, visit `http://localhost:8091` on the host machine to see the Web Console to start Couchbase Server setup.
 
-![Setup splash screen](https://d774lla4im6mk.cloudfront.net/6.6.2/setup-initial.jpg)
+![Setup splash screen](https://d774lla4im6mk.cloudfront.net/setup-initial.jpg)
 
 Walk through the Setup wizard and accept the default values.
 
 -	Note: You may need to lower the RAM allocated to various services to fit within the bounds of the resource of the containers.
 -	Enable the beer-sample bucket to load some sample data.
 
-![Creating a cluster](https://d774lla4im6mk.cloudfront.net/6.6.2/cluster-creation.jpg)
+![Creating a cluster](https://d774lla4im6mk.cloudfront.net/cluster-creation.jpg)
 
-![Completing the wizard](https://d774lla4im6mk.cloudfront.net/6.6.2/finish-wizard.jpg)
+![Completing the wizard](https://d774lla4im6mk.cloudfront.net/finish-wizard.jpg)
 
-![UI home](https://d774lla4im6mk.cloudfront.net/6.6.2/ui-home.jpg)
+![UI home](https://d774lla4im6mk.cloudfront.net/ui-home.jpg)
 
-![Loading sample data](https://d774lla4im6mk.cloudfront.net/6.6.2/load-sample-data.jpg)
+![Loading sample data](https://d774lla4im6mk.cloudfront.net/load-sample-data.jpg)
 
 **Note :** For detailed information on configuring the Server, see [Deployment Guidelines](https://docs.couchbase.com/server/current/install/install-production-deployment.html).
 

--- a/community/couchbase-server/7.0.0-beta/README.md
+++ b/community/couchbase-server/7.0.0-beta/README.md
@@ -26,20 +26,20 @@ Here is how to get a single node Couchbase Server cluster running on Docker cont
 
 **Step - 2 :** Next, visit `http://localhost:8091` on the host machine to see the Web Console to start Couchbase Server setup.
 
-![Setup splash screen](https://d774lla4im6mk.cloudfront.net/6.6.2/setup-initial.jpg)
+![Setup splash screen](https://d774lla4im6mk.cloudfront.net/setup-initial.jpg)
 
 Walk through the Setup wizard and accept the default values.
 
 -	Note: You may need to lower the RAM allocated to various services to fit within the bounds of the resource of the containers.
 -	Enable the beer-sample bucket to load some sample data.
 
-![Creating a cluster](https://d774lla4im6mk.cloudfront.net/6.6.2/cluster-creation.jpg)
+![Creating a cluster](https://d774lla4im6mk.cloudfront.net/cluster-creation.jpg)
 
-![Completing the wizard](https://d774lla4im6mk.cloudfront.net/6.6.2/finish-wizard.jpg)
+![Completing the wizard](https://d774lla4im6mk.cloudfront.net/finish-wizard.jpg)
 
-![UI home](https://d774lla4im6mk.cloudfront.net/6.6.2/ui-home.jpg)
+![UI home](https://d774lla4im6mk.cloudfront.net/ui-home.jpg)
 
-![Loading sample data](https://d774lla4im6mk.cloudfront.net/6.6.2/load-sample-data.jpg)
+![Loading sample data](https://d774lla4im6mk.cloudfront.net/load-sample-data.jpg)
 
 **Note :** For detailed information on configuring the Server, see [Deployment Guidelines](https://docs.couchbase.com/server/current/install/install-production-deployment.html).
 

--- a/community/couchbase-server/7.0.0/README.md
+++ b/community/couchbase-server/7.0.0/README.md
@@ -26,20 +26,20 @@ Here is how to get a single node Couchbase Server cluster running on Docker cont
 
 **Step - 2 :** Next, visit `http://localhost:8091` on the host machine to see the Web Console to start Couchbase Server setup.
 
-![Setup splash screen](https://d774lla4im6mk.cloudfront.net/6.6.2/setup-initial.jpg)
+![Setup splash screen](https://d774lla4im6mk.cloudfront.net/setup-initial.jpg)
 
 Walk through the Setup wizard and accept the default values.
 
 -	Note: You may need to lower the RAM allocated to various services to fit within the bounds of the resource of the containers.
 -	Enable the beer-sample bucket to load some sample data.
 
-![Creating a cluster](https://d774lla4im6mk.cloudfront.net/6.6.2/cluster-creation.jpg)
+![Creating a cluster](https://d774lla4im6mk.cloudfront.net/cluster-creation.jpg)
 
-![Completing the wizard](https://d774lla4im6mk.cloudfront.net/6.6.2/finish-wizard.jpg)
+![Completing the wizard](https://d774lla4im6mk.cloudfront.net/finish-wizard.jpg)
 
-![UI home](https://d774lla4im6mk.cloudfront.net/6.6.2/ui-home.jpg)
+![UI home](https://d774lla4im6mk.cloudfront.net/ui-home.jpg)
 
-![Loading sample data](https://d774lla4im6mk.cloudfront.net/6.6.2/load-sample-data.jpg)
+![Loading sample data](https://d774lla4im6mk.cloudfront.net/load-sample-data.jpg)
 
 **Note :** For detailed information on configuring the Server, see [Deployment Guidelines](https://docs.couchbase.com/server/current/install/install-production-deployment.html).
 

--- a/community/couchbase-server/7.0.1/README.md
+++ b/community/couchbase-server/7.0.1/README.md
@@ -26,20 +26,20 @@ Here is how to get a single node Couchbase Server cluster running on Docker cont
 
 **Step - 2 :** Next, visit `http://localhost:8091` on the host machine to see the Web Console to start Couchbase Server setup.
 
-![Setup splash screen](https://d774lla4im6mk.cloudfront.net/6.6.2/setup-initial.jpg)
+![Setup splash screen](https://d774lla4im6mk.cloudfront.net/setup-initial.jpg)
 
 Walk through the Setup wizard and accept the default values.
 
 -	Note: You may need to lower the RAM allocated to various services to fit within the bounds of the resource of the containers.
 -	Enable the beer-sample bucket to load some sample data.
 
-![Creating a cluster](https://d774lla4im6mk.cloudfront.net/6.6.2/cluster-creation.jpg)
+![Creating a cluster](https://d774lla4im6mk.cloudfront.net/cluster-creation.jpg)
 
-![Completing the wizard](https://d774lla4im6mk.cloudfront.net/6.6.2/finish-wizard.jpg)
+![Completing the wizard](https://d774lla4im6mk.cloudfront.net/finish-wizard.jpg)
 
-![UI home](https://d774lla4im6mk.cloudfront.net/6.6.2/ui-home.jpg)
+![UI home](https://d774lla4im6mk.cloudfront.net/ui-home.jpg)
 
-![Loading sample data](https://d774lla4im6mk.cloudfront.net/6.6.2/load-sample-data.jpg)
+![Loading sample data](https://d774lla4im6mk.cloudfront.net/load-sample-data.jpg)
 
 **Note :** For detailed information on configuring the Server, see [Deployment Guidelines](https://docs.couchbase.com/server/current/install/install-production-deployment.html).
 

--- a/community/couchbase-server/7.0.2/README.md
+++ b/community/couchbase-server/7.0.2/README.md
@@ -26,20 +26,20 @@ Here is how to get a single node Couchbase Server cluster running on Docker cont
 
 **Step - 2 :** Next, visit `http://localhost:8091` on the host machine to see the Web Console to start Couchbase Server setup.
 
-![Setup splash screen](https://d774lla4im6mk.cloudfront.net/6.6.2/setup-initial.jpg)
+![Setup splash screen](https://d774lla4im6mk.cloudfront.net/setup-initial.jpg)
 
 Walk through the Setup wizard and accept the default values.
 
 -	Note: You may need to lower the RAM allocated to various services to fit within the bounds of the resource of the containers.
 -	Enable the beer-sample bucket to load some sample data.
 
-![Creating a cluster](https://d774lla4im6mk.cloudfront.net/6.6.2/cluster-creation.jpg)
+![Creating a cluster](https://d774lla4im6mk.cloudfront.net/cluster-creation.jpg)
 
-![Completing the wizard](https://d774lla4im6mk.cloudfront.net/6.6.2/finish-wizard.jpg)
+![Completing the wizard](https://d774lla4im6mk.cloudfront.net/finish-wizard.jpg)
 
-![UI home](https://d774lla4im6mk.cloudfront.net/6.6.2/ui-home.jpg)
+![UI home](https://d774lla4im6mk.cloudfront.net/ui-home.jpg)
 
-![Loading sample data](https://d774lla4im6mk.cloudfront.net/6.6.2/load-sample-data.jpg)
+![Loading sample data](https://d774lla4im6mk.cloudfront.net/load-sample-data.jpg)
 
 **Note :** For detailed information on configuring the Server, see [Deployment Guidelines](https://docs.couchbase.com/server/current/install/install-production-deployment.html).
 

--- a/community/couchbase-server/7.1.0/aarch64/README.md
+++ b/community/couchbase-server/7.1.0/aarch64/README.md
@@ -26,20 +26,20 @@ Here is how to get a single node Couchbase Server cluster running on Docker cont
 
 **Step - 2 :** Next, visit `http://localhost:8091` on the host machine to see the Web Console to start Couchbase Server setup.
 
-![Setup splash screen](https://d774lla4im6mk.cloudfront.net/6.6.2/setup-initial.jpg)
+![Setup splash screen](https://d774lla4im6mk.cloudfront.net/setup-initial.jpg)
 
 Walk through the Setup wizard and accept the default values.
 
 -	Note: You may need to lower the RAM allocated to various services to fit within the bounds of the resource of the containers.
 -	Enable the beer-sample bucket to load some sample data.
 
-![Creating a cluster](https://d774lla4im6mk.cloudfront.net/6.6.2/cluster-creation.jpg)
+![Creating a cluster](https://d774lla4im6mk.cloudfront.net/cluster-creation.jpg)
 
-![Completing the wizard](https://d774lla4im6mk.cloudfront.net/6.6.2/finish-wizard.jpg)
+![Completing the wizard](https://d774lla4im6mk.cloudfront.net/finish-wizard.jpg)
 
-![UI home](https://d774lla4im6mk.cloudfront.net/6.6.2/ui-home.jpg)
+![UI home](https://d774lla4im6mk.cloudfront.net/ui-home.jpg)
 
-![Loading sample data](https://d774lla4im6mk.cloudfront.net/6.6.2/load-sample-data.jpg)
+![Loading sample data](https://d774lla4im6mk.cloudfront.net/load-sample-data.jpg)
 
 **Note :** For detailed information on configuring the Server, see [Deployment Guidelines](https://docs.couchbase.com/server/current/install/install-production-deployment.html).
 

--- a/community/couchbase-server/7.1.0/x86_64/README.md
+++ b/community/couchbase-server/7.1.0/x86_64/README.md
@@ -26,20 +26,20 @@ Here is how to get a single node Couchbase Server cluster running on Docker cont
 
 **Step - 2 :** Next, visit `http://localhost:8091` on the host machine to see the Web Console to start Couchbase Server setup.
 
-![Setup splash screen](https://d774lla4im6mk.cloudfront.net/6.6.2/setup-initial.jpg)
+![Setup splash screen](https://d774lla4im6mk.cloudfront.net/setup-initial.jpg)
 
 Walk through the Setup wizard and accept the default values.
 
 -	Note: You may need to lower the RAM allocated to various services to fit within the bounds of the resource of the containers.
 -	Enable the beer-sample bucket to load some sample data.
 
-![Creating a cluster](https://d774lla4im6mk.cloudfront.net/6.6.2/cluster-creation.jpg)
+![Creating a cluster](https://d774lla4im6mk.cloudfront.net/cluster-creation.jpg)
 
-![Completing the wizard](https://d774lla4im6mk.cloudfront.net/6.6.2/finish-wizard.jpg)
+![Completing the wizard](https://d774lla4im6mk.cloudfront.net/finish-wizard.jpg)
 
-![UI home](https://d774lla4im6mk.cloudfront.net/6.6.2/ui-home.jpg)
+![UI home](https://d774lla4im6mk.cloudfront.net/ui-home.jpg)
 
-![Loading sample data](https://d774lla4im6mk.cloudfront.net/6.6.2/load-sample-data.jpg)
+![Loading sample data](https://d774lla4im6mk.cloudfront.net/load-sample-data.jpg)
 
 **Note :** For detailed information on configuring the Server, see [Deployment Guidelines](https://docs.couchbase.com/server/current/install/install-production-deployment.html).
 

--- a/community/sync-gateway/2.1.0/README.md
+++ b/community/sync-gateway/2.1.0/README.md
@@ -80,10 +80,19 @@ $ curl http://localhost:4985
 
 **Step - 1 :** Prepare the Sync Gateway configuration file on your local machine:
 
+For versions 3.0.0 and newer:
 ```
 $ cd /tmp
-$ wget https://raw.githubusercontent.com/couchbase/sync_gateway/master/examples/basic-walrus-bucket.json
-$ mv basic-walrus-bucket.json my-sg-config.json
+$ wget https://raw.githubusercontent.com/couchbase/sync_gateway/master/examples/startup_config/basic.json
+$ mv basic.json my-sg-config.json
+$ vi my-sg-config.json  # make edits
+```
+
+For older versions:
+```
+$ cd /tmp
+$ wget https://raw.githubusercontent.com/couchbase/sync_gateway/master/examples/release/2.8.3/examples/serviceconfig.json
+$ mv serviceconfig.json my-sg-config.json
 $ vi my-sg-config.json  # make edits
 ```
 
@@ -99,7 +108,13 @@ Sync Gateway can also load its configuration directly from a public URL.
 
 **Step - 2 :** Then start Sync Gateway and give it the URL to the raw JSON data:
 
-`$ docker run -p 4984:4984 -d couchbase/sync-gateway https://raw.githubusercontent.com/couchbase/sync_gateway/master/examples/basic-walrus-bucket.json`
+For versions 3.0.0 and newer:
+
+`$ docker run -p 4984:4984 -d couchbase/sync-gateway https://raw.githubusercontent.com/couchbase/sync_gateway/master/examples/startup_config/basic.json`
+
+For older versions:
+
+`$ docker run -p 4984:4984 -d couchbase/sync-gateway https://raw.githubusercontent.com/couchbase/sync_gateway/release/2.8.3/examples/serviceconfig.json`
 
 # Running with a Couchbase Server container
 

--- a/community/sync-gateway/2.1.1/README.md
+++ b/community/sync-gateway/2.1.1/README.md
@@ -80,10 +80,19 @@ $ curl http://localhost:4985
 
 **Step - 1 :** Prepare the Sync Gateway configuration file on your local machine:
 
+For versions 3.0.0 and newer:
 ```
 $ cd /tmp
-$ wget https://raw.githubusercontent.com/couchbase/sync_gateway/master/examples/basic-walrus-bucket.json
-$ mv basic-walrus-bucket.json my-sg-config.json
+$ wget https://raw.githubusercontent.com/couchbase/sync_gateway/master/examples/startup_config/basic.json
+$ mv basic.json my-sg-config.json
+$ vi my-sg-config.json  # make edits
+```
+
+For older versions:
+```
+$ cd /tmp
+$ wget https://raw.githubusercontent.com/couchbase/sync_gateway/master/examples/release/2.8.3/examples/serviceconfig.json
+$ mv serviceconfig.json my-sg-config.json
 $ vi my-sg-config.json  # make edits
 ```
 
@@ -99,7 +108,13 @@ Sync Gateway can also load its configuration directly from a public URL.
 
 **Step - 2 :** Then start Sync Gateway and give it the URL to the raw JSON data:
 
-`$ docker run -p 4984:4984 -d couchbase/sync-gateway https://raw.githubusercontent.com/couchbase/sync_gateway/master/examples/basic-walrus-bucket.json`
+For versions 3.0.0 and newer:
+
+`$ docker run -p 4984:4984 -d couchbase/sync-gateway https://raw.githubusercontent.com/couchbase/sync_gateway/master/examples/startup_config/basic.json`
+
+For older versions:
+
+`$ docker run -p 4984:4984 -d couchbase/sync-gateway https://raw.githubusercontent.com/couchbase/sync_gateway/release/2.8.3/examples/serviceconfig.json`
 
 # Running with a Couchbase Server container
 

--- a/community/sync-gateway/2.1.2/README.md
+++ b/community/sync-gateway/2.1.2/README.md
@@ -80,10 +80,19 @@ $ curl http://localhost:4985
 
 **Step - 1 :** Prepare the Sync Gateway configuration file on your local machine:
 
+For versions 3.0.0 and newer:
 ```
 $ cd /tmp
-$ wget https://raw.githubusercontent.com/couchbase/sync_gateway/master/examples/basic-walrus-bucket.json
-$ mv basic-walrus-bucket.json my-sg-config.json
+$ wget https://raw.githubusercontent.com/couchbase/sync_gateway/master/examples/startup_config/basic.json
+$ mv basic.json my-sg-config.json
+$ vi my-sg-config.json  # make edits
+```
+
+For older versions:
+```
+$ cd /tmp
+$ wget https://raw.githubusercontent.com/couchbase/sync_gateway/master/examples/release/2.8.3/examples/serviceconfig.json
+$ mv serviceconfig.json my-sg-config.json
 $ vi my-sg-config.json  # make edits
 ```
 
@@ -99,7 +108,13 @@ Sync Gateway can also load its configuration directly from a public URL.
 
 **Step - 2 :** Then start Sync Gateway and give it the URL to the raw JSON data:
 
-`$ docker run -p 4984:4984 -d couchbase/sync-gateway https://raw.githubusercontent.com/couchbase/sync_gateway/master/examples/basic-walrus-bucket.json`
+For versions 3.0.0 and newer:
+
+`$ docker run -p 4984:4984 -d couchbase/sync-gateway https://raw.githubusercontent.com/couchbase/sync_gateway/master/examples/startup_config/basic.json`
+
+For older versions:
+
+`$ docker run -p 4984:4984 -d couchbase/sync-gateway https://raw.githubusercontent.com/couchbase/sync_gateway/release/2.8.3/examples/serviceconfig.json`
 
 # Running with a Couchbase Server container
 

--- a/community/sync-gateway/2.1.3/README.md
+++ b/community/sync-gateway/2.1.3/README.md
@@ -80,10 +80,19 @@ $ curl http://localhost:4985
 
 **Step - 1 :** Prepare the Sync Gateway configuration file on your local machine:
 
+For versions 3.0.0 and newer:
 ```
 $ cd /tmp
-$ wget https://raw.githubusercontent.com/couchbase/sync_gateway/master/examples/basic-walrus-bucket.json
-$ mv basic-walrus-bucket.json my-sg-config.json
+$ wget https://raw.githubusercontent.com/couchbase/sync_gateway/master/examples/startup_config/basic.json
+$ mv basic.json my-sg-config.json
+$ vi my-sg-config.json  # make edits
+```
+
+For older versions:
+```
+$ cd /tmp
+$ wget https://raw.githubusercontent.com/couchbase/sync_gateway/master/examples/release/2.8.3/examples/serviceconfig.json
+$ mv serviceconfig.json my-sg-config.json
 $ vi my-sg-config.json  # make edits
 ```
 
@@ -99,7 +108,13 @@ Sync Gateway can also load its configuration directly from a public URL.
 
 **Step - 2 :** Then start Sync Gateway and give it the URL to the raw JSON data:
 
-`$ docker run -p 4984:4984 -d couchbase/sync-gateway https://raw.githubusercontent.com/couchbase/sync_gateway/master/examples/basic-walrus-bucket.json`
+For versions 3.0.0 and newer:
+
+`$ docker run -p 4984:4984 -d couchbase/sync-gateway https://raw.githubusercontent.com/couchbase/sync_gateway/master/examples/startup_config/basic.json`
+
+For older versions:
+
+`$ docker run -p 4984:4984 -d couchbase/sync-gateway https://raw.githubusercontent.com/couchbase/sync_gateway/release/2.8.3/examples/serviceconfig.json`
 
 # Running with a Couchbase Server container
 

--- a/community/sync-gateway/2.5.0/README.md
+++ b/community/sync-gateway/2.5.0/README.md
@@ -80,10 +80,19 @@ $ curl http://localhost:4985
 
 **Step - 1 :** Prepare the Sync Gateway configuration file on your local machine:
 
+For versions 3.0.0 and newer:
 ```
 $ cd /tmp
-$ wget https://raw.githubusercontent.com/couchbase/sync_gateway/master/examples/basic-walrus-bucket.json
-$ mv basic-walrus-bucket.json my-sg-config.json
+$ wget https://raw.githubusercontent.com/couchbase/sync_gateway/master/examples/startup_config/basic.json
+$ mv basic.json my-sg-config.json
+$ vi my-sg-config.json  # make edits
+```
+
+For older versions:
+```
+$ cd /tmp
+$ wget https://raw.githubusercontent.com/couchbase/sync_gateway/master/examples/release/2.8.3/examples/serviceconfig.json
+$ mv serviceconfig.json my-sg-config.json
 $ vi my-sg-config.json  # make edits
 ```
 
@@ -99,7 +108,13 @@ Sync Gateway can also load its configuration directly from a public URL.
 
 **Step - 2 :** Then start Sync Gateway and give it the URL to the raw JSON data:
 
-`$ docker run -p 4984:4984 -d couchbase/sync-gateway https://raw.githubusercontent.com/couchbase/sync_gateway/master/examples/basic-walrus-bucket.json`
+For versions 3.0.0 and newer:
+
+`$ docker run -p 4984:4984 -d couchbase/sync-gateway https://raw.githubusercontent.com/couchbase/sync_gateway/master/examples/startup_config/basic.json`
+
+For older versions:
+
+`$ docker run -p 4984:4984 -d couchbase/sync-gateway https://raw.githubusercontent.com/couchbase/sync_gateway/release/2.8.3/examples/serviceconfig.json`
 
 # Running with a Couchbase Server container
 

--- a/community/sync-gateway/2.5.1/README.md
+++ b/community/sync-gateway/2.5.1/README.md
@@ -80,10 +80,19 @@ $ curl http://localhost:4985
 
 **Step - 1 :** Prepare the Sync Gateway configuration file on your local machine:
 
+For versions 3.0.0 and newer:
 ```
 $ cd /tmp
-$ wget https://raw.githubusercontent.com/couchbase/sync_gateway/master/examples/basic-walrus-bucket.json
-$ mv basic-walrus-bucket.json my-sg-config.json
+$ wget https://raw.githubusercontent.com/couchbase/sync_gateway/master/examples/startup_config/basic.json
+$ mv basic.json my-sg-config.json
+$ vi my-sg-config.json  # make edits
+```
+
+For older versions:
+```
+$ cd /tmp
+$ wget https://raw.githubusercontent.com/couchbase/sync_gateway/master/examples/release/2.8.3/examples/serviceconfig.json
+$ mv serviceconfig.json my-sg-config.json
 $ vi my-sg-config.json  # make edits
 ```
 
@@ -99,7 +108,13 @@ Sync Gateway can also load its configuration directly from a public URL.
 
 **Step - 2 :** Then start Sync Gateway and give it the URL to the raw JSON data:
 
-`$ docker run -p 4984:4984 -d couchbase/sync-gateway https://raw.githubusercontent.com/couchbase/sync_gateway/master/examples/basic-walrus-bucket.json`
+For versions 3.0.0 and newer:
+
+`$ docker run -p 4984:4984 -d couchbase/sync-gateway https://raw.githubusercontent.com/couchbase/sync_gateway/master/examples/startup_config/basic.json`
+
+For older versions:
+
+`$ docker run -p 4984:4984 -d couchbase/sync-gateway https://raw.githubusercontent.com/couchbase/sync_gateway/release/2.8.3/examples/serviceconfig.json`
 
 # Running with a Couchbase Server container
 

--- a/community/sync-gateway/2.6.0/README.md
+++ b/community/sync-gateway/2.6.0/README.md
@@ -80,10 +80,19 @@ $ curl http://localhost:4985
 
 **Step - 1 :** Prepare the Sync Gateway configuration file on your local machine:
 
+For versions 3.0.0 and newer:
 ```
 $ cd /tmp
-$ wget https://raw.githubusercontent.com/couchbase/sync_gateway/master/examples/basic-walrus-bucket.json
-$ mv basic-walrus-bucket.json my-sg-config.json
+$ wget https://raw.githubusercontent.com/couchbase/sync_gateway/master/examples/startup_config/basic.json
+$ mv basic.json my-sg-config.json
+$ vi my-sg-config.json  # make edits
+```
+
+For older versions:
+```
+$ cd /tmp
+$ wget https://raw.githubusercontent.com/couchbase/sync_gateway/master/examples/release/2.8.3/examples/serviceconfig.json
+$ mv serviceconfig.json my-sg-config.json
 $ vi my-sg-config.json  # make edits
 ```
 
@@ -99,7 +108,13 @@ Sync Gateway can also load its configuration directly from a public URL.
 
 **Step - 2 :** Then start Sync Gateway and give it the URL to the raw JSON data:
 
-`$ docker run -p 4984:4984 -d couchbase/sync-gateway https://raw.githubusercontent.com/couchbase/sync_gateway/master/examples/basic-walrus-bucket.json`
+For versions 3.0.0 and newer:
+
+`$ docker run -p 4984:4984 -d couchbase/sync-gateway https://raw.githubusercontent.com/couchbase/sync_gateway/master/examples/startup_config/basic.json`
+
+For older versions:
+
+`$ docker run -p 4984:4984 -d couchbase/sync-gateway https://raw.githubusercontent.com/couchbase/sync_gateway/release/2.8.3/examples/serviceconfig.json`
 
 # Running with a Couchbase Server container
 

--- a/community/sync-gateway/2.6.1/README.md
+++ b/community/sync-gateway/2.6.1/README.md
@@ -80,10 +80,19 @@ $ curl http://localhost:4985
 
 **Step - 1 :** Prepare the Sync Gateway configuration file on your local machine:
 
+For versions 3.0.0 and newer:
 ```
 $ cd /tmp
-$ wget https://raw.githubusercontent.com/couchbase/sync_gateway/master/examples/basic-walrus-bucket.json
-$ mv basic-walrus-bucket.json my-sg-config.json
+$ wget https://raw.githubusercontent.com/couchbase/sync_gateway/master/examples/startup_config/basic.json
+$ mv basic.json my-sg-config.json
+$ vi my-sg-config.json  # make edits
+```
+
+For older versions:
+```
+$ cd /tmp
+$ wget https://raw.githubusercontent.com/couchbase/sync_gateway/master/examples/release/2.8.3/examples/serviceconfig.json
+$ mv serviceconfig.json my-sg-config.json
 $ vi my-sg-config.json  # make edits
 ```
 
@@ -99,7 +108,13 @@ Sync Gateway can also load its configuration directly from a public URL.
 
 **Step - 2 :** Then start Sync Gateway and give it the URL to the raw JSON data:
 
-`$ docker run -p 4984:4984 -d couchbase/sync-gateway https://raw.githubusercontent.com/couchbase/sync_gateway/master/examples/basic-walrus-bucket.json`
+For versions 3.0.0 and newer:
+
+`$ docker run -p 4984:4984 -d couchbase/sync-gateway https://raw.githubusercontent.com/couchbase/sync_gateway/master/examples/startup_config/basic.json`
+
+For older versions:
+
+`$ docker run -p 4984:4984 -d couchbase/sync-gateway https://raw.githubusercontent.com/couchbase/sync_gateway/release/2.8.3/examples/serviceconfig.json`
 
 # Running with a Couchbase Server container
 

--- a/community/sync-gateway/2.7.0/README.md
+++ b/community/sync-gateway/2.7.0/README.md
@@ -80,10 +80,19 @@ $ curl http://localhost:4985
 
 **Step - 1 :** Prepare the Sync Gateway configuration file on your local machine:
 
+For versions 3.0.0 and newer:
 ```
 $ cd /tmp
-$ wget https://raw.githubusercontent.com/couchbase/sync_gateway/master/examples/basic-walrus-bucket.json
-$ mv basic-walrus-bucket.json my-sg-config.json
+$ wget https://raw.githubusercontent.com/couchbase/sync_gateway/master/examples/startup_config/basic.json
+$ mv basic.json my-sg-config.json
+$ vi my-sg-config.json  # make edits
+```
+
+For older versions:
+```
+$ cd /tmp
+$ wget https://raw.githubusercontent.com/couchbase/sync_gateway/master/examples/release/2.8.3/examples/serviceconfig.json
+$ mv serviceconfig.json my-sg-config.json
 $ vi my-sg-config.json  # make edits
 ```
 
@@ -99,7 +108,13 @@ Sync Gateway can also load its configuration directly from a public URL.
 
 **Step - 2 :** Then start Sync Gateway and give it the URL to the raw JSON data:
 
-`$ docker run -p 4984:4984 -d couchbase/sync-gateway https://raw.githubusercontent.com/couchbase/sync_gateway/master/examples/basic-walrus-bucket.json`
+For versions 3.0.0 and newer:
+
+`$ docker run -p 4984:4984 -d couchbase/sync-gateway https://raw.githubusercontent.com/couchbase/sync_gateway/master/examples/startup_config/basic.json`
+
+For older versions:
+
+`$ docker run -p 4984:4984 -d couchbase/sync-gateway https://raw.githubusercontent.com/couchbase/sync_gateway/release/2.8.3/examples/serviceconfig.json`
 
 # Running with a Couchbase Server container
 

--- a/community/sync-gateway/2.7.1/README.md
+++ b/community/sync-gateway/2.7.1/README.md
@@ -80,10 +80,19 @@ $ curl http://localhost:4985
 
 **Step - 1 :** Prepare the Sync Gateway configuration file on your local machine:
 
+For versions 3.0.0 and newer:
 ```
 $ cd /tmp
-$ wget https://raw.githubusercontent.com/couchbase/sync_gateway/master/examples/basic-walrus-bucket.json
-$ mv basic-walrus-bucket.json my-sg-config.json
+$ wget https://raw.githubusercontent.com/couchbase/sync_gateway/master/examples/startup_config/basic.json
+$ mv basic.json my-sg-config.json
+$ vi my-sg-config.json  # make edits
+```
+
+For older versions:
+```
+$ cd /tmp
+$ wget https://raw.githubusercontent.com/couchbase/sync_gateway/master/examples/release/2.8.3/examples/serviceconfig.json
+$ mv serviceconfig.json my-sg-config.json
 $ vi my-sg-config.json  # make edits
 ```
 
@@ -99,7 +108,13 @@ Sync Gateway can also load its configuration directly from a public URL.
 
 **Step - 2 :** Then start Sync Gateway and give it the URL to the raw JSON data:
 
-`$ docker run -p 4984:4984 -d couchbase/sync-gateway https://raw.githubusercontent.com/couchbase/sync_gateway/master/examples/basic-walrus-bucket.json`
+For versions 3.0.0 and newer:
+
+`$ docker run -p 4984:4984 -d couchbase/sync-gateway https://raw.githubusercontent.com/couchbase/sync_gateway/master/examples/startup_config/basic.json`
+
+For older versions:
+
+`$ docker run -p 4984:4984 -d couchbase/sync-gateway https://raw.githubusercontent.com/couchbase/sync_gateway/release/2.8.3/examples/serviceconfig.json`
 
 # Running with a Couchbase Server container
 

--- a/community/sync-gateway/2.7.2/README.md
+++ b/community/sync-gateway/2.7.2/README.md
@@ -80,10 +80,19 @@ $ curl http://localhost:4985
 
 **Step - 1 :** Prepare the Sync Gateway configuration file on your local machine:
 
+For versions 3.0.0 and newer:
 ```
 $ cd /tmp
-$ wget https://raw.githubusercontent.com/couchbase/sync_gateway/master/examples/basic-walrus-bucket.json
-$ mv basic-walrus-bucket.json my-sg-config.json
+$ wget https://raw.githubusercontent.com/couchbase/sync_gateway/master/examples/startup_config/basic.json
+$ mv basic.json my-sg-config.json
+$ vi my-sg-config.json  # make edits
+```
+
+For older versions:
+```
+$ cd /tmp
+$ wget https://raw.githubusercontent.com/couchbase/sync_gateway/master/examples/release/2.8.3/examples/serviceconfig.json
+$ mv serviceconfig.json my-sg-config.json
 $ vi my-sg-config.json  # make edits
 ```
 
@@ -99,7 +108,13 @@ Sync Gateway can also load its configuration directly from a public URL.
 
 **Step - 2 :** Then start Sync Gateway and give it the URL to the raw JSON data:
 
-`$ docker run -p 4984:4984 -d couchbase/sync-gateway https://raw.githubusercontent.com/couchbase/sync_gateway/master/examples/basic-walrus-bucket.json`
+For versions 3.0.0 and newer:
+
+`$ docker run -p 4984:4984 -d couchbase/sync-gateway https://raw.githubusercontent.com/couchbase/sync_gateway/master/examples/startup_config/basic.json`
+
+For older versions:
+
+`$ docker run -p 4984:4984 -d couchbase/sync-gateway https://raw.githubusercontent.com/couchbase/sync_gateway/release/2.8.3/examples/serviceconfig.json`
 
 # Running with a Couchbase Server container
 

--- a/community/sync-gateway/2.7.3/README.md
+++ b/community/sync-gateway/2.7.3/README.md
@@ -80,10 +80,19 @@ $ curl http://localhost:4985
 
 **Step - 1 :** Prepare the Sync Gateway configuration file on your local machine:
 
+For versions 3.0.0 and newer:
 ```
 $ cd /tmp
-$ wget https://raw.githubusercontent.com/couchbase/sync_gateway/master/examples/basic-walrus-bucket.json
-$ mv basic-walrus-bucket.json my-sg-config.json
+$ wget https://raw.githubusercontent.com/couchbase/sync_gateway/master/examples/startup_config/basic.json
+$ mv basic.json my-sg-config.json
+$ vi my-sg-config.json  # make edits
+```
+
+For older versions:
+```
+$ cd /tmp
+$ wget https://raw.githubusercontent.com/couchbase/sync_gateway/master/examples/release/2.8.3/examples/serviceconfig.json
+$ mv serviceconfig.json my-sg-config.json
 $ vi my-sg-config.json  # make edits
 ```
 
@@ -99,7 +108,13 @@ Sync Gateway can also load its configuration directly from a public URL.
 
 **Step - 2 :** Then start Sync Gateway and give it the URL to the raw JSON data:
 
-`$ docker run -p 4984:4984 -d couchbase/sync-gateway https://raw.githubusercontent.com/couchbase/sync_gateway/master/examples/basic-walrus-bucket.json`
+For versions 3.0.0 and newer:
+
+`$ docker run -p 4984:4984 -d couchbase/sync-gateway https://raw.githubusercontent.com/couchbase/sync_gateway/master/examples/startup_config/basic.json`
+
+For older versions:
+
+`$ docker run -p 4984:4984 -d couchbase/sync-gateway https://raw.githubusercontent.com/couchbase/sync_gateway/release/2.8.3/examples/serviceconfig.json`
 
 # Running with a Couchbase Server container
 

--- a/community/sync-gateway/2.7.4/README.md
+++ b/community/sync-gateway/2.7.4/README.md
@@ -80,10 +80,19 @@ $ curl http://localhost:4985
 
 **Step - 1 :** Prepare the Sync Gateway configuration file on your local machine:
 
+For versions 3.0.0 and newer:
 ```
 $ cd /tmp
-$ wget https://raw.githubusercontent.com/couchbase/sync_gateway/master/examples/basic-walrus-bucket.json
-$ mv basic-walrus-bucket.json my-sg-config.json
+$ wget https://raw.githubusercontent.com/couchbase/sync_gateway/master/examples/startup_config/basic.json
+$ mv basic.json my-sg-config.json
+$ vi my-sg-config.json  # make edits
+```
+
+For older versions:
+```
+$ cd /tmp
+$ wget https://raw.githubusercontent.com/couchbase/sync_gateway/master/examples/release/2.8.3/examples/serviceconfig.json
+$ mv serviceconfig.json my-sg-config.json
 $ vi my-sg-config.json  # make edits
 ```
 
@@ -99,7 +108,13 @@ Sync Gateway can also load its configuration directly from a public URL.
 
 **Step - 2 :** Then start Sync Gateway and give it the URL to the raw JSON data:
 
-`$ docker run -p 4984:4984 -d couchbase/sync-gateway https://raw.githubusercontent.com/couchbase/sync_gateway/master/examples/basic-walrus-bucket.json`
+For versions 3.0.0 and newer:
+
+`$ docker run -p 4984:4984 -d couchbase/sync-gateway https://raw.githubusercontent.com/couchbase/sync_gateway/master/examples/startup_config/basic.json`
+
+For older versions:
+
+`$ docker run -p 4984:4984 -d couchbase/sync-gateway https://raw.githubusercontent.com/couchbase/sync_gateway/release/2.8.3/examples/serviceconfig.json`
 
 # Running with a Couchbase Server container
 

--- a/community/sync-gateway/2.8.0/README.md
+++ b/community/sync-gateway/2.8.0/README.md
@@ -80,10 +80,19 @@ $ curl http://localhost:4985
 
 **Step - 1 :** Prepare the Sync Gateway configuration file on your local machine:
 
+For versions 3.0.0 and newer:
 ```
 $ cd /tmp
-$ wget https://raw.githubusercontent.com/couchbase/sync_gateway/master/examples/basic-walrus-bucket.json
-$ mv basic-walrus-bucket.json my-sg-config.json
+$ wget https://raw.githubusercontent.com/couchbase/sync_gateway/master/examples/startup_config/basic.json
+$ mv basic.json my-sg-config.json
+$ vi my-sg-config.json  # make edits
+```
+
+For older versions:
+```
+$ cd /tmp
+$ wget https://raw.githubusercontent.com/couchbase/sync_gateway/master/examples/release/2.8.3/examples/serviceconfig.json
+$ mv serviceconfig.json my-sg-config.json
 $ vi my-sg-config.json  # make edits
 ```
 
@@ -99,7 +108,13 @@ Sync Gateway can also load its configuration directly from a public URL.
 
 **Step - 2 :** Then start Sync Gateway and give it the URL to the raw JSON data:
 
-`$ docker run -p 4984:4984 -d couchbase/sync-gateway https://raw.githubusercontent.com/couchbase/sync_gateway/master/examples/basic-walrus-bucket.json`
+For versions 3.0.0 and newer:
+
+`$ docker run -p 4984:4984 -d couchbase/sync-gateway https://raw.githubusercontent.com/couchbase/sync_gateway/master/examples/startup_config/basic.json`
+
+For older versions:
+
+`$ docker run -p 4984:4984 -d couchbase/sync-gateway https://raw.githubusercontent.com/couchbase/sync_gateway/release/2.8.3/examples/serviceconfig.json`
 
 # Running with a Couchbase Server container
 

--- a/community/sync-gateway/2.8.2/README.md
+++ b/community/sync-gateway/2.8.2/README.md
@@ -80,10 +80,19 @@ $ curl http://localhost:4985
 
 **Step - 1 :** Prepare the Sync Gateway configuration file on your local machine:
 
+For versions 3.0.0 and newer:
 ```
 $ cd /tmp
-$ wget https://raw.githubusercontent.com/couchbase/sync_gateway/master/examples/basic-walrus-bucket.json
-$ mv basic-walrus-bucket.json my-sg-config.json
+$ wget https://raw.githubusercontent.com/couchbase/sync_gateway/master/examples/startup_config/basic.json
+$ mv basic.json my-sg-config.json
+$ vi my-sg-config.json  # make edits
+```
+
+For older versions:
+```
+$ cd /tmp
+$ wget https://raw.githubusercontent.com/couchbase/sync_gateway/master/examples/release/2.8.3/examples/serviceconfig.json
+$ mv serviceconfig.json my-sg-config.json
 $ vi my-sg-config.json  # make edits
 ```
 
@@ -99,7 +108,13 @@ Sync Gateway can also load its configuration directly from a public URL.
 
 **Step - 2 :** Then start Sync Gateway and give it the URL to the raw JSON data:
 
-`$ docker run -p 4984:4984 -d couchbase/sync-gateway https://raw.githubusercontent.com/couchbase/sync_gateway/master/examples/basic-walrus-bucket.json`
+For versions 3.0.0 and newer:
+
+`$ docker run -p 4984:4984 -d couchbase/sync-gateway https://raw.githubusercontent.com/couchbase/sync_gateway/master/examples/startup_config/basic.json`
+
+For older versions:
+
+`$ docker run -p 4984:4984 -d couchbase/sync-gateway https://raw.githubusercontent.com/couchbase/sync_gateway/release/2.8.3/examples/serviceconfig.json`
 
 # Running with a Couchbase Server container
 

--- a/community/sync-gateway/2.8.3/README.md
+++ b/community/sync-gateway/2.8.3/README.md
@@ -80,10 +80,19 @@ $ curl http://localhost:4985
 
 **Step - 1 :** Prepare the Sync Gateway configuration file on your local machine:
 
+For versions 3.0.0 and newer:
 ```
 $ cd /tmp
-$ wget https://raw.githubusercontent.com/couchbase/sync_gateway/master/examples/basic-walrus-bucket.json
-$ mv basic-walrus-bucket.json my-sg-config.json
+$ wget https://raw.githubusercontent.com/couchbase/sync_gateway/master/examples/startup_config/basic.json
+$ mv basic.json my-sg-config.json
+$ vi my-sg-config.json  # make edits
+```
+
+For older versions:
+```
+$ cd /tmp
+$ wget https://raw.githubusercontent.com/couchbase/sync_gateway/master/examples/release/2.8.3/examples/serviceconfig.json
+$ mv serviceconfig.json my-sg-config.json
 $ vi my-sg-config.json  # make edits
 ```
 
@@ -99,7 +108,13 @@ Sync Gateway can also load its configuration directly from a public URL.
 
 **Step - 2 :** Then start Sync Gateway and give it the URL to the raw JSON data:
 
-`$ docker run -p 4984:4984 -d couchbase/sync-gateway https://raw.githubusercontent.com/couchbase/sync_gateway/master/examples/basic-walrus-bucket.json`
+For versions 3.0.0 and newer:
+
+`$ docker run -p 4984:4984 -d couchbase/sync-gateway https://raw.githubusercontent.com/couchbase/sync_gateway/master/examples/startup_config/basic.json`
+
+For older versions:
+
+`$ docker run -p 4984:4984 -d couchbase/sync-gateway https://raw.githubusercontent.com/couchbase/sync_gateway/release/2.8.3/examples/serviceconfig.json`
 
 # Running with a Couchbase Server container
 

--- a/community/sync-gateway/3.0.0-beta01/README.md
+++ b/community/sync-gateway/3.0.0-beta01/README.md
@@ -80,10 +80,19 @@ $ curl http://localhost:4985
 
 **Step - 1 :** Prepare the Sync Gateway configuration file on your local machine:
 
+For versions 3.0.0 and newer:
 ```
 $ cd /tmp
-$ wget https://raw.githubusercontent.com/couchbase/sync_gateway/master/examples/basic-walrus-bucket.json
-$ mv basic-walrus-bucket.json my-sg-config.json
+$ wget https://raw.githubusercontent.com/couchbase/sync_gateway/master/examples/startup_config/basic.json
+$ mv basic.json my-sg-config.json
+$ vi my-sg-config.json  # make edits
+```
+
+For older versions:
+```
+$ cd /tmp
+$ wget https://raw.githubusercontent.com/couchbase/sync_gateway/master/examples/release/2.8.3/examples/serviceconfig.json
+$ mv serviceconfig.json my-sg-config.json
 $ vi my-sg-config.json  # make edits
 ```
 
@@ -99,7 +108,13 @@ Sync Gateway can also load its configuration directly from a public URL.
 
 **Step - 2 :** Then start Sync Gateway and give it the URL to the raw JSON data:
 
-`$ docker run -p 4984:4984 -d couchbase/sync-gateway https://raw.githubusercontent.com/couchbase/sync_gateway/master/examples/basic-walrus-bucket.json`
+For versions 3.0.0 and newer:
+
+`$ docker run -p 4984:4984 -d couchbase/sync-gateway https://raw.githubusercontent.com/couchbase/sync_gateway/master/examples/startup_config/basic.json`
+
+For older versions:
+
+`$ docker run -p 4984:4984 -d couchbase/sync-gateway https://raw.githubusercontent.com/couchbase/sync_gateway/release/2.8.3/examples/serviceconfig.json`
 
 # Running with a Couchbase Server container
 

--- a/community/sync-gateway/3.0.0-beta02/README.md
+++ b/community/sync-gateway/3.0.0-beta02/README.md
@@ -80,10 +80,19 @@ $ curl http://localhost:4985
 
 **Step - 1 :** Prepare the Sync Gateway configuration file on your local machine:
 
+For versions 3.0.0 and newer:
 ```
 $ cd /tmp
-$ wget https://raw.githubusercontent.com/couchbase/sync_gateway/master/examples/basic-walrus-bucket.json
-$ mv basic-walrus-bucket.json my-sg-config.json
+$ wget https://raw.githubusercontent.com/couchbase/sync_gateway/master/examples/startup_config/basic.json
+$ mv basic.json my-sg-config.json
+$ vi my-sg-config.json  # make edits
+```
+
+For older versions:
+```
+$ cd /tmp
+$ wget https://raw.githubusercontent.com/couchbase/sync_gateway/master/examples/release/2.8.3/examples/serviceconfig.json
+$ mv serviceconfig.json my-sg-config.json
 $ vi my-sg-config.json  # make edits
 ```
 
@@ -99,7 +108,13 @@ Sync Gateway can also load its configuration directly from a public URL.
 
 **Step - 2 :** Then start Sync Gateway and give it the URL to the raw JSON data:
 
-`$ docker run -p 4984:4984 -d couchbase/sync-gateway https://raw.githubusercontent.com/couchbase/sync_gateway/master/examples/basic-walrus-bucket.json`
+For versions 3.0.0 and newer:
+
+`$ docker run -p 4984:4984 -d couchbase/sync-gateway https://raw.githubusercontent.com/couchbase/sync_gateway/master/examples/startup_config/basic.json`
+
+For older versions:
+
+`$ docker run -p 4984:4984 -d couchbase/sync-gateway https://raw.githubusercontent.com/couchbase/sync_gateway/release/2.8.3/examples/serviceconfig.json`
 
 # Running with a Couchbase Server container
 

--- a/community/sync-gateway/3.0.0/README.md
+++ b/community/sync-gateway/3.0.0/README.md
@@ -80,10 +80,19 @@ $ curl http://localhost:4985
 
 **Step - 1 :** Prepare the Sync Gateway configuration file on your local machine:
 
+For versions 3.0.0 and newer:
 ```
 $ cd /tmp
-$ wget https://raw.githubusercontent.com/couchbase/sync_gateway/master/examples/basic-walrus-bucket.json
-$ mv basic-walrus-bucket.json my-sg-config.json
+$ wget https://raw.githubusercontent.com/couchbase/sync_gateway/master/examples/startup_config/basic.json
+$ mv basic.json my-sg-config.json
+$ vi my-sg-config.json  # make edits
+```
+
+For older versions:
+```
+$ cd /tmp
+$ wget https://raw.githubusercontent.com/couchbase/sync_gateway/master/examples/release/2.8.3/examples/serviceconfig.json
+$ mv serviceconfig.json my-sg-config.json
 $ vi my-sg-config.json  # make edits
 ```
 
@@ -99,7 +108,13 @@ Sync Gateway can also load its configuration directly from a public URL.
 
 **Step - 2 :** Then start Sync Gateway and give it the URL to the raw JSON data:
 
-`$ docker run -p 4984:4984 -d couchbase/sync-gateway https://raw.githubusercontent.com/couchbase/sync_gateway/master/examples/basic-walrus-bucket.json`
+For versions 3.0.0 and newer:
+
+`$ docker run -p 4984:4984 -d couchbase/sync-gateway https://raw.githubusercontent.com/couchbase/sync_gateway/master/examples/startup_config/basic.json`
+
+For older versions:
+
+`$ docker run -p 4984:4984 -d couchbase/sync-gateway https://raw.githubusercontent.com/couchbase/sync_gateway/release/2.8.3/examples/serviceconfig.json`
 
 # Running with a Couchbase Server container
 

--- a/enterprise/couchbase-server/4.0.0/README.md
+++ b/enterprise/couchbase-server/4.0.0/README.md
@@ -26,20 +26,20 @@ Here is how to get a single node Couchbase Server cluster running on Docker cont
 
 **Step - 2 :** Next, visit `http://localhost:8091` on the host machine to see the Web Console to start Couchbase Server setup.
 
-![Setup splash screen](https://d774lla4im6mk.cloudfront.net/6.6.2/setup-initial.jpg)
+![Setup splash screen](https://d774lla4im6mk.cloudfront.net/setup-initial.jpg)
 
 Walk through the Setup wizard and accept the default values.
 
 -	Note: You may need to lower the RAM allocated to various services to fit within the bounds of the resource of the containers.
 -	Enable the beer-sample bucket to load some sample data.
 
-![Creating a cluster](https://d774lla4im6mk.cloudfront.net/6.6.2/cluster-creation.jpg)
+![Creating a cluster](https://d774lla4im6mk.cloudfront.net/cluster-creation.jpg)
 
-![Completing the wizard](https://d774lla4im6mk.cloudfront.net/6.6.2/finish-wizard.jpg)
+![Completing the wizard](https://d774lla4im6mk.cloudfront.net/finish-wizard.jpg)
 
-![UI home](https://d774lla4im6mk.cloudfront.net/6.6.2/ui-home.jpg)
+![UI home](https://d774lla4im6mk.cloudfront.net/ui-home.jpg)
 
-![Loading sample data](https://d774lla4im6mk.cloudfront.net/6.6.2/load-sample-data.jpg)
+![Loading sample data](https://d774lla4im6mk.cloudfront.net/load-sample-data.jpg)
 
 **Note :** For detailed information on configuring the Server, see [Deployment Guidelines](https://docs.couchbase.com/server/current/install/install-production-deployment.html).
 

--- a/enterprise/couchbase-server/4.1.0/README.md
+++ b/enterprise/couchbase-server/4.1.0/README.md
@@ -26,20 +26,20 @@ Here is how to get a single node Couchbase Server cluster running on Docker cont
 
 **Step - 2 :** Next, visit `http://localhost:8091` on the host machine to see the Web Console to start Couchbase Server setup.
 
-![Setup splash screen](https://d774lla4im6mk.cloudfront.net/6.6.2/setup-initial.jpg)
+![Setup splash screen](https://d774lla4im6mk.cloudfront.net/setup-initial.jpg)
 
 Walk through the Setup wizard and accept the default values.
 
 -	Note: You may need to lower the RAM allocated to various services to fit within the bounds of the resource of the containers.
 -	Enable the beer-sample bucket to load some sample data.
 
-![Creating a cluster](https://d774lla4im6mk.cloudfront.net/6.6.2/cluster-creation.jpg)
+![Creating a cluster](https://d774lla4im6mk.cloudfront.net/cluster-creation.jpg)
 
-![Completing the wizard](https://d774lla4im6mk.cloudfront.net/6.6.2/finish-wizard.jpg)
+![Completing the wizard](https://d774lla4im6mk.cloudfront.net/finish-wizard.jpg)
 
-![UI home](https://d774lla4im6mk.cloudfront.net/6.6.2/ui-home.jpg)
+![UI home](https://d774lla4im6mk.cloudfront.net/ui-home.jpg)
 
-![Loading sample data](https://d774lla4im6mk.cloudfront.net/6.6.2/load-sample-data.jpg)
+![Loading sample data](https://d774lla4im6mk.cloudfront.net/load-sample-data.jpg)
 
 **Note :** For detailed information on configuring the Server, see [Deployment Guidelines](https://docs.couchbase.com/server/current/install/install-production-deployment.html).
 

--- a/enterprise/couchbase-server/4.1.1/README.md
+++ b/enterprise/couchbase-server/4.1.1/README.md
@@ -26,20 +26,20 @@ Here is how to get a single node Couchbase Server cluster running on Docker cont
 
 **Step - 2 :** Next, visit `http://localhost:8091` on the host machine to see the Web Console to start Couchbase Server setup.
 
-![Setup splash screen](https://d774lla4im6mk.cloudfront.net/6.6.2/setup-initial.jpg)
+![Setup splash screen](https://d774lla4im6mk.cloudfront.net/setup-initial.jpg)
 
 Walk through the Setup wizard and accept the default values.
 
 -	Note: You may need to lower the RAM allocated to various services to fit within the bounds of the resource of the containers.
 -	Enable the beer-sample bucket to load some sample data.
 
-![Creating a cluster](https://d774lla4im6mk.cloudfront.net/6.6.2/cluster-creation.jpg)
+![Creating a cluster](https://d774lla4im6mk.cloudfront.net/cluster-creation.jpg)
 
-![Completing the wizard](https://d774lla4im6mk.cloudfront.net/6.6.2/finish-wizard.jpg)
+![Completing the wizard](https://d774lla4im6mk.cloudfront.net/finish-wizard.jpg)
 
-![UI home](https://d774lla4im6mk.cloudfront.net/6.6.2/ui-home.jpg)
+![UI home](https://d774lla4im6mk.cloudfront.net/ui-home.jpg)
 
-![Loading sample data](https://d774lla4im6mk.cloudfront.net/6.6.2/load-sample-data.jpg)
+![Loading sample data](https://d774lla4im6mk.cloudfront.net/load-sample-data.jpg)
 
 **Note :** For detailed information on configuring the Server, see [Deployment Guidelines](https://docs.couchbase.com/server/current/install/install-production-deployment.html).
 

--- a/enterprise/couchbase-server/4.1.2/README.md
+++ b/enterprise/couchbase-server/4.1.2/README.md
@@ -26,20 +26,20 @@ Here is how to get a single node Couchbase Server cluster running on Docker cont
 
 **Step - 2 :** Next, visit `http://localhost:8091` on the host machine to see the Web Console to start Couchbase Server setup.
 
-![Setup splash screen](https://d774lla4im6mk.cloudfront.net/6.6.2/setup-initial.jpg)
+![Setup splash screen](https://d774lla4im6mk.cloudfront.net/setup-initial.jpg)
 
 Walk through the Setup wizard and accept the default values.
 
 -	Note: You may need to lower the RAM allocated to various services to fit within the bounds of the resource of the containers.
 -	Enable the beer-sample bucket to load some sample data.
 
-![Creating a cluster](https://d774lla4im6mk.cloudfront.net/6.6.2/cluster-creation.jpg)
+![Creating a cluster](https://d774lla4im6mk.cloudfront.net/cluster-creation.jpg)
 
-![Completing the wizard](https://d774lla4im6mk.cloudfront.net/6.6.2/finish-wizard.jpg)
+![Completing the wizard](https://d774lla4im6mk.cloudfront.net/finish-wizard.jpg)
 
-![UI home](https://d774lla4im6mk.cloudfront.net/6.6.2/ui-home.jpg)
+![UI home](https://d774lla4im6mk.cloudfront.net/ui-home.jpg)
 
-![Loading sample data](https://d774lla4im6mk.cloudfront.net/6.6.2/load-sample-data.jpg)
+![Loading sample data](https://d774lla4im6mk.cloudfront.net/load-sample-data.jpg)
 
 **Note :** For detailed information on configuring the Server, see [Deployment Guidelines](https://docs.couchbase.com/server/current/install/install-production-deployment.html).
 

--- a/enterprise/couchbase-server/4.5.0/README.md
+++ b/enterprise/couchbase-server/4.5.0/README.md
@@ -26,20 +26,20 @@ Here is how to get a single node Couchbase Server cluster running on Docker cont
 
 **Step - 2 :** Next, visit `http://localhost:8091` on the host machine to see the Web Console to start Couchbase Server setup.
 
-![Setup splash screen](https://d774lla4im6mk.cloudfront.net/6.6.2/setup-initial.jpg)
+![Setup splash screen](https://d774lla4im6mk.cloudfront.net/setup-initial.jpg)
 
 Walk through the Setup wizard and accept the default values.
 
 -	Note: You may need to lower the RAM allocated to various services to fit within the bounds of the resource of the containers.
 -	Enable the beer-sample bucket to load some sample data.
 
-![Creating a cluster](https://d774lla4im6mk.cloudfront.net/6.6.2/cluster-creation.jpg)
+![Creating a cluster](https://d774lla4im6mk.cloudfront.net/cluster-creation.jpg)
 
-![Completing the wizard](https://d774lla4im6mk.cloudfront.net/6.6.2/finish-wizard.jpg)
+![Completing the wizard](https://d774lla4im6mk.cloudfront.net/finish-wizard.jpg)
 
-![UI home](https://d774lla4im6mk.cloudfront.net/6.6.2/ui-home.jpg)
+![UI home](https://d774lla4im6mk.cloudfront.net/ui-home.jpg)
 
-![Loading sample data](https://d774lla4im6mk.cloudfront.net/6.6.2/load-sample-data.jpg)
+![Loading sample data](https://d774lla4im6mk.cloudfront.net/load-sample-data.jpg)
 
 **Note :** For detailed information on configuring the Server, see [Deployment Guidelines](https://docs.couchbase.com/server/current/install/install-production-deployment.html).
 

--- a/enterprise/couchbase-server/4.5.1/README.md
+++ b/enterprise/couchbase-server/4.5.1/README.md
@@ -26,20 +26,20 @@ Here is how to get a single node Couchbase Server cluster running on Docker cont
 
 **Step - 2 :** Next, visit `http://localhost:8091` on the host machine to see the Web Console to start Couchbase Server setup.
 
-![Setup splash screen](https://d774lla4im6mk.cloudfront.net/6.6.2/setup-initial.jpg)
+![Setup splash screen](https://d774lla4im6mk.cloudfront.net/setup-initial.jpg)
 
 Walk through the Setup wizard and accept the default values.
 
 -	Note: You may need to lower the RAM allocated to various services to fit within the bounds of the resource of the containers.
 -	Enable the beer-sample bucket to load some sample data.
 
-![Creating a cluster](https://d774lla4im6mk.cloudfront.net/6.6.2/cluster-creation.jpg)
+![Creating a cluster](https://d774lla4im6mk.cloudfront.net/cluster-creation.jpg)
 
-![Completing the wizard](https://d774lla4im6mk.cloudfront.net/6.6.2/finish-wizard.jpg)
+![Completing the wizard](https://d774lla4im6mk.cloudfront.net/finish-wizard.jpg)
 
-![UI home](https://d774lla4im6mk.cloudfront.net/6.6.2/ui-home.jpg)
+![UI home](https://d774lla4im6mk.cloudfront.net/ui-home.jpg)
 
-![Loading sample data](https://d774lla4im6mk.cloudfront.net/6.6.2/load-sample-data.jpg)
+![Loading sample data](https://d774lla4im6mk.cloudfront.net/load-sample-data.jpg)
 
 **Note :** For detailed information on configuring the Server, see [Deployment Guidelines](https://docs.couchbase.com/server/current/install/install-production-deployment.html).
 

--- a/enterprise/couchbase-server/4.6.0/README.md
+++ b/enterprise/couchbase-server/4.6.0/README.md
@@ -26,20 +26,20 @@ Here is how to get a single node Couchbase Server cluster running on Docker cont
 
 **Step - 2 :** Next, visit `http://localhost:8091` on the host machine to see the Web Console to start Couchbase Server setup.
 
-![Setup splash screen](https://d774lla4im6mk.cloudfront.net/6.6.2/setup-initial.jpg)
+![Setup splash screen](https://d774lla4im6mk.cloudfront.net/setup-initial.jpg)
 
 Walk through the Setup wizard and accept the default values.
 
 -	Note: You may need to lower the RAM allocated to various services to fit within the bounds of the resource of the containers.
 -	Enable the beer-sample bucket to load some sample data.
 
-![Creating a cluster](https://d774lla4im6mk.cloudfront.net/6.6.2/cluster-creation.jpg)
+![Creating a cluster](https://d774lla4im6mk.cloudfront.net/cluster-creation.jpg)
 
-![Completing the wizard](https://d774lla4im6mk.cloudfront.net/6.6.2/finish-wizard.jpg)
+![Completing the wizard](https://d774lla4im6mk.cloudfront.net/finish-wizard.jpg)
 
-![UI home](https://d774lla4im6mk.cloudfront.net/6.6.2/ui-home.jpg)
+![UI home](https://d774lla4im6mk.cloudfront.net/ui-home.jpg)
 
-![Loading sample data](https://d774lla4im6mk.cloudfront.net/6.6.2/load-sample-data.jpg)
+![Loading sample data](https://d774lla4im6mk.cloudfront.net/load-sample-data.jpg)
 
 **Note :** For detailed information on configuring the Server, see [Deployment Guidelines](https://docs.couchbase.com/server/current/install/install-production-deployment.html).
 

--- a/enterprise/couchbase-server/4.6.1/README.md
+++ b/enterprise/couchbase-server/4.6.1/README.md
@@ -26,20 +26,20 @@ Here is how to get a single node Couchbase Server cluster running on Docker cont
 
 **Step - 2 :** Next, visit `http://localhost:8091` on the host machine to see the Web Console to start Couchbase Server setup.
 
-![Setup splash screen](https://d774lla4im6mk.cloudfront.net/6.6.2/setup-initial.jpg)
+![Setup splash screen](https://d774lla4im6mk.cloudfront.net/setup-initial.jpg)
 
 Walk through the Setup wizard and accept the default values.
 
 -	Note: You may need to lower the RAM allocated to various services to fit within the bounds of the resource of the containers.
 -	Enable the beer-sample bucket to load some sample data.
 
-![Creating a cluster](https://d774lla4im6mk.cloudfront.net/6.6.2/cluster-creation.jpg)
+![Creating a cluster](https://d774lla4im6mk.cloudfront.net/cluster-creation.jpg)
 
-![Completing the wizard](https://d774lla4im6mk.cloudfront.net/6.6.2/finish-wizard.jpg)
+![Completing the wizard](https://d774lla4im6mk.cloudfront.net/finish-wizard.jpg)
 
-![UI home](https://d774lla4im6mk.cloudfront.net/6.6.2/ui-home.jpg)
+![UI home](https://d774lla4im6mk.cloudfront.net/ui-home.jpg)
 
-![Loading sample data](https://d774lla4im6mk.cloudfront.net/6.6.2/load-sample-data.jpg)
+![Loading sample data](https://d774lla4im6mk.cloudfront.net/load-sample-data.jpg)
 
 **Note :** For detailed information on configuring the Server, see [Deployment Guidelines](https://docs.couchbase.com/server/current/install/install-production-deployment.html).
 

--- a/enterprise/couchbase-server/4.6.2/README.md
+++ b/enterprise/couchbase-server/4.6.2/README.md
@@ -26,20 +26,20 @@ Here is how to get a single node Couchbase Server cluster running on Docker cont
 
 **Step - 2 :** Next, visit `http://localhost:8091` on the host machine to see the Web Console to start Couchbase Server setup.
 
-![Setup splash screen](https://d774lla4im6mk.cloudfront.net/6.6.2/setup-initial.jpg)
+![Setup splash screen](https://d774lla4im6mk.cloudfront.net/setup-initial.jpg)
 
 Walk through the Setup wizard and accept the default values.
 
 -	Note: You may need to lower the RAM allocated to various services to fit within the bounds of the resource of the containers.
 -	Enable the beer-sample bucket to load some sample data.
 
-![Creating a cluster](https://d774lla4im6mk.cloudfront.net/6.6.2/cluster-creation.jpg)
+![Creating a cluster](https://d774lla4im6mk.cloudfront.net/cluster-creation.jpg)
 
-![Completing the wizard](https://d774lla4im6mk.cloudfront.net/6.6.2/finish-wizard.jpg)
+![Completing the wizard](https://d774lla4im6mk.cloudfront.net/finish-wizard.jpg)
 
-![UI home](https://d774lla4im6mk.cloudfront.net/6.6.2/ui-home.jpg)
+![UI home](https://d774lla4im6mk.cloudfront.net/ui-home.jpg)
 
-![Loading sample data](https://d774lla4im6mk.cloudfront.net/6.6.2/load-sample-data.jpg)
+![Loading sample data](https://d774lla4im6mk.cloudfront.net/load-sample-data.jpg)
 
 **Note :** For detailed information on configuring the Server, see [Deployment Guidelines](https://docs.couchbase.com/server/current/install/install-production-deployment.html).
 

--- a/enterprise/couchbase-server/4.6.3/README.md
+++ b/enterprise/couchbase-server/4.6.3/README.md
@@ -26,20 +26,20 @@ Here is how to get a single node Couchbase Server cluster running on Docker cont
 
 **Step - 2 :** Next, visit `http://localhost:8091` on the host machine to see the Web Console to start Couchbase Server setup.
 
-![Setup splash screen](https://d774lla4im6mk.cloudfront.net/6.6.2/setup-initial.jpg)
+![Setup splash screen](https://d774lla4im6mk.cloudfront.net/setup-initial.jpg)
 
 Walk through the Setup wizard and accept the default values.
 
 -	Note: You may need to lower the RAM allocated to various services to fit within the bounds of the resource of the containers.
 -	Enable the beer-sample bucket to load some sample data.
 
-![Creating a cluster](https://d774lla4im6mk.cloudfront.net/6.6.2/cluster-creation.jpg)
+![Creating a cluster](https://d774lla4im6mk.cloudfront.net/cluster-creation.jpg)
 
-![Completing the wizard](https://d774lla4im6mk.cloudfront.net/6.6.2/finish-wizard.jpg)
+![Completing the wizard](https://d774lla4im6mk.cloudfront.net/finish-wizard.jpg)
 
-![UI home](https://d774lla4im6mk.cloudfront.net/6.6.2/ui-home.jpg)
+![UI home](https://d774lla4im6mk.cloudfront.net/ui-home.jpg)
 
-![Loading sample data](https://d774lla4im6mk.cloudfront.net/6.6.2/load-sample-data.jpg)
+![Loading sample data](https://d774lla4im6mk.cloudfront.net/load-sample-data.jpg)
 
 **Note :** For detailed information on configuring the Server, see [Deployment Guidelines](https://docs.couchbase.com/server/current/install/install-production-deployment.html).
 

--- a/enterprise/couchbase-server/4.6.4/README.md
+++ b/enterprise/couchbase-server/4.6.4/README.md
@@ -26,20 +26,20 @@ Here is how to get a single node Couchbase Server cluster running on Docker cont
 
 **Step - 2 :** Next, visit `http://localhost:8091` on the host machine to see the Web Console to start Couchbase Server setup.
 
-![Setup splash screen](https://d774lla4im6mk.cloudfront.net/6.6.2/setup-initial.jpg)
+![Setup splash screen](https://d774lla4im6mk.cloudfront.net/setup-initial.jpg)
 
 Walk through the Setup wizard and accept the default values.
 
 -	Note: You may need to lower the RAM allocated to various services to fit within the bounds of the resource of the containers.
 -	Enable the beer-sample bucket to load some sample data.
 
-![Creating a cluster](https://d774lla4im6mk.cloudfront.net/6.6.2/cluster-creation.jpg)
+![Creating a cluster](https://d774lla4im6mk.cloudfront.net/cluster-creation.jpg)
 
-![Completing the wizard](https://d774lla4im6mk.cloudfront.net/6.6.2/finish-wizard.jpg)
+![Completing the wizard](https://d774lla4im6mk.cloudfront.net/finish-wizard.jpg)
 
-![UI home](https://d774lla4im6mk.cloudfront.net/6.6.2/ui-home.jpg)
+![UI home](https://d774lla4im6mk.cloudfront.net/ui-home.jpg)
 
-![Loading sample data](https://d774lla4im6mk.cloudfront.net/6.6.2/load-sample-data.jpg)
+![Loading sample data](https://d774lla4im6mk.cloudfront.net/load-sample-data.jpg)
 
 **Note :** For detailed information on configuring the Server, see [Deployment Guidelines](https://docs.couchbase.com/server/current/install/install-production-deployment.html).
 

--- a/enterprise/couchbase-server/4.6.5/README.md
+++ b/enterprise/couchbase-server/4.6.5/README.md
@@ -26,20 +26,20 @@ Here is how to get a single node Couchbase Server cluster running on Docker cont
 
 **Step - 2 :** Next, visit `http://localhost:8091` on the host machine to see the Web Console to start Couchbase Server setup.
 
-![Setup splash screen](https://d774lla4im6mk.cloudfront.net/6.6.2/setup-initial.jpg)
+![Setup splash screen](https://d774lla4im6mk.cloudfront.net/setup-initial.jpg)
 
 Walk through the Setup wizard and accept the default values.
 
 -	Note: You may need to lower the RAM allocated to various services to fit within the bounds of the resource of the containers.
 -	Enable the beer-sample bucket to load some sample data.
 
-![Creating a cluster](https://d774lla4im6mk.cloudfront.net/6.6.2/cluster-creation.jpg)
+![Creating a cluster](https://d774lla4im6mk.cloudfront.net/cluster-creation.jpg)
 
-![Completing the wizard](https://d774lla4im6mk.cloudfront.net/6.6.2/finish-wizard.jpg)
+![Completing the wizard](https://d774lla4im6mk.cloudfront.net/finish-wizard.jpg)
 
-![UI home](https://d774lla4im6mk.cloudfront.net/6.6.2/ui-home.jpg)
+![UI home](https://d774lla4im6mk.cloudfront.net/ui-home.jpg)
 
-![Loading sample data](https://d774lla4im6mk.cloudfront.net/6.6.2/load-sample-data.jpg)
+![Loading sample data](https://d774lla4im6mk.cloudfront.net/load-sample-data.jpg)
 
 **Note :** For detailed information on configuring the Server, see [Deployment Guidelines](https://docs.couchbase.com/server/current/install/install-production-deployment.html).
 

--- a/enterprise/couchbase-server/5.0.1/README.md
+++ b/enterprise/couchbase-server/5.0.1/README.md
@@ -26,20 +26,20 @@ Here is how to get a single node Couchbase Server cluster running on Docker cont
 
 **Step - 2 :** Next, visit `http://localhost:8091` on the host machine to see the Web Console to start Couchbase Server setup.
 
-![Setup splash screen](https://d774lla4im6mk.cloudfront.net/6.6.2/setup-initial.jpg)
+![Setup splash screen](https://d774lla4im6mk.cloudfront.net/setup-initial.jpg)
 
 Walk through the Setup wizard and accept the default values.
 
 -	Note: You may need to lower the RAM allocated to various services to fit within the bounds of the resource of the containers.
 -	Enable the beer-sample bucket to load some sample data.
 
-![Creating a cluster](https://d774lla4im6mk.cloudfront.net/6.6.2/cluster-creation.jpg)
+![Creating a cluster](https://d774lla4im6mk.cloudfront.net/cluster-creation.jpg)
 
-![Completing the wizard](https://d774lla4im6mk.cloudfront.net/6.6.2/finish-wizard.jpg)
+![Completing the wizard](https://d774lla4im6mk.cloudfront.net/finish-wizard.jpg)
 
-![UI home](https://d774lla4im6mk.cloudfront.net/6.6.2/ui-home.jpg)
+![UI home](https://d774lla4im6mk.cloudfront.net/ui-home.jpg)
 
-![Loading sample data](https://d774lla4im6mk.cloudfront.net/6.6.2/load-sample-data.jpg)
+![Loading sample data](https://d774lla4im6mk.cloudfront.net/load-sample-data.jpg)
 
 **Note :** For detailed information on configuring the Server, see [Deployment Guidelines](https://docs.couchbase.com/server/current/install/install-production-deployment.html).
 

--- a/enterprise/couchbase-server/5.1.0/README.md
+++ b/enterprise/couchbase-server/5.1.0/README.md
@@ -26,20 +26,20 @@ Here is how to get a single node Couchbase Server cluster running on Docker cont
 
 **Step - 2 :** Next, visit `http://localhost:8091` on the host machine to see the Web Console to start Couchbase Server setup.
 
-![Setup splash screen](https://d774lla4im6mk.cloudfront.net/6.6.2/setup-initial.jpg)
+![Setup splash screen](https://d774lla4im6mk.cloudfront.net/setup-initial.jpg)
 
 Walk through the Setup wizard and accept the default values.
 
 -	Note: You may need to lower the RAM allocated to various services to fit within the bounds of the resource of the containers.
 -	Enable the beer-sample bucket to load some sample data.
 
-![Creating a cluster](https://d774lla4im6mk.cloudfront.net/6.6.2/cluster-creation.jpg)
+![Creating a cluster](https://d774lla4im6mk.cloudfront.net/cluster-creation.jpg)
 
-![Completing the wizard](https://d774lla4im6mk.cloudfront.net/6.6.2/finish-wizard.jpg)
+![Completing the wizard](https://d774lla4im6mk.cloudfront.net/finish-wizard.jpg)
 
-![UI home](https://d774lla4im6mk.cloudfront.net/6.6.2/ui-home.jpg)
+![UI home](https://d774lla4im6mk.cloudfront.net/ui-home.jpg)
 
-![Loading sample data](https://d774lla4im6mk.cloudfront.net/6.6.2/load-sample-data.jpg)
+![Loading sample data](https://d774lla4im6mk.cloudfront.net/load-sample-data.jpg)
 
 **Note :** For detailed information on configuring the Server, see [Deployment Guidelines](https://docs.couchbase.com/server/current/install/install-production-deployment.html).
 

--- a/enterprise/couchbase-server/5.1.1/README.md
+++ b/enterprise/couchbase-server/5.1.1/README.md
@@ -26,20 +26,20 @@ Here is how to get a single node Couchbase Server cluster running on Docker cont
 
 **Step - 2 :** Next, visit `http://localhost:8091` on the host machine to see the Web Console to start Couchbase Server setup.
 
-![Setup splash screen](https://d774lla4im6mk.cloudfront.net/6.6.2/setup-initial.jpg)
+![Setup splash screen](https://d774lla4im6mk.cloudfront.net/setup-initial.jpg)
 
 Walk through the Setup wizard and accept the default values.
 
 -	Note: You may need to lower the RAM allocated to various services to fit within the bounds of the resource of the containers.
 -	Enable the beer-sample bucket to load some sample data.
 
-![Creating a cluster](https://d774lla4im6mk.cloudfront.net/6.6.2/cluster-creation.jpg)
+![Creating a cluster](https://d774lla4im6mk.cloudfront.net/cluster-creation.jpg)
 
-![Completing the wizard](https://d774lla4im6mk.cloudfront.net/6.6.2/finish-wizard.jpg)
+![Completing the wizard](https://d774lla4im6mk.cloudfront.net/finish-wizard.jpg)
 
-![UI home](https://d774lla4im6mk.cloudfront.net/6.6.2/ui-home.jpg)
+![UI home](https://d774lla4im6mk.cloudfront.net/ui-home.jpg)
 
-![Loading sample data](https://d774lla4im6mk.cloudfront.net/6.6.2/load-sample-data.jpg)
+![Loading sample data](https://d774lla4im6mk.cloudfront.net/load-sample-data.jpg)
 
 **Note :** For detailed information on configuring the Server, see [Deployment Guidelines](https://docs.couchbase.com/server/current/install/install-production-deployment.html).
 

--- a/enterprise/couchbase-server/5.1.2/README.md
+++ b/enterprise/couchbase-server/5.1.2/README.md
@@ -26,20 +26,20 @@ Here is how to get a single node Couchbase Server cluster running on Docker cont
 
 **Step - 2 :** Next, visit `http://localhost:8091` on the host machine to see the Web Console to start Couchbase Server setup.
 
-![Setup splash screen](https://d774lla4im6mk.cloudfront.net/6.6.2/setup-initial.jpg)
+![Setup splash screen](https://d774lla4im6mk.cloudfront.net/setup-initial.jpg)
 
 Walk through the Setup wizard and accept the default values.
 
 -	Note: You may need to lower the RAM allocated to various services to fit within the bounds of the resource of the containers.
 -	Enable the beer-sample bucket to load some sample data.
 
-![Creating a cluster](https://d774lla4im6mk.cloudfront.net/6.6.2/cluster-creation.jpg)
+![Creating a cluster](https://d774lla4im6mk.cloudfront.net/cluster-creation.jpg)
 
-![Completing the wizard](https://d774lla4im6mk.cloudfront.net/6.6.2/finish-wizard.jpg)
+![Completing the wizard](https://d774lla4im6mk.cloudfront.net/finish-wizard.jpg)
 
-![UI home](https://d774lla4im6mk.cloudfront.net/6.6.2/ui-home.jpg)
+![UI home](https://d774lla4im6mk.cloudfront.net/ui-home.jpg)
 
-![Loading sample data](https://d774lla4im6mk.cloudfront.net/6.6.2/load-sample-data.jpg)
+![Loading sample data](https://d774lla4im6mk.cloudfront.net/load-sample-data.jpg)
 
 **Note :** For detailed information on configuring the Server, see [Deployment Guidelines](https://docs.couchbase.com/server/current/install/install-production-deployment.html).
 

--- a/enterprise/couchbase-server/5.1.3/README.md
+++ b/enterprise/couchbase-server/5.1.3/README.md
@@ -26,20 +26,20 @@ Here is how to get a single node Couchbase Server cluster running on Docker cont
 
 **Step - 2 :** Next, visit `http://localhost:8091` on the host machine to see the Web Console to start Couchbase Server setup.
 
-![Setup splash screen](https://d774lla4im6mk.cloudfront.net/6.6.2/setup-initial.jpg)
+![Setup splash screen](https://d774lla4im6mk.cloudfront.net/setup-initial.jpg)
 
 Walk through the Setup wizard and accept the default values.
 
 -	Note: You may need to lower the RAM allocated to various services to fit within the bounds of the resource of the containers.
 -	Enable the beer-sample bucket to load some sample data.
 
-![Creating a cluster](https://d774lla4im6mk.cloudfront.net/6.6.2/cluster-creation.jpg)
+![Creating a cluster](https://d774lla4im6mk.cloudfront.net/cluster-creation.jpg)
 
-![Completing the wizard](https://d774lla4im6mk.cloudfront.net/6.6.2/finish-wizard.jpg)
+![Completing the wizard](https://d774lla4im6mk.cloudfront.net/finish-wizard.jpg)
 
-![UI home](https://d774lla4im6mk.cloudfront.net/6.6.2/ui-home.jpg)
+![UI home](https://d774lla4im6mk.cloudfront.net/ui-home.jpg)
 
-![Loading sample data](https://d774lla4im6mk.cloudfront.net/6.6.2/load-sample-data.jpg)
+![Loading sample data](https://d774lla4im6mk.cloudfront.net/load-sample-data.jpg)
 
 **Note :** For detailed information on configuring the Server, see [Deployment Guidelines](https://docs.couchbase.com/server/current/install/install-production-deployment.html).
 

--- a/enterprise/couchbase-server/5.5.0/README.md
+++ b/enterprise/couchbase-server/5.5.0/README.md
@@ -26,20 +26,20 @@ Here is how to get a single node Couchbase Server cluster running on Docker cont
 
 **Step - 2 :** Next, visit `http://localhost:8091` on the host machine to see the Web Console to start Couchbase Server setup.
 
-![Setup splash screen](https://d774lla4im6mk.cloudfront.net/6.6.2/setup-initial.jpg)
+![Setup splash screen](https://d774lla4im6mk.cloudfront.net/setup-initial.jpg)
 
 Walk through the Setup wizard and accept the default values.
 
 -	Note: You may need to lower the RAM allocated to various services to fit within the bounds of the resource of the containers.
 -	Enable the beer-sample bucket to load some sample data.
 
-![Creating a cluster](https://d774lla4im6mk.cloudfront.net/6.6.2/cluster-creation.jpg)
+![Creating a cluster](https://d774lla4im6mk.cloudfront.net/cluster-creation.jpg)
 
-![Completing the wizard](https://d774lla4im6mk.cloudfront.net/6.6.2/finish-wizard.jpg)
+![Completing the wizard](https://d774lla4im6mk.cloudfront.net/finish-wizard.jpg)
 
-![UI home](https://d774lla4im6mk.cloudfront.net/6.6.2/ui-home.jpg)
+![UI home](https://d774lla4im6mk.cloudfront.net/ui-home.jpg)
 
-![Loading sample data](https://d774lla4im6mk.cloudfront.net/6.6.2/load-sample-data.jpg)
+![Loading sample data](https://d774lla4im6mk.cloudfront.net/load-sample-data.jpg)
 
 **Note :** For detailed information on configuring the Server, see [Deployment Guidelines](https://docs.couchbase.com/server/current/install/install-production-deployment.html).
 

--- a/enterprise/couchbase-server/5.5.1/README.md
+++ b/enterprise/couchbase-server/5.5.1/README.md
@@ -26,20 +26,20 @@ Here is how to get a single node Couchbase Server cluster running on Docker cont
 
 **Step - 2 :** Next, visit `http://localhost:8091` on the host machine to see the Web Console to start Couchbase Server setup.
 
-![Setup splash screen](https://d774lla4im6mk.cloudfront.net/6.6.2/setup-initial.jpg)
+![Setup splash screen](https://d774lla4im6mk.cloudfront.net/setup-initial.jpg)
 
 Walk through the Setup wizard and accept the default values.
 
 -	Note: You may need to lower the RAM allocated to various services to fit within the bounds of the resource of the containers.
 -	Enable the beer-sample bucket to load some sample data.
 
-![Creating a cluster](https://d774lla4im6mk.cloudfront.net/6.6.2/cluster-creation.jpg)
+![Creating a cluster](https://d774lla4im6mk.cloudfront.net/cluster-creation.jpg)
 
-![Completing the wizard](https://d774lla4im6mk.cloudfront.net/6.6.2/finish-wizard.jpg)
+![Completing the wizard](https://d774lla4im6mk.cloudfront.net/finish-wizard.jpg)
 
-![UI home](https://d774lla4im6mk.cloudfront.net/6.6.2/ui-home.jpg)
+![UI home](https://d774lla4im6mk.cloudfront.net/ui-home.jpg)
 
-![Loading sample data](https://d774lla4im6mk.cloudfront.net/6.6.2/load-sample-data.jpg)
+![Loading sample data](https://d774lla4im6mk.cloudfront.net/load-sample-data.jpg)
 
 **Note :** For detailed information on configuring the Server, see [Deployment Guidelines](https://docs.couchbase.com/server/current/install/install-production-deployment.html).
 

--- a/enterprise/couchbase-server/5.5.2/README.md
+++ b/enterprise/couchbase-server/5.5.2/README.md
@@ -26,20 +26,20 @@ Here is how to get a single node Couchbase Server cluster running on Docker cont
 
 **Step - 2 :** Next, visit `http://localhost:8091` on the host machine to see the Web Console to start Couchbase Server setup.
 
-![Setup splash screen](https://d774lla4im6mk.cloudfront.net/6.6.2/setup-initial.jpg)
+![Setup splash screen](https://d774lla4im6mk.cloudfront.net/setup-initial.jpg)
 
 Walk through the Setup wizard and accept the default values.
 
 -	Note: You may need to lower the RAM allocated to various services to fit within the bounds of the resource of the containers.
 -	Enable the beer-sample bucket to load some sample data.
 
-![Creating a cluster](https://d774lla4im6mk.cloudfront.net/6.6.2/cluster-creation.jpg)
+![Creating a cluster](https://d774lla4im6mk.cloudfront.net/cluster-creation.jpg)
 
-![Completing the wizard](https://d774lla4im6mk.cloudfront.net/6.6.2/finish-wizard.jpg)
+![Completing the wizard](https://d774lla4im6mk.cloudfront.net/finish-wizard.jpg)
 
-![UI home](https://d774lla4im6mk.cloudfront.net/6.6.2/ui-home.jpg)
+![UI home](https://d774lla4im6mk.cloudfront.net/ui-home.jpg)
 
-![Loading sample data](https://d774lla4im6mk.cloudfront.net/6.6.2/load-sample-data.jpg)
+![Loading sample data](https://d774lla4im6mk.cloudfront.net/load-sample-data.jpg)
 
 **Note :** For detailed information on configuring the Server, see [Deployment Guidelines](https://docs.couchbase.com/server/current/install/install-production-deployment.html).
 

--- a/enterprise/couchbase-server/5.5.3/README.md
+++ b/enterprise/couchbase-server/5.5.3/README.md
@@ -26,20 +26,20 @@ Here is how to get a single node Couchbase Server cluster running on Docker cont
 
 **Step - 2 :** Next, visit `http://localhost:8091` on the host machine to see the Web Console to start Couchbase Server setup.
 
-![Setup splash screen](https://d774lla4im6mk.cloudfront.net/6.6.2/setup-initial.jpg)
+![Setup splash screen](https://d774lla4im6mk.cloudfront.net/setup-initial.jpg)
 
 Walk through the Setup wizard and accept the default values.
 
 -	Note: You may need to lower the RAM allocated to various services to fit within the bounds of the resource of the containers.
 -	Enable the beer-sample bucket to load some sample data.
 
-![Creating a cluster](https://d774lla4im6mk.cloudfront.net/6.6.2/cluster-creation.jpg)
+![Creating a cluster](https://d774lla4im6mk.cloudfront.net/cluster-creation.jpg)
 
-![Completing the wizard](https://d774lla4im6mk.cloudfront.net/6.6.2/finish-wizard.jpg)
+![Completing the wizard](https://d774lla4im6mk.cloudfront.net/finish-wizard.jpg)
 
-![UI home](https://d774lla4im6mk.cloudfront.net/6.6.2/ui-home.jpg)
+![UI home](https://d774lla4im6mk.cloudfront.net/ui-home.jpg)
 
-![Loading sample data](https://d774lla4im6mk.cloudfront.net/6.6.2/load-sample-data.jpg)
+![Loading sample data](https://d774lla4im6mk.cloudfront.net/load-sample-data.jpg)
 
 **Note :** For detailed information on configuring the Server, see [Deployment Guidelines](https://docs.couchbase.com/server/current/install/install-production-deployment.html).
 

--- a/enterprise/couchbase-server/5.5.4/README.md
+++ b/enterprise/couchbase-server/5.5.4/README.md
@@ -26,20 +26,20 @@ Here is how to get a single node Couchbase Server cluster running on Docker cont
 
 **Step - 2 :** Next, visit `http://localhost:8091` on the host machine to see the Web Console to start Couchbase Server setup.
 
-![Setup splash screen](https://d774lla4im6mk.cloudfront.net/6.6.2/setup-initial.jpg)
+![Setup splash screen](https://d774lla4im6mk.cloudfront.net/setup-initial.jpg)
 
 Walk through the Setup wizard and accept the default values.
 
 -	Note: You may need to lower the RAM allocated to various services to fit within the bounds of the resource of the containers.
 -	Enable the beer-sample bucket to load some sample data.
 
-![Creating a cluster](https://d774lla4im6mk.cloudfront.net/6.6.2/cluster-creation.jpg)
+![Creating a cluster](https://d774lla4im6mk.cloudfront.net/cluster-creation.jpg)
 
-![Completing the wizard](https://d774lla4im6mk.cloudfront.net/6.6.2/finish-wizard.jpg)
+![Completing the wizard](https://d774lla4im6mk.cloudfront.net/finish-wizard.jpg)
 
-![UI home](https://d774lla4im6mk.cloudfront.net/6.6.2/ui-home.jpg)
+![UI home](https://d774lla4im6mk.cloudfront.net/ui-home.jpg)
 
-![Loading sample data](https://d774lla4im6mk.cloudfront.net/6.6.2/load-sample-data.jpg)
+![Loading sample data](https://d774lla4im6mk.cloudfront.net/load-sample-data.jpg)
 
 **Note :** For detailed information on configuring the Server, see [Deployment Guidelines](https://docs.couchbase.com/server/current/install/install-production-deployment.html).
 

--- a/enterprise/couchbase-server/5.5.5/README.md
+++ b/enterprise/couchbase-server/5.5.5/README.md
@@ -26,20 +26,20 @@ Here is how to get a single node Couchbase Server cluster running on Docker cont
 
 **Step - 2 :** Next, visit `http://localhost:8091` on the host machine to see the Web Console to start Couchbase Server setup.
 
-![Setup splash screen](https://d774lla4im6mk.cloudfront.net/6.6.2/setup-initial.jpg)
+![Setup splash screen](https://d774lla4im6mk.cloudfront.net/setup-initial.jpg)
 
 Walk through the Setup wizard and accept the default values.
 
 -	Note: You may need to lower the RAM allocated to various services to fit within the bounds of the resource of the containers.
 -	Enable the beer-sample bucket to load some sample data.
 
-![Creating a cluster](https://d774lla4im6mk.cloudfront.net/6.6.2/cluster-creation.jpg)
+![Creating a cluster](https://d774lla4im6mk.cloudfront.net/cluster-creation.jpg)
 
-![Completing the wizard](https://d774lla4im6mk.cloudfront.net/6.6.2/finish-wizard.jpg)
+![Completing the wizard](https://d774lla4im6mk.cloudfront.net/finish-wizard.jpg)
 
-![UI home](https://d774lla4im6mk.cloudfront.net/6.6.2/ui-home.jpg)
+![UI home](https://d774lla4im6mk.cloudfront.net/ui-home.jpg)
 
-![Loading sample data](https://d774lla4im6mk.cloudfront.net/6.6.2/load-sample-data.jpg)
+![Loading sample data](https://d774lla4im6mk.cloudfront.net/load-sample-data.jpg)
 
 **Note :** For detailed information on configuring the Server, see [Deployment Guidelines](https://docs.couchbase.com/server/current/install/install-production-deployment.html).
 

--- a/enterprise/couchbase-server/5.5.6/README.md
+++ b/enterprise/couchbase-server/5.5.6/README.md
@@ -26,20 +26,20 @@ Here is how to get a single node Couchbase Server cluster running on Docker cont
 
 **Step - 2 :** Next, visit `http://localhost:8091` on the host machine to see the Web Console to start Couchbase Server setup.
 
-![Setup splash screen](https://d774lla4im6mk.cloudfront.net/6.6.2/setup-initial.jpg)
+![Setup splash screen](https://d774lla4im6mk.cloudfront.net/setup-initial.jpg)
 
 Walk through the Setup wizard and accept the default values.
 
 -	Note: You may need to lower the RAM allocated to various services to fit within the bounds of the resource of the containers.
 -	Enable the beer-sample bucket to load some sample data.
 
-![Creating a cluster](https://d774lla4im6mk.cloudfront.net/6.6.2/cluster-creation.jpg)
+![Creating a cluster](https://d774lla4im6mk.cloudfront.net/cluster-creation.jpg)
 
-![Completing the wizard](https://d774lla4im6mk.cloudfront.net/6.6.2/finish-wizard.jpg)
+![Completing the wizard](https://d774lla4im6mk.cloudfront.net/finish-wizard.jpg)
 
-![UI home](https://d774lla4im6mk.cloudfront.net/6.6.2/ui-home.jpg)
+![UI home](https://d774lla4im6mk.cloudfront.net/ui-home.jpg)
 
-![Loading sample data](https://d774lla4im6mk.cloudfront.net/6.6.2/load-sample-data.jpg)
+![Loading sample data](https://d774lla4im6mk.cloudfront.net/load-sample-data.jpg)
 
 **Note :** For detailed information on configuring the Server, see [Deployment Guidelines](https://docs.couchbase.com/server/current/install/install-production-deployment.html).
 

--- a/enterprise/couchbase-server/6.0.0/README.md
+++ b/enterprise/couchbase-server/6.0.0/README.md
@@ -26,20 +26,20 @@ Here is how to get a single node Couchbase Server cluster running on Docker cont
 
 **Step - 2 :** Next, visit `http://localhost:8091` on the host machine to see the Web Console to start Couchbase Server setup.
 
-![Setup splash screen](https://d774lla4im6mk.cloudfront.net/6.6.2/setup-initial.jpg)
+![Setup splash screen](https://d774lla4im6mk.cloudfront.net/setup-initial.jpg)
 
 Walk through the Setup wizard and accept the default values.
 
 -	Note: You may need to lower the RAM allocated to various services to fit within the bounds of the resource of the containers.
 -	Enable the beer-sample bucket to load some sample data.
 
-![Creating a cluster](https://d774lla4im6mk.cloudfront.net/6.6.2/cluster-creation.jpg)
+![Creating a cluster](https://d774lla4im6mk.cloudfront.net/cluster-creation.jpg)
 
-![Completing the wizard](https://d774lla4im6mk.cloudfront.net/6.6.2/finish-wizard.jpg)
+![Completing the wizard](https://d774lla4im6mk.cloudfront.net/finish-wizard.jpg)
 
-![UI home](https://d774lla4im6mk.cloudfront.net/6.6.2/ui-home.jpg)
+![UI home](https://d774lla4im6mk.cloudfront.net/ui-home.jpg)
 
-![Loading sample data](https://d774lla4im6mk.cloudfront.net/6.6.2/load-sample-data.jpg)
+![Loading sample data](https://d774lla4im6mk.cloudfront.net/load-sample-data.jpg)
 
 **Note :** For detailed information on configuring the Server, see [Deployment Guidelines](https://docs.couchbase.com/server/current/install/install-production-deployment.html).
 

--- a/enterprise/couchbase-server/6.0.1/README.md
+++ b/enterprise/couchbase-server/6.0.1/README.md
@@ -26,20 +26,20 @@ Here is how to get a single node Couchbase Server cluster running on Docker cont
 
 **Step - 2 :** Next, visit `http://localhost:8091` on the host machine to see the Web Console to start Couchbase Server setup.
 
-![Setup splash screen](https://d774lla4im6mk.cloudfront.net/6.6.2/setup-initial.jpg)
+![Setup splash screen](https://d774lla4im6mk.cloudfront.net/setup-initial.jpg)
 
 Walk through the Setup wizard and accept the default values.
 
 -	Note: You may need to lower the RAM allocated to various services to fit within the bounds of the resource of the containers.
 -	Enable the beer-sample bucket to load some sample data.
 
-![Creating a cluster](https://d774lla4im6mk.cloudfront.net/6.6.2/cluster-creation.jpg)
+![Creating a cluster](https://d774lla4im6mk.cloudfront.net/cluster-creation.jpg)
 
-![Completing the wizard](https://d774lla4im6mk.cloudfront.net/6.6.2/finish-wizard.jpg)
+![Completing the wizard](https://d774lla4im6mk.cloudfront.net/finish-wizard.jpg)
 
-![UI home](https://d774lla4im6mk.cloudfront.net/6.6.2/ui-home.jpg)
+![UI home](https://d774lla4im6mk.cloudfront.net/ui-home.jpg)
 
-![Loading sample data](https://d774lla4im6mk.cloudfront.net/6.6.2/load-sample-data.jpg)
+![Loading sample data](https://d774lla4im6mk.cloudfront.net/load-sample-data.jpg)
 
 **Note :** For detailed information on configuring the Server, see [Deployment Guidelines](https://docs.couchbase.com/server/current/install/install-production-deployment.html).
 

--- a/enterprise/couchbase-server/6.0.2/README.md
+++ b/enterprise/couchbase-server/6.0.2/README.md
@@ -26,20 +26,20 @@ Here is how to get a single node Couchbase Server cluster running on Docker cont
 
 **Step - 2 :** Next, visit `http://localhost:8091` on the host machine to see the Web Console to start Couchbase Server setup.
 
-![Setup splash screen](https://d774lla4im6mk.cloudfront.net/6.6.2/setup-initial.jpg)
+![Setup splash screen](https://d774lla4im6mk.cloudfront.net/setup-initial.jpg)
 
 Walk through the Setup wizard and accept the default values.
 
 -	Note: You may need to lower the RAM allocated to various services to fit within the bounds of the resource of the containers.
 -	Enable the beer-sample bucket to load some sample data.
 
-![Creating a cluster](https://d774lla4im6mk.cloudfront.net/6.6.2/cluster-creation.jpg)
+![Creating a cluster](https://d774lla4im6mk.cloudfront.net/cluster-creation.jpg)
 
-![Completing the wizard](https://d774lla4im6mk.cloudfront.net/6.6.2/finish-wizard.jpg)
+![Completing the wizard](https://d774lla4im6mk.cloudfront.net/finish-wizard.jpg)
 
-![UI home](https://d774lla4im6mk.cloudfront.net/6.6.2/ui-home.jpg)
+![UI home](https://d774lla4im6mk.cloudfront.net/ui-home.jpg)
 
-![Loading sample data](https://d774lla4im6mk.cloudfront.net/6.6.2/load-sample-data.jpg)
+![Loading sample data](https://d774lla4im6mk.cloudfront.net/load-sample-data.jpg)
 
 **Note :** For detailed information on configuring the Server, see [Deployment Guidelines](https://docs.couchbase.com/server/current/install/install-production-deployment.html).
 

--- a/enterprise/couchbase-server/6.0.3/README.md
+++ b/enterprise/couchbase-server/6.0.3/README.md
@@ -26,20 +26,20 @@ Here is how to get a single node Couchbase Server cluster running on Docker cont
 
 **Step - 2 :** Next, visit `http://localhost:8091` on the host machine to see the Web Console to start Couchbase Server setup.
 
-![Setup splash screen](https://d774lla4im6mk.cloudfront.net/6.6.2/setup-initial.jpg)
+![Setup splash screen](https://d774lla4im6mk.cloudfront.net/setup-initial.jpg)
 
 Walk through the Setup wizard and accept the default values.
 
 -	Note: You may need to lower the RAM allocated to various services to fit within the bounds of the resource of the containers.
 -	Enable the beer-sample bucket to load some sample data.
 
-![Creating a cluster](https://d774lla4im6mk.cloudfront.net/6.6.2/cluster-creation.jpg)
+![Creating a cluster](https://d774lla4im6mk.cloudfront.net/cluster-creation.jpg)
 
-![Completing the wizard](https://d774lla4im6mk.cloudfront.net/6.6.2/finish-wizard.jpg)
+![Completing the wizard](https://d774lla4im6mk.cloudfront.net/finish-wizard.jpg)
 
-![UI home](https://d774lla4im6mk.cloudfront.net/6.6.2/ui-home.jpg)
+![UI home](https://d774lla4im6mk.cloudfront.net/ui-home.jpg)
 
-![Loading sample data](https://d774lla4im6mk.cloudfront.net/6.6.2/load-sample-data.jpg)
+![Loading sample data](https://d774lla4im6mk.cloudfront.net/load-sample-data.jpg)
 
 **Note :** For detailed information on configuring the Server, see [Deployment Guidelines](https://docs.couchbase.com/server/current/install/install-production-deployment.html).
 

--- a/enterprise/couchbase-server/6.0.4/README.md
+++ b/enterprise/couchbase-server/6.0.4/README.md
@@ -26,20 +26,20 @@ Here is how to get a single node Couchbase Server cluster running on Docker cont
 
 **Step - 2 :** Next, visit `http://localhost:8091` on the host machine to see the Web Console to start Couchbase Server setup.
 
-![Setup splash screen](https://d774lla4im6mk.cloudfront.net/6.6.2/setup-initial.jpg)
+![Setup splash screen](https://d774lla4im6mk.cloudfront.net/setup-initial.jpg)
 
 Walk through the Setup wizard and accept the default values.
 
 -	Note: You may need to lower the RAM allocated to various services to fit within the bounds of the resource of the containers.
 -	Enable the beer-sample bucket to load some sample data.
 
-![Creating a cluster](https://d774lla4im6mk.cloudfront.net/6.6.2/cluster-creation.jpg)
+![Creating a cluster](https://d774lla4im6mk.cloudfront.net/cluster-creation.jpg)
 
-![Completing the wizard](https://d774lla4im6mk.cloudfront.net/6.6.2/finish-wizard.jpg)
+![Completing the wizard](https://d774lla4im6mk.cloudfront.net/finish-wizard.jpg)
 
-![UI home](https://d774lla4im6mk.cloudfront.net/6.6.2/ui-home.jpg)
+![UI home](https://d774lla4im6mk.cloudfront.net/ui-home.jpg)
 
-![Loading sample data](https://d774lla4im6mk.cloudfront.net/6.6.2/load-sample-data.jpg)
+![Loading sample data](https://d774lla4im6mk.cloudfront.net/load-sample-data.jpg)
 
 **Note :** For detailed information on configuring the Server, see [Deployment Guidelines](https://docs.couchbase.com/server/current/install/install-production-deployment.html).
 

--- a/enterprise/couchbase-server/6.0.5/README.md
+++ b/enterprise/couchbase-server/6.0.5/README.md
@@ -26,20 +26,20 @@ Here is how to get a single node Couchbase Server cluster running on Docker cont
 
 **Step - 2 :** Next, visit `http://localhost:8091` on the host machine to see the Web Console to start Couchbase Server setup.
 
-![Setup splash screen](https://d774lla4im6mk.cloudfront.net/6.6.2/setup-initial.jpg)
+![Setup splash screen](https://d774lla4im6mk.cloudfront.net/setup-initial.jpg)
 
 Walk through the Setup wizard and accept the default values.
 
 -	Note: You may need to lower the RAM allocated to various services to fit within the bounds of the resource of the containers.
 -	Enable the beer-sample bucket to load some sample data.
 
-![Creating a cluster](https://d774lla4im6mk.cloudfront.net/6.6.2/cluster-creation.jpg)
+![Creating a cluster](https://d774lla4im6mk.cloudfront.net/cluster-creation.jpg)
 
-![Completing the wizard](https://d774lla4im6mk.cloudfront.net/6.6.2/finish-wizard.jpg)
+![Completing the wizard](https://d774lla4im6mk.cloudfront.net/finish-wizard.jpg)
 
-![UI home](https://d774lla4im6mk.cloudfront.net/6.6.2/ui-home.jpg)
+![UI home](https://d774lla4im6mk.cloudfront.net/ui-home.jpg)
 
-![Loading sample data](https://d774lla4im6mk.cloudfront.net/6.6.2/load-sample-data.jpg)
+![Loading sample data](https://d774lla4im6mk.cloudfront.net/load-sample-data.jpg)
 
 **Note :** For detailed information on configuring the Server, see [Deployment Guidelines](https://docs.couchbase.com/server/current/install/install-production-deployment.html).
 

--- a/enterprise/couchbase-server/6.5.0-beta/README.md
+++ b/enterprise/couchbase-server/6.5.0-beta/README.md
@@ -26,20 +26,20 @@ Here is how to get a single node Couchbase Server cluster running on Docker cont
 
 **Step - 2 :** Next, visit `http://localhost:8091` on the host machine to see the Web Console to start Couchbase Server setup.
 
-![Setup splash screen](https://d774lla4im6mk.cloudfront.net/6.6.2/setup-initial.jpg)
+![Setup splash screen](https://d774lla4im6mk.cloudfront.net/setup-initial.jpg)
 
 Walk through the Setup wizard and accept the default values.
 
 -	Note: You may need to lower the RAM allocated to various services to fit within the bounds of the resource of the containers.
 -	Enable the beer-sample bucket to load some sample data.
 
-![Creating a cluster](https://d774lla4im6mk.cloudfront.net/6.6.2/cluster-creation.jpg)
+![Creating a cluster](https://d774lla4im6mk.cloudfront.net/cluster-creation.jpg)
 
-![Completing the wizard](https://d774lla4im6mk.cloudfront.net/6.6.2/finish-wizard.jpg)
+![Completing the wizard](https://d774lla4im6mk.cloudfront.net/finish-wizard.jpg)
 
-![UI home](https://d774lla4im6mk.cloudfront.net/6.6.2/ui-home.jpg)
+![UI home](https://d774lla4im6mk.cloudfront.net/ui-home.jpg)
 
-![Loading sample data](https://d774lla4im6mk.cloudfront.net/6.6.2/load-sample-data.jpg)
+![Loading sample data](https://d774lla4im6mk.cloudfront.net/load-sample-data.jpg)
 
 **Note :** For detailed information on configuring the Server, see [Deployment Guidelines](https://docs.couchbase.com/server/current/install/install-production-deployment.html).
 

--- a/enterprise/couchbase-server/6.5.0-beta2/README.md
+++ b/enterprise/couchbase-server/6.5.0-beta2/README.md
@@ -26,20 +26,20 @@ Here is how to get a single node Couchbase Server cluster running on Docker cont
 
 **Step - 2 :** Next, visit `http://localhost:8091` on the host machine to see the Web Console to start Couchbase Server setup.
 
-![Setup splash screen](https://d774lla4im6mk.cloudfront.net/6.6.2/setup-initial.jpg)
+![Setup splash screen](https://d774lla4im6mk.cloudfront.net/setup-initial.jpg)
 
 Walk through the Setup wizard and accept the default values.
 
 -	Note: You may need to lower the RAM allocated to various services to fit within the bounds of the resource of the containers.
 -	Enable the beer-sample bucket to load some sample data.
 
-![Creating a cluster](https://d774lla4im6mk.cloudfront.net/6.6.2/cluster-creation.jpg)
+![Creating a cluster](https://d774lla4im6mk.cloudfront.net/cluster-creation.jpg)
 
-![Completing the wizard](https://d774lla4im6mk.cloudfront.net/6.6.2/finish-wizard.jpg)
+![Completing the wizard](https://d774lla4im6mk.cloudfront.net/finish-wizard.jpg)
 
-![UI home](https://d774lla4im6mk.cloudfront.net/6.6.2/ui-home.jpg)
+![UI home](https://d774lla4im6mk.cloudfront.net/ui-home.jpg)
 
-![Loading sample data](https://d774lla4im6mk.cloudfront.net/6.6.2/load-sample-data.jpg)
+![Loading sample data](https://d774lla4im6mk.cloudfront.net/load-sample-data.jpg)
 
 **Note :** For detailed information on configuring the Server, see [Deployment Guidelines](https://docs.couchbase.com/server/current/install/install-production-deployment.html).
 

--- a/enterprise/couchbase-server/6.5.0/README.md
+++ b/enterprise/couchbase-server/6.5.0/README.md
@@ -26,20 +26,20 @@ Here is how to get a single node Couchbase Server cluster running on Docker cont
 
 **Step - 2 :** Next, visit `http://localhost:8091` on the host machine to see the Web Console to start Couchbase Server setup.
 
-![Setup splash screen](https://d774lla4im6mk.cloudfront.net/6.6.2/setup-initial.jpg)
+![Setup splash screen](https://d774lla4im6mk.cloudfront.net/setup-initial.jpg)
 
 Walk through the Setup wizard and accept the default values.
 
 -	Note: You may need to lower the RAM allocated to various services to fit within the bounds of the resource of the containers.
 -	Enable the beer-sample bucket to load some sample data.
 
-![Creating a cluster](https://d774lla4im6mk.cloudfront.net/6.6.2/cluster-creation.jpg)
+![Creating a cluster](https://d774lla4im6mk.cloudfront.net/cluster-creation.jpg)
 
-![Completing the wizard](https://d774lla4im6mk.cloudfront.net/6.6.2/finish-wizard.jpg)
+![Completing the wizard](https://d774lla4im6mk.cloudfront.net/finish-wizard.jpg)
 
-![UI home](https://d774lla4im6mk.cloudfront.net/6.6.2/ui-home.jpg)
+![UI home](https://d774lla4im6mk.cloudfront.net/ui-home.jpg)
 
-![Loading sample data](https://d774lla4im6mk.cloudfront.net/6.6.2/load-sample-data.jpg)
+![Loading sample data](https://d774lla4im6mk.cloudfront.net/load-sample-data.jpg)
 
 **Note :** For detailed information on configuring the Server, see [Deployment Guidelines](https://docs.couchbase.com/server/current/install/install-production-deployment.html).
 

--- a/enterprise/couchbase-server/6.5.1/README.md
+++ b/enterprise/couchbase-server/6.5.1/README.md
@@ -26,20 +26,20 @@ Here is how to get a single node Couchbase Server cluster running on Docker cont
 
 **Step - 2 :** Next, visit `http://localhost:8091` on the host machine to see the Web Console to start Couchbase Server setup.
 
-![Setup splash screen](https://d774lla4im6mk.cloudfront.net/6.6.2/setup-initial.jpg)
+![Setup splash screen](https://d774lla4im6mk.cloudfront.net/setup-initial.jpg)
 
 Walk through the Setup wizard and accept the default values.
 
 -	Note: You may need to lower the RAM allocated to various services to fit within the bounds of the resource of the containers.
 -	Enable the beer-sample bucket to load some sample data.
 
-![Creating a cluster](https://d774lla4im6mk.cloudfront.net/6.6.2/cluster-creation.jpg)
+![Creating a cluster](https://d774lla4im6mk.cloudfront.net/cluster-creation.jpg)
 
-![Completing the wizard](https://d774lla4im6mk.cloudfront.net/6.6.2/finish-wizard.jpg)
+![Completing the wizard](https://d774lla4im6mk.cloudfront.net/finish-wizard.jpg)
 
-![UI home](https://d774lla4im6mk.cloudfront.net/6.6.2/ui-home.jpg)
+![UI home](https://d774lla4im6mk.cloudfront.net/ui-home.jpg)
 
-![Loading sample data](https://d774lla4im6mk.cloudfront.net/6.6.2/load-sample-data.jpg)
+![Loading sample data](https://d774lla4im6mk.cloudfront.net/load-sample-data.jpg)
 
 **Note :** For detailed information on configuring the Server, see [Deployment Guidelines](https://docs.couchbase.com/server/current/install/install-production-deployment.html).
 

--- a/enterprise/couchbase-server/6.5.2/README.md
+++ b/enterprise/couchbase-server/6.5.2/README.md
@@ -26,20 +26,20 @@ Here is how to get a single node Couchbase Server cluster running on Docker cont
 
 **Step - 2 :** Next, visit `http://localhost:8091` on the host machine to see the Web Console to start Couchbase Server setup.
 
-![Setup splash screen](https://d774lla4im6mk.cloudfront.net/6.6.2/setup-initial.jpg)
+![Setup splash screen](https://d774lla4im6mk.cloudfront.net/setup-initial.jpg)
 
 Walk through the Setup wizard and accept the default values.
 
 -	Note: You may need to lower the RAM allocated to various services to fit within the bounds of the resource of the containers.
 -	Enable the beer-sample bucket to load some sample data.
 
-![Creating a cluster](https://d774lla4im6mk.cloudfront.net/6.6.2/cluster-creation.jpg)
+![Creating a cluster](https://d774lla4im6mk.cloudfront.net/cluster-creation.jpg)
 
-![Completing the wizard](https://d774lla4im6mk.cloudfront.net/6.6.2/finish-wizard.jpg)
+![Completing the wizard](https://d774lla4im6mk.cloudfront.net/finish-wizard.jpg)
 
-![UI home](https://d774lla4im6mk.cloudfront.net/6.6.2/ui-home.jpg)
+![UI home](https://d774lla4im6mk.cloudfront.net/ui-home.jpg)
 
-![Loading sample data](https://d774lla4im6mk.cloudfront.net/6.6.2/load-sample-data.jpg)
+![Loading sample data](https://d774lla4im6mk.cloudfront.net/load-sample-data.jpg)
 
 **Note :** For detailed information on configuring the Server, see [Deployment Guidelines](https://docs.couchbase.com/server/current/install/install-production-deployment.html).
 

--- a/enterprise/couchbase-server/6.6.0/README.md
+++ b/enterprise/couchbase-server/6.6.0/README.md
@@ -26,20 +26,20 @@ Here is how to get a single node Couchbase Server cluster running on Docker cont
 
 **Step - 2 :** Next, visit `http://localhost:8091` on the host machine to see the Web Console to start Couchbase Server setup.
 
-![Setup splash screen](https://d774lla4im6mk.cloudfront.net/6.6.2/setup-initial.jpg)
+![Setup splash screen](https://d774lla4im6mk.cloudfront.net/setup-initial.jpg)
 
 Walk through the Setup wizard and accept the default values.
 
 -	Note: You may need to lower the RAM allocated to various services to fit within the bounds of the resource of the containers.
 -	Enable the beer-sample bucket to load some sample data.
 
-![Creating a cluster](https://d774lla4im6mk.cloudfront.net/6.6.2/cluster-creation.jpg)
+![Creating a cluster](https://d774lla4im6mk.cloudfront.net/cluster-creation.jpg)
 
-![Completing the wizard](https://d774lla4im6mk.cloudfront.net/6.6.2/finish-wizard.jpg)
+![Completing the wizard](https://d774lla4im6mk.cloudfront.net/finish-wizard.jpg)
 
-![UI home](https://d774lla4im6mk.cloudfront.net/6.6.2/ui-home.jpg)
+![UI home](https://d774lla4im6mk.cloudfront.net/ui-home.jpg)
 
-![Loading sample data](https://d774lla4im6mk.cloudfront.net/6.6.2/load-sample-data.jpg)
+![Loading sample data](https://d774lla4im6mk.cloudfront.net/load-sample-data.jpg)
 
 **Note :** For detailed information on configuring the Server, see [Deployment Guidelines](https://docs.couchbase.com/server/current/install/install-production-deployment.html).
 

--- a/enterprise/couchbase-server/6.6.1/README.md
+++ b/enterprise/couchbase-server/6.6.1/README.md
@@ -26,20 +26,20 @@ Here is how to get a single node Couchbase Server cluster running on Docker cont
 
 **Step - 2 :** Next, visit `http://localhost:8091` on the host machine to see the Web Console to start Couchbase Server setup.
 
-![Setup splash screen](https://d774lla4im6mk.cloudfront.net/6.6.2/setup-initial.jpg)
+![Setup splash screen](https://d774lla4im6mk.cloudfront.net/setup-initial.jpg)
 
 Walk through the Setup wizard and accept the default values.
 
 -	Note: You may need to lower the RAM allocated to various services to fit within the bounds of the resource of the containers.
 -	Enable the beer-sample bucket to load some sample data.
 
-![Creating a cluster](https://d774lla4im6mk.cloudfront.net/6.6.2/cluster-creation.jpg)
+![Creating a cluster](https://d774lla4im6mk.cloudfront.net/cluster-creation.jpg)
 
-![Completing the wizard](https://d774lla4im6mk.cloudfront.net/6.6.2/finish-wizard.jpg)
+![Completing the wizard](https://d774lla4im6mk.cloudfront.net/finish-wizard.jpg)
 
-![UI home](https://d774lla4im6mk.cloudfront.net/6.6.2/ui-home.jpg)
+![UI home](https://d774lla4im6mk.cloudfront.net/ui-home.jpg)
 
-![Loading sample data](https://d774lla4im6mk.cloudfront.net/6.6.2/load-sample-data.jpg)
+![Loading sample data](https://d774lla4im6mk.cloudfront.net/load-sample-data.jpg)
 
 **Note :** For detailed information on configuring the Server, see [Deployment Guidelines](https://docs.couchbase.com/server/current/install/install-production-deployment.html).
 

--- a/enterprise/couchbase-server/6.6.2/README.md
+++ b/enterprise/couchbase-server/6.6.2/README.md
@@ -26,20 +26,20 @@ Here is how to get a single node Couchbase Server cluster running on Docker cont
 
 **Step - 2 :** Next, visit `http://localhost:8091` on the host machine to see the Web Console to start Couchbase Server setup.
 
-![Setup splash screen](https://d774lla4im6mk.cloudfront.net/6.6.2/setup-initial.jpg)
+![Setup splash screen](https://d774lla4im6mk.cloudfront.net/setup-initial.jpg)
 
 Walk through the Setup wizard and accept the default values.
 
 -	Note: You may need to lower the RAM allocated to various services to fit within the bounds of the resource of the containers.
 -	Enable the beer-sample bucket to load some sample data.
 
-![Creating a cluster](https://d774lla4im6mk.cloudfront.net/6.6.2/cluster-creation.jpg)
+![Creating a cluster](https://d774lla4im6mk.cloudfront.net/cluster-creation.jpg)
 
-![Completing the wizard](https://d774lla4im6mk.cloudfront.net/6.6.2/finish-wizard.jpg)
+![Completing the wizard](https://d774lla4im6mk.cloudfront.net/finish-wizard.jpg)
 
-![UI home](https://d774lla4im6mk.cloudfront.net/6.6.2/ui-home.jpg)
+![UI home](https://d774lla4im6mk.cloudfront.net/ui-home.jpg)
 
-![Loading sample data](https://d774lla4im6mk.cloudfront.net/6.6.2/load-sample-data.jpg)
+![Loading sample data](https://d774lla4im6mk.cloudfront.net/load-sample-data.jpg)
 
 **Note :** For detailed information on configuring the Server, see [Deployment Guidelines](https://docs.couchbase.com/server/current/install/install-production-deployment.html).
 

--- a/enterprise/couchbase-server/6.6.3/README.md
+++ b/enterprise/couchbase-server/6.6.3/README.md
@@ -26,20 +26,20 @@ Here is how to get a single node Couchbase Server cluster running on Docker cont
 
 **Step - 2 :** Next, visit `http://localhost:8091` on the host machine to see the Web Console to start Couchbase Server setup.
 
-![Setup splash screen](https://d774lla4im6mk.cloudfront.net/6.6.2/setup-initial.jpg)
+![Setup splash screen](https://d774lla4im6mk.cloudfront.net/setup-initial.jpg)
 
 Walk through the Setup wizard and accept the default values.
 
 -	Note: You may need to lower the RAM allocated to various services to fit within the bounds of the resource of the containers.
 -	Enable the beer-sample bucket to load some sample data.
 
-![Creating a cluster](https://d774lla4im6mk.cloudfront.net/6.6.2/cluster-creation.jpg)
+![Creating a cluster](https://d774lla4im6mk.cloudfront.net/cluster-creation.jpg)
 
-![Completing the wizard](https://d774lla4im6mk.cloudfront.net/6.6.2/finish-wizard.jpg)
+![Completing the wizard](https://d774lla4im6mk.cloudfront.net/finish-wizard.jpg)
 
-![UI home](https://d774lla4im6mk.cloudfront.net/6.6.2/ui-home.jpg)
+![UI home](https://d774lla4im6mk.cloudfront.net/ui-home.jpg)
 
-![Loading sample data](https://d774lla4im6mk.cloudfront.net/6.6.2/load-sample-data.jpg)
+![Loading sample data](https://d774lla4im6mk.cloudfront.net/load-sample-data.jpg)
 
 **Note :** For detailed information on configuring the Server, see [Deployment Guidelines](https://docs.couchbase.com/server/current/install/install-production-deployment.html).
 

--- a/enterprise/couchbase-server/6.6.4/README.md
+++ b/enterprise/couchbase-server/6.6.4/README.md
@@ -26,20 +26,20 @@ Here is how to get a single node Couchbase Server cluster running on Docker cont
 
 **Step - 2 :** Next, visit `http://localhost:8091` on the host machine to see the Web Console to start Couchbase Server setup.
 
-![Setup splash screen](https://d774lla4im6mk.cloudfront.net/6.6.2/setup-initial.jpg)
+![Setup splash screen](https://d774lla4im6mk.cloudfront.net/setup-initial.jpg)
 
 Walk through the Setup wizard and accept the default values.
 
 -	Note: You may need to lower the RAM allocated to various services to fit within the bounds of the resource of the containers.
 -	Enable the beer-sample bucket to load some sample data.
 
-![Creating a cluster](https://d774lla4im6mk.cloudfront.net/6.6.2/cluster-creation.jpg)
+![Creating a cluster](https://d774lla4im6mk.cloudfront.net/cluster-creation.jpg)
 
-![Completing the wizard](https://d774lla4im6mk.cloudfront.net/6.6.2/finish-wizard.jpg)
+![Completing the wizard](https://d774lla4im6mk.cloudfront.net/finish-wizard.jpg)
 
-![UI home](https://d774lla4im6mk.cloudfront.net/6.6.2/ui-home.jpg)
+![UI home](https://d774lla4im6mk.cloudfront.net/ui-home.jpg)
 
-![Loading sample data](https://d774lla4im6mk.cloudfront.net/6.6.2/load-sample-data.jpg)
+![Loading sample data](https://d774lla4im6mk.cloudfront.net/load-sample-data.jpg)
 
 **Note :** For detailed information on configuring the Server, see [Deployment Guidelines](https://docs.couchbase.com/server/current/install/install-production-deployment.html).
 

--- a/enterprise/couchbase-server/6.6.5/README.md
+++ b/enterprise/couchbase-server/6.6.5/README.md
@@ -26,20 +26,20 @@ Here is how to get a single node Couchbase Server cluster running on Docker cont
 
 **Step - 2 :** Next, visit `http://localhost:8091` on the host machine to see the Web Console to start Couchbase Server setup.
 
-![Setup splash screen](https://d774lla4im6mk.cloudfront.net/6.6.2/setup-initial.jpg)
+![Setup splash screen](https://d774lla4im6mk.cloudfront.net/setup-initial.jpg)
 
 Walk through the Setup wizard and accept the default values.
 
 -	Note: You may need to lower the RAM allocated to various services to fit within the bounds of the resource of the containers.
 -	Enable the beer-sample bucket to load some sample data.
 
-![Creating a cluster](https://d774lla4im6mk.cloudfront.net/6.6.2/cluster-creation.jpg)
+![Creating a cluster](https://d774lla4im6mk.cloudfront.net/cluster-creation.jpg)
 
-![Completing the wizard](https://d774lla4im6mk.cloudfront.net/6.6.2/finish-wizard.jpg)
+![Completing the wizard](https://d774lla4im6mk.cloudfront.net/finish-wizard.jpg)
 
-![UI home](https://d774lla4im6mk.cloudfront.net/6.6.2/ui-home.jpg)
+![UI home](https://d774lla4im6mk.cloudfront.net/ui-home.jpg)
 
-![Loading sample data](https://d774lla4im6mk.cloudfront.net/6.6.2/load-sample-data.jpg)
+![Loading sample data](https://d774lla4im6mk.cloudfront.net/load-sample-data.jpg)
 
 **Note :** For detailed information on configuring the Server, see [Deployment Guidelines](https://docs.couchbase.com/server/current/install/install-production-deployment.html).
 

--- a/enterprise/couchbase-server/7.0.0-5017/README.md
+++ b/enterprise/couchbase-server/7.0.0-5017/README.md
@@ -26,20 +26,20 @@ Here is how to get a single node Couchbase Server cluster running on Docker cont
 
 **Step - 2 :** Next, visit `http://localhost:8091` on the host machine to see the Web Console to start Couchbase Server setup.
 
-![Setup splash screen](https://d774lla4im6mk.cloudfront.net/6.6.2/setup-initial.jpg)
+![Setup splash screen](https://d774lla4im6mk.cloudfront.net/setup-initial.jpg)
 
 Walk through the Setup wizard and accept the default values.
 
 -	Note: You may need to lower the RAM allocated to various services to fit within the bounds of the resource of the containers.
 -	Enable the beer-sample bucket to load some sample data.
 
-![Creating a cluster](https://d774lla4im6mk.cloudfront.net/6.6.2/cluster-creation.jpg)
+![Creating a cluster](https://d774lla4im6mk.cloudfront.net/cluster-creation.jpg)
 
-![Completing the wizard](https://d774lla4im6mk.cloudfront.net/6.6.2/finish-wizard.jpg)
+![Completing the wizard](https://d774lla4im6mk.cloudfront.net/finish-wizard.jpg)
 
-![UI home](https://d774lla4im6mk.cloudfront.net/6.6.2/ui-home.jpg)
+![UI home](https://d774lla4im6mk.cloudfront.net/ui-home.jpg)
 
-![Loading sample data](https://d774lla4im6mk.cloudfront.net/6.6.2/load-sample-data.jpg)
+![Loading sample data](https://d774lla4im6mk.cloudfront.net/load-sample-data.jpg)
 
 **Note :** For detailed information on configuring the Server, see [Deployment Guidelines](https://docs.couchbase.com/server/current/install/install-production-deployment.html).
 

--- a/enterprise/couchbase-server/7.0.0-beta/README.md
+++ b/enterprise/couchbase-server/7.0.0-beta/README.md
@@ -26,20 +26,20 @@ Here is how to get a single node Couchbase Server cluster running on Docker cont
 
 **Step - 2 :** Next, visit `http://localhost:8091` on the host machine to see the Web Console to start Couchbase Server setup.
 
-![Setup splash screen](https://d774lla4im6mk.cloudfront.net/6.6.2/setup-initial.jpg)
+![Setup splash screen](https://d774lla4im6mk.cloudfront.net/setup-initial.jpg)
 
 Walk through the Setup wizard and accept the default values.
 
 -	Note: You may need to lower the RAM allocated to various services to fit within the bounds of the resource of the containers.
 -	Enable the beer-sample bucket to load some sample data.
 
-![Creating a cluster](https://d774lla4im6mk.cloudfront.net/6.6.2/cluster-creation.jpg)
+![Creating a cluster](https://d774lla4im6mk.cloudfront.net/cluster-creation.jpg)
 
-![Completing the wizard](https://d774lla4im6mk.cloudfront.net/6.6.2/finish-wizard.jpg)
+![Completing the wizard](https://d774lla4im6mk.cloudfront.net/finish-wizard.jpg)
 
-![UI home](https://d774lla4im6mk.cloudfront.net/6.6.2/ui-home.jpg)
+![UI home](https://d774lla4im6mk.cloudfront.net/ui-home.jpg)
 
-![Loading sample data](https://d774lla4im6mk.cloudfront.net/6.6.2/load-sample-data.jpg)
+![Loading sample data](https://d774lla4im6mk.cloudfront.net/load-sample-data.jpg)
 
 **Note :** For detailed information on configuring the Server, see [Deployment Guidelines](https://docs.couchbase.com/server/current/install/install-production-deployment.html).
 

--- a/enterprise/couchbase-server/7.0.0/README.md
+++ b/enterprise/couchbase-server/7.0.0/README.md
@@ -26,20 +26,20 @@ Here is how to get a single node Couchbase Server cluster running on Docker cont
 
 **Step - 2 :** Next, visit `http://localhost:8091` on the host machine to see the Web Console to start Couchbase Server setup.
 
-![Setup splash screen](https://d774lla4im6mk.cloudfront.net/6.6.2/setup-initial.jpg)
+![Setup splash screen](https://d774lla4im6mk.cloudfront.net/setup-initial.jpg)
 
 Walk through the Setup wizard and accept the default values.
 
 -	Note: You may need to lower the RAM allocated to various services to fit within the bounds of the resource of the containers.
 -	Enable the beer-sample bucket to load some sample data.
 
-![Creating a cluster](https://d774lla4im6mk.cloudfront.net/6.6.2/cluster-creation.jpg)
+![Creating a cluster](https://d774lla4im6mk.cloudfront.net/cluster-creation.jpg)
 
-![Completing the wizard](https://d774lla4im6mk.cloudfront.net/6.6.2/finish-wizard.jpg)
+![Completing the wizard](https://d774lla4im6mk.cloudfront.net/finish-wizard.jpg)
 
-![UI home](https://d774lla4im6mk.cloudfront.net/6.6.2/ui-home.jpg)
+![UI home](https://d774lla4im6mk.cloudfront.net/ui-home.jpg)
 
-![Loading sample data](https://d774lla4im6mk.cloudfront.net/6.6.2/load-sample-data.jpg)
+![Loading sample data](https://d774lla4im6mk.cloudfront.net/load-sample-data.jpg)
 
 **Note :** For detailed information on configuring the Server, see [Deployment Guidelines](https://docs.couchbase.com/server/current/install/install-production-deployment.html).
 

--- a/enterprise/couchbase-server/7.0.1/README.md
+++ b/enterprise/couchbase-server/7.0.1/README.md
@@ -26,20 +26,20 @@ Here is how to get a single node Couchbase Server cluster running on Docker cont
 
 **Step - 2 :** Next, visit `http://localhost:8091` on the host machine to see the Web Console to start Couchbase Server setup.
 
-![Setup splash screen](https://d774lla4im6mk.cloudfront.net/6.6.2/setup-initial.jpg)
+![Setup splash screen](https://d774lla4im6mk.cloudfront.net/setup-initial.jpg)
 
 Walk through the Setup wizard and accept the default values.
 
 -	Note: You may need to lower the RAM allocated to various services to fit within the bounds of the resource of the containers.
 -	Enable the beer-sample bucket to load some sample data.
 
-![Creating a cluster](https://d774lla4im6mk.cloudfront.net/6.6.2/cluster-creation.jpg)
+![Creating a cluster](https://d774lla4im6mk.cloudfront.net/cluster-creation.jpg)
 
-![Completing the wizard](https://d774lla4im6mk.cloudfront.net/6.6.2/finish-wizard.jpg)
+![Completing the wizard](https://d774lla4im6mk.cloudfront.net/finish-wizard.jpg)
 
-![UI home](https://d774lla4im6mk.cloudfront.net/6.6.2/ui-home.jpg)
+![UI home](https://d774lla4im6mk.cloudfront.net/ui-home.jpg)
 
-![Loading sample data](https://d774lla4im6mk.cloudfront.net/6.6.2/load-sample-data.jpg)
+![Loading sample data](https://d774lla4im6mk.cloudfront.net/load-sample-data.jpg)
 
 **Note :** For detailed information on configuring the Server, see [Deployment Guidelines](https://docs.couchbase.com/server/current/install/install-production-deployment.html).
 

--- a/enterprise/couchbase-server/7.0.2/README.md
+++ b/enterprise/couchbase-server/7.0.2/README.md
@@ -26,20 +26,20 @@ Here is how to get a single node Couchbase Server cluster running on Docker cont
 
 **Step - 2 :** Next, visit `http://localhost:8091` on the host machine to see the Web Console to start Couchbase Server setup.
 
-![Setup splash screen](https://d774lla4im6mk.cloudfront.net/6.6.2/setup-initial.jpg)
+![Setup splash screen](https://d774lla4im6mk.cloudfront.net/setup-initial.jpg)
 
 Walk through the Setup wizard and accept the default values.
 
 -	Note: You may need to lower the RAM allocated to various services to fit within the bounds of the resource of the containers.
 -	Enable the beer-sample bucket to load some sample data.
 
-![Creating a cluster](https://d774lla4im6mk.cloudfront.net/6.6.2/cluster-creation.jpg)
+![Creating a cluster](https://d774lla4im6mk.cloudfront.net/cluster-creation.jpg)
 
-![Completing the wizard](https://d774lla4im6mk.cloudfront.net/6.6.2/finish-wizard.jpg)
+![Completing the wizard](https://d774lla4im6mk.cloudfront.net/finish-wizard.jpg)
 
-![UI home](https://d774lla4im6mk.cloudfront.net/6.6.2/ui-home.jpg)
+![UI home](https://d774lla4im6mk.cloudfront.net/ui-home.jpg)
 
-![Loading sample data](https://d774lla4im6mk.cloudfront.net/6.6.2/load-sample-data.jpg)
+![Loading sample data](https://d774lla4im6mk.cloudfront.net/load-sample-data.jpg)
 
 **Note :** For detailed information on configuring the Server, see [Deployment Guidelines](https://docs.couchbase.com/server/current/install/install-production-deployment.html).
 

--- a/enterprise/couchbase-server/7.0.3/README.md
+++ b/enterprise/couchbase-server/7.0.3/README.md
@@ -26,20 +26,20 @@ Here is how to get a single node Couchbase Server cluster running on Docker cont
 
 **Step - 2 :** Next, visit `http://localhost:8091` on the host machine to see the Web Console to start Couchbase Server setup.
 
-![Setup splash screen](https://d774lla4im6mk.cloudfront.net/6.6.2/setup-initial.jpg)
+![Setup splash screen](https://d774lla4im6mk.cloudfront.net/setup-initial.jpg)
 
 Walk through the Setup wizard and accept the default values.
 
 -	Note: You may need to lower the RAM allocated to various services to fit within the bounds of the resource of the containers.
 -	Enable the beer-sample bucket to load some sample data.
 
-![Creating a cluster](https://d774lla4im6mk.cloudfront.net/6.6.2/cluster-creation.jpg)
+![Creating a cluster](https://d774lla4im6mk.cloudfront.net/cluster-creation.jpg)
 
-![Completing the wizard](https://d774lla4im6mk.cloudfront.net/6.6.2/finish-wizard.jpg)
+![Completing the wizard](https://d774lla4im6mk.cloudfront.net/finish-wizard.jpg)
 
-![UI home](https://d774lla4im6mk.cloudfront.net/6.6.2/ui-home.jpg)
+![UI home](https://d774lla4im6mk.cloudfront.net/ui-home.jpg)
 
-![Loading sample data](https://d774lla4im6mk.cloudfront.net/6.6.2/load-sample-data.jpg)
+![Loading sample data](https://d774lla4im6mk.cloudfront.net/load-sample-data.jpg)
 
 **Note :** For detailed information on configuring the Server, see [Deployment Guidelines](https://docs.couchbase.com/server/current/install/install-production-deployment.html).
 

--- a/enterprise/couchbase-server/7.0.4/README.md
+++ b/enterprise/couchbase-server/7.0.4/README.md
@@ -26,20 +26,20 @@ Here is how to get a single node Couchbase Server cluster running on Docker cont
 
 **Step - 2 :** Next, visit `http://localhost:8091` on the host machine to see the Web Console to start Couchbase Server setup.
 
-![Setup splash screen](https://d774lla4im6mk.cloudfront.net/6.6.2/setup-initial.jpg)
+![Setup splash screen](https://d774lla4im6mk.cloudfront.net/setup-initial.jpg)
 
 Walk through the Setup wizard and accept the default values.
 
 -	Note: You may need to lower the RAM allocated to various services to fit within the bounds of the resource of the containers.
 -	Enable the beer-sample bucket to load some sample data.
 
-![Creating a cluster](https://d774lla4im6mk.cloudfront.net/6.6.2/cluster-creation.jpg)
+![Creating a cluster](https://d774lla4im6mk.cloudfront.net/cluster-creation.jpg)
 
-![Completing the wizard](https://d774lla4im6mk.cloudfront.net/6.6.2/finish-wizard.jpg)
+![Completing the wizard](https://d774lla4im6mk.cloudfront.net/finish-wizard.jpg)
 
-![UI home](https://d774lla4im6mk.cloudfront.net/6.6.2/ui-home.jpg)
+![UI home](https://d774lla4im6mk.cloudfront.net/ui-home.jpg)
 
-![Loading sample data](https://d774lla4im6mk.cloudfront.net/6.6.2/load-sample-data.jpg)
+![Loading sample data](https://d774lla4im6mk.cloudfront.net/load-sample-data.jpg)
 
 **Note :** For detailed information on configuring the Server, see [Deployment Guidelines](https://docs.couchbase.com/server/current/install/install-production-deployment.html).
 

--- a/enterprise/couchbase-server/7.1.0/aarch64/README.md
+++ b/enterprise/couchbase-server/7.1.0/aarch64/README.md
@@ -26,20 +26,20 @@ Here is how to get a single node Couchbase Server cluster running on Docker cont
 
 **Step - 2 :** Next, visit `http://localhost:8091` on the host machine to see the Web Console to start Couchbase Server setup.
 
-![Setup splash screen](https://d774lla4im6mk.cloudfront.net/6.6.2/setup-initial.jpg)
+![Setup splash screen](https://d774lla4im6mk.cloudfront.net/setup-initial.jpg)
 
 Walk through the Setup wizard and accept the default values.
 
 -	Note: You may need to lower the RAM allocated to various services to fit within the bounds of the resource of the containers.
 -	Enable the beer-sample bucket to load some sample data.
 
-![Creating a cluster](https://d774lla4im6mk.cloudfront.net/6.6.2/cluster-creation.jpg)
+![Creating a cluster](https://d774lla4im6mk.cloudfront.net/cluster-creation.jpg)
 
-![Completing the wizard](https://d774lla4im6mk.cloudfront.net/6.6.2/finish-wizard.jpg)
+![Completing the wizard](https://d774lla4im6mk.cloudfront.net/finish-wizard.jpg)
 
-![UI home](https://d774lla4im6mk.cloudfront.net/6.6.2/ui-home.jpg)
+![UI home](https://d774lla4im6mk.cloudfront.net/ui-home.jpg)
 
-![Loading sample data](https://d774lla4im6mk.cloudfront.net/6.6.2/load-sample-data.jpg)
+![Loading sample data](https://d774lla4im6mk.cloudfront.net/load-sample-data.jpg)
 
 **Note :** For detailed information on configuring the Server, see [Deployment Guidelines](https://docs.couchbase.com/server/current/install/install-production-deployment.html).
 

--- a/enterprise/couchbase-server/7.1.0/x86_64/README.md
+++ b/enterprise/couchbase-server/7.1.0/x86_64/README.md
@@ -26,20 +26,20 @@ Here is how to get a single node Couchbase Server cluster running on Docker cont
 
 **Step - 2 :** Next, visit `http://localhost:8091` on the host machine to see the Web Console to start Couchbase Server setup.
 
-![Setup splash screen](https://d774lla4im6mk.cloudfront.net/6.6.2/setup-initial.jpg)
+![Setup splash screen](https://d774lla4im6mk.cloudfront.net/setup-initial.jpg)
 
 Walk through the Setup wizard and accept the default values.
 
 -	Note: You may need to lower the RAM allocated to various services to fit within the bounds of the resource of the containers.
 -	Enable the beer-sample bucket to load some sample data.
 
-![Creating a cluster](https://d774lla4im6mk.cloudfront.net/6.6.2/cluster-creation.jpg)
+![Creating a cluster](https://d774lla4im6mk.cloudfront.net/cluster-creation.jpg)
 
-![Completing the wizard](https://d774lla4im6mk.cloudfront.net/6.6.2/finish-wizard.jpg)
+![Completing the wizard](https://d774lla4im6mk.cloudfront.net/finish-wizard.jpg)
 
-![UI home](https://d774lla4im6mk.cloudfront.net/6.6.2/ui-home.jpg)
+![UI home](https://d774lla4im6mk.cloudfront.net/ui-home.jpg)
 
-![Loading sample data](https://d774lla4im6mk.cloudfront.net/6.6.2/load-sample-data.jpg)
+![Loading sample data](https://d774lla4im6mk.cloudfront.net/load-sample-data.jpg)
 
 **Note :** For detailed information on configuring the Server, see [Deployment Guidelines](https://docs.couchbase.com/server/current/install/install-production-deployment.html).
 

--- a/enterprise/sync-gateway/2.1.0/README.md
+++ b/enterprise/sync-gateway/2.1.0/README.md
@@ -80,10 +80,19 @@ $ curl http://localhost:4985
 
 **Step - 1 :** Prepare the Sync Gateway configuration file on your local machine:
 
+For versions 3.0.0 and newer:
 ```
 $ cd /tmp
-$ wget https://raw.githubusercontent.com/couchbase/sync_gateway/master/examples/basic-walrus-bucket.json
-$ mv basic-walrus-bucket.json my-sg-config.json
+$ wget https://raw.githubusercontent.com/couchbase/sync_gateway/master/examples/startup_config/basic.json
+$ mv basic.json my-sg-config.json
+$ vi my-sg-config.json  # make edits
+```
+
+For older versions:
+```
+$ cd /tmp
+$ wget https://raw.githubusercontent.com/couchbase/sync_gateway/master/examples/release/2.8.3/examples/serviceconfig.json
+$ mv serviceconfig.json my-sg-config.json
 $ vi my-sg-config.json  # make edits
 ```
 
@@ -99,7 +108,13 @@ Sync Gateway can also load its configuration directly from a public URL.
 
 **Step - 2 :** Then start Sync Gateway and give it the URL to the raw JSON data:
 
-`$ docker run -p 4984:4984 -d couchbase/sync-gateway https://raw.githubusercontent.com/couchbase/sync_gateway/master/examples/basic-walrus-bucket.json`
+For versions 3.0.0 and newer:
+
+`$ docker run -p 4984:4984 -d couchbase/sync-gateway https://raw.githubusercontent.com/couchbase/sync_gateway/master/examples/startup_config/basic.json`
+
+For older versions:
+
+`$ docker run -p 4984:4984 -d couchbase/sync-gateway https://raw.githubusercontent.com/couchbase/sync_gateway/release/2.8.3/examples/serviceconfig.json`
 
 # Running with a Couchbase Server container
 

--- a/enterprise/sync-gateway/2.1.1/README.md
+++ b/enterprise/sync-gateway/2.1.1/README.md
@@ -80,10 +80,19 @@ $ curl http://localhost:4985
 
 **Step - 1 :** Prepare the Sync Gateway configuration file on your local machine:
 
+For versions 3.0.0 and newer:
 ```
 $ cd /tmp
-$ wget https://raw.githubusercontent.com/couchbase/sync_gateway/master/examples/basic-walrus-bucket.json
-$ mv basic-walrus-bucket.json my-sg-config.json
+$ wget https://raw.githubusercontent.com/couchbase/sync_gateway/master/examples/startup_config/basic.json
+$ mv basic.json my-sg-config.json
+$ vi my-sg-config.json  # make edits
+```
+
+For older versions:
+```
+$ cd /tmp
+$ wget https://raw.githubusercontent.com/couchbase/sync_gateway/master/examples/release/2.8.3/examples/serviceconfig.json
+$ mv serviceconfig.json my-sg-config.json
 $ vi my-sg-config.json  # make edits
 ```
 
@@ -99,7 +108,13 @@ Sync Gateway can also load its configuration directly from a public URL.
 
 **Step - 2 :** Then start Sync Gateway and give it the URL to the raw JSON data:
 
-`$ docker run -p 4984:4984 -d couchbase/sync-gateway https://raw.githubusercontent.com/couchbase/sync_gateway/master/examples/basic-walrus-bucket.json`
+For versions 3.0.0 and newer:
+
+`$ docker run -p 4984:4984 -d couchbase/sync-gateway https://raw.githubusercontent.com/couchbase/sync_gateway/master/examples/startup_config/basic.json`
+
+For older versions:
+
+`$ docker run -p 4984:4984 -d couchbase/sync-gateway https://raw.githubusercontent.com/couchbase/sync_gateway/release/2.8.3/examples/serviceconfig.json`
 
 # Running with a Couchbase Server container
 

--- a/enterprise/sync-gateway/2.1.2/README.md
+++ b/enterprise/sync-gateway/2.1.2/README.md
@@ -80,10 +80,19 @@ $ curl http://localhost:4985
 
 **Step - 1 :** Prepare the Sync Gateway configuration file on your local machine:
 
+For versions 3.0.0 and newer:
 ```
 $ cd /tmp
-$ wget https://raw.githubusercontent.com/couchbase/sync_gateway/master/examples/basic-walrus-bucket.json
-$ mv basic-walrus-bucket.json my-sg-config.json
+$ wget https://raw.githubusercontent.com/couchbase/sync_gateway/master/examples/startup_config/basic.json
+$ mv basic.json my-sg-config.json
+$ vi my-sg-config.json  # make edits
+```
+
+For older versions:
+```
+$ cd /tmp
+$ wget https://raw.githubusercontent.com/couchbase/sync_gateway/master/examples/release/2.8.3/examples/serviceconfig.json
+$ mv serviceconfig.json my-sg-config.json
 $ vi my-sg-config.json  # make edits
 ```
 
@@ -99,7 +108,13 @@ Sync Gateway can also load its configuration directly from a public URL.
 
 **Step - 2 :** Then start Sync Gateway and give it the URL to the raw JSON data:
 
-`$ docker run -p 4984:4984 -d couchbase/sync-gateway https://raw.githubusercontent.com/couchbase/sync_gateway/master/examples/basic-walrus-bucket.json`
+For versions 3.0.0 and newer:
+
+`$ docker run -p 4984:4984 -d couchbase/sync-gateway https://raw.githubusercontent.com/couchbase/sync_gateway/master/examples/startup_config/basic.json`
+
+For older versions:
+
+`$ docker run -p 4984:4984 -d couchbase/sync-gateway https://raw.githubusercontent.com/couchbase/sync_gateway/release/2.8.3/examples/serviceconfig.json`
 
 # Running with a Couchbase Server container
 

--- a/enterprise/sync-gateway/2.1.3/README.md
+++ b/enterprise/sync-gateway/2.1.3/README.md
@@ -80,10 +80,19 @@ $ curl http://localhost:4985
 
 **Step - 1 :** Prepare the Sync Gateway configuration file on your local machine:
 
+For versions 3.0.0 and newer:
 ```
 $ cd /tmp
-$ wget https://raw.githubusercontent.com/couchbase/sync_gateway/master/examples/basic-walrus-bucket.json
-$ mv basic-walrus-bucket.json my-sg-config.json
+$ wget https://raw.githubusercontent.com/couchbase/sync_gateway/master/examples/startup_config/basic.json
+$ mv basic.json my-sg-config.json
+$ vi my-sg-config.json  # make edits
+```
+
+For older versions:
+```
+$ cd /tmp
+$ wget https://raw.githubusercontent.com/couchbase/sync_gateway/master/examples/release/2.8.3/examples/serviceconfig.json
+$ mv serviceconfig.json my-sg-config.json
 $ vi my-sg-config.json  # make edits
 ```
 
@@ -99,7 +108,13 @@ Sync Gateway can also load its configuration directly from a public URL.
 
 **Step - 2 :** Then start Sync Gateway and give it the URL to the raw JSON data:
 
-`$ docker run -p 4984:4984 -d couchbase/sync-gateway https://raw.githubusercontent.com/couchbase/sync_gateway/master/examples/basic-walrus-bucket.json`
+For versions 3.0.0 and newer:
+
+`$ docker run -p 4984:4984 -d couchbase/sync-gateway https://raw.githubusercontent.com/couchbase/sync_gateway/master/examples/startup_config/basic.json`
+
+For older versions:
+
+`$ docker run -p 4984:4984 -d couchbase/sync-gateway https://raw.githubusercontent.com/couchbase/sync_gateway/release/2.8.3/examples/serviceconfig.json`
 
 # Running with a Couchbase Server container
 

--- a/enterprise/sync-gateway/2.5.0/README.md
+++ b/enterprise/sync-gateway/2.5.0/README.md
@@ -80,10 +80,19 @@ $ curl http://localhost:4985
 
 **Step - 1 :** Prepare the Sync Gateway configuration file on your local machine:
 
+For versions 3.0.0 and newer:
 ```
 $ cd /tmp
-$ wget https://raw.githubusercontent.com/couchbase/sync_gateway/master/examples/basic-walrus-bucket.json
-$ mv basic-walrus-bucket.json my-sg-config.json
+$ wget https://raw.githubusercontent.com/couchbase/sync_gateway/master/examples/startup_config/basic.json
+$ mv basic.json my-sg-config.json
+$ vi my-sg-config.json  # make edits
+```
+
+For older versions:
+```
+$ cd /tmp
+$ wget https://raw.githubusercontent.com/couchbase/sync_gateway/master/examples/release/2.8.3/examples/serviceconfig.json
+$ mv serviceconfig.json my-sg-config.json
 $ vi my-sg-config.json  # make edits
 ```
 
@@ -99,7 +108,13 @@ Sync Gateway can also load its configuration directly from a public URL.
 
 **Step - 2 :** Then start Sync Gateway and give it the URL to the raw JSON data:
 
-`$ docker run -p 4984:4984 -d couchbase/sync-gateway https://raw.githubusercontent.com/couchbase/sync_gateway/master/examples/basic-walrus-bucket.json`
+For versions 3.0.0 and newer:
+
+`$ docker run -p 4984:4984 -d couchbase/sync-gateway https://raw.githubusercontent.com/couchbase/sync_gateway/master/examples/startup_config/basic.json`
+
+For older versions:
+
+`$ docker run -p 4984:4984 -d couchbase/sync-gateway https://raw.githubusercontent.com/couchbase/sync_gateway/release/2.8.3/examples/serviceconfig.json`
 
 # Running with a Couchbase Server container
 

--- a/enterprise/sync-gateway/2.5.1/README.md
+++ b/enterprise/sync-gateway/2.5.1/README.md
@@ -80,10 +80,19 @@ $ curl http://localhost:4985
 
 **Step - 1 :** Prepare the Sync Gateway configuration file on your local machine:
 
+For versions 3.0.0 and newer:
 ```
 $ cd /tmp
-$ wget https://raw.githubusercontent.com/couchbase/sync_gateway/master/examples/basic-walrus-bucket.json
-$ mv basic-walrus-bucket.json my-sg-config.json
+$ wget https://raw.githubusercontent.com/couchbase/sync_gateway/master/examples/startup_config/basic.json
+$ mv basic.json my-sg-config.json
+$ vi my-sg-config.json  # make edits
+```
+
+For older versions:
+```
+$ cd /tmp
+$ wget https://raw.githubusercontent.com/couchbase/sync_gateway/master/examples/release/2.8.3/examples/serviceconfig.json
+$ mv serviceconfig.json my-sg-config.json
 $ vi my-sg-config.json  # make edits
 ```
 
@@ -99,7 +108,13 @@ Sync Gateway can also load its configuration directly from a public URL.
 
 **Step - 2 :** Then start Sync Gateway and give it the URL to the raw JSON data:
 
-`$ docker run -p 4984:4984 -d couchbase/sync-gateway https://raw.githubusercontent.com/couchbase/sync_gateway/master/examples/basic-walrus-bucket.json`
+For versions 3.0.0 and newer:
+
+`$ docker run -p 4984:4984 -d couchbase/sync-gateway https://raw.githubusercontent.com/couchbase/sync_gateway/master/examples/startup_config/basic.json`
+
+For older versions:
+
+`$ docker run -p 4984:4984 -d couchbase/sync-gateway https://raw.githubusercontent.com/couchbase/sync_gateway/release/2.8.3/examples/serviceconfig.json`
 
 # Running with a Couchbase Server container
 

--- a/enterprise/sync-gateway/2.6.0/README.md
+++ b/enterprise/sync-gateway/2.6.0/README.md
@@ -80,10 +80,19 @@ $ curl http://localhost:4985
 
 **Step - 1 :** Prepare the Sync Gateway configuration file on your local machine:
 
+For versions 3.0.0 and newer:
 ```
 $ cd /tmp
-$ wget https://raw.githubusercontent.com/couchbase/sync_gateway/master/examples/basic-walrus-bucket.json
-$ mv basic-walrus-bucket.json my-sg-config.json
+$ wget https://raw.githubusercontent.com/couchbase/sync_gateway/master/examples/startup_config/basic.json
+$ mv basic.json my-sg-config.json
+$ vi my-sg-config.json  # make edits
+```
+
+For older versions:
+```
+$ cd /tmp
+$ wget https://raw.githubusercontent.com/couchbase/sync_gateway/master/examples/release/2.8.3/examples/serviceconfig.json
+$ mv serviceconfig.json my-sg-config.json
 $ vi my-sg-config.json  # make edits
 ```
 
@@ -99,7 +108,13 @@ Sync Gateway can also load its configuration directly from a public URL.
 
 **Step - 2 :** Then start Sync Gateway and give it the URL to the raw JSON data:
 
-`$ docker run -p 4984:4984 -d couchbase/sync-gateway https://raw.githubusercontent.com/couchbase/sync_gateway/master/examples/basic-walrus-bucket.json`
+For versions 3.0.0 and newer:
+
+`$ docker run -p 4984:4984 -d couchbase/sync-gateway https://raw.githubusercontent.com/couchbase/sync_gateway/master/examples/startup_config/basic.json`
+
+For older versions:
+
+`$ docker run -p 4984:4984 -d couchbase/sync-gateway https://raw.githubusercontent.com/couchbase/sync_gateway/release/2.8.3/examples/serviceconfig.json`
 
 # Running with a Couchbase Server container
 

--- a/enterprise/sync-gateway/2.6.1/README.md
+++ b/enterprise/sync-gateway/2.6.1/README.md
@@ -80,10 +80,19 @@ $ curl http://localhost:4985
 
 **Step - 1 :** Prepare the Sync Gateway configuration file on your local machine:
 
+For versions 3.0.0 and newer:
 ```
 $ cd /tmp
-$ wget https://raw.githubusercontent.com/couchbase/sync_gateway/master/examples/basic-walrus-bucket.json
-$ mv basic-walrus-bucket.json my-sg-config.json
+$ wget https://raw.githubusercontent.com/couchbase/sync_gateway/master/examples/startup_config/basic.json
+$ mv basic.json my-sg-config.json
+$ vi my-sg-config.json  # make edits
+```
+
+For older versions:
+```
+$ cd /tmp
+$ wget https://raw.githubusercontent.com/couchbase/sync_gateway/master/examples/release/2.8.3/examples/serviceconfig.json
+$ mv serviceconfig.json my-sg-config.json
 $ vi my-sg-config.json  # make edits
 ```
 
@@ -99,7 +108,13 @@ Sync Gateway can also load its configuration directly from a public URL.
 
 **Step - 2 :** Then start Sync Gateway and give it the URL to the raw JSON data:
 
-`$ docker run -p 4984:4984 -d couchbase/sync-gateway https://raw.githubusercontent.com/couchbase/sync_gateway/master/examples/basic-walrus-bucket.json`
+For versions 3.0.0 and newer:
+
+`$ docker run -p 4984:4984 -d couchbase/sync-gateway https://raw.githubusercontent.com/couchbase/sync_gateway/master/examples/startup_config/basic.json`
+
+For older versions:
+
+`$ docker run -p 4984:4984 -d couchbase/sync-gateway https://raw.githubusercontent.com/couchbase/sync_gateway/release/2.8.3/examples/serviceconfig.json`
 
 # Running with a Couchbase Server container
 

--- a/enterprise/sync-gateway/2.7.0/README.md
+++ b/enterprise/sync-gateway/2.7.0/README.md
@@ -80,10 +80,19 @@ $ curl http://localhost:4985
 
 **Step - 1 :** Prepare the Sync Gateway configuration file on your local machine:
 
+For versions 3.0.0 and newer:
 ```
 $ cd /tmp
-$ wget https://raw.githubusercontent.com/couchbase/sync_gateway/master/examples/basic-walrus-bucket.json
-$ mv basic-walrus-bucket.json my-sg-config.json
+$ wget https://raw.githubusercontent.com/couchbase/sync_gateway/master/examples/startup_config/basic.json
+$ mv basic.json my-sg-config.json
+$ vi my-sg-config.json  # make edits
+```
+
+For older versions:
+```
+$ cd /tmp
+$ wget https://raw.githubusercontent.com/couchbase/sync_gateway/master/examples/release/2.8.3/examples/serviceconfig.json
+$ mv serviceconfig.json my-sg-config.json
 $ vi my-sg-config.json  # make edits
 ```
 
@@ -99,7 +108,13 @@ Sync Gateway can also load its configuration directly from a public URL.
 
 **Step - 2 :** Then start Sync Gateway and give it the URL to the raw JSON data:
 
-`$ docker run -p 4984:4984 -d couchbase/sync-gateway https://raw.githubusercontent.com/couchbase/sync_gateway/master/examples/basic-walrus-bucket.json`
+For versions 3.0.0 and newer:
+
+`$ docker run -p 4984:4984 -d couchbase/sync-gateway https://raw.githubusercontent.com/couchbase/sync_gateway/master/examples/startup_config/basic.json`
+
+For older versions:
+
+`$ docker run -p 4984:4984 -d couchbase/sync-gateway https://raw.githubusercontent.com/couchbase/sync_gateway/release/2.8.3/examples/serviceconfig.json`
 
 # Running with a Couchbase Server container
 

--- a/enterprise/sync-gateway/2.7.1/README.md
+++ b/enterprise/sync-gateway/2.7.1/README.md
@@ -80,10 +80,19 @@ $ curl http://localhost:4985
 
 **Step - 1 :** Prepare the Sync Gateway configuration file on your local machine:
 
+For versions 3.0.0 and newer:
 ```
 $ cd /tmp
-$ wget https://raw.githubusercontent.com/couchbase/sync_gateway/master/examples/basic-walrus-bucket.json
-$ mv basic-walrus-bucket.json my-sg-config.json
+$ wget https://raw.githubusercontent.com/couchbase/sync_gateway/master/examples/startup_config/basic.json
+$ mv basic.json my-sg-config.json
+$ vi my-sg-config.json  # make edits
+```
+
+For older versions:
+```
+$ cd /tmp
+$ wget https://raw.githubusercontent.com/couchbase/sync_gateway/master/examples/release/2.8.3/examples/serviceconfig.json
+$ mv serviceconfig.json my-sg-config.json
 $ vi my-sg-config.json  # make edits
 ```
 
@@ -99,7 +108,13 @@ Sync Gateway can also load its configuration directly from a public URL.
 
 **Step - 2 :** Then start Sync Gateway and give it the URL to the raw JSON data:
 
-`$ docker run -p 4984:4984 -d couchbase/sync-gateway https://raw.githubusercontent.com/couchbase/sync_gateway/master/examples/basic-walrus-bucket.json`
+For versions 3.0.0 and newer:
+
+`$ docker run -p 4984:4984 -d couchbase/sync-gateway https://raw.githubusercontent.com/couchbase/sync_gateway/master/examples/startup_config/basic.json`
+
+For older versions:
+
+`$ docker run -p 4984:4984 -d couchbase/sync-gateway https://raw.githubusercontent.com/couchbase/sync_gateway/release/2.8.3/examples/serviceconfig.json`
 
 # Running with a Couchbase Server container
 

--- a/enterprise/sync-gateway/2.7.2/README.md
+++ b/enterprise/sync-gateway/2.7.2/README.md
@@ -80,10 +80,19 @@ $ curl http://localhost:4985
 
 **Step - 1 :** Prepare the Sync Gateway configuration file on your local machine:
 
+For versions 3.0.0 and newer:
 ```
 $ cd /tmp
-$ wget https://raw.githubusercontent.com/couchbase/sync_gateway/master/examples/basic-walrus-bucket.json
-$ mv basic-walrus-bucket.json my-sg-config.json
+$ wget https://raw.githubusercontent.com/couchbase/sync_gateway/master/examples/startup_config/basic.json
+$ mv basic.json my-sg-config.json
+$ vi my-sg-config.json  # make edits
+```
+
+For older versions:
+```
+$ cd /tmp
+$ wget https://raw.githubusercontent.com/couchbase/sync_gateway/master/examples/release/2.8.3/examples/serviceconfig.json
+$ mv serviceconfig.json my-sg-config.json
 $ vi my-sg-config.json  # make edits
 ```
 
@@ -99,7 +108,13 @@ Sync Gateway can also load its configuration directly from a public URL.
 
 **Step - 2 :** Then start Sync Gateway and give it the URL to the raw JSON data:
 
-`$ docker run -p 4984:4984 -d couchbase/sync-gateway https://raw.githubusercontent.com/couchbase/sync_gateway/master/examples/basic-walrus-bucket.json`
+For versions 3.0.0 and newer:
+
+`$ docker run -p 4984:4984 -d couchbase/sync-gateway https://raw.githubusercontent.com/couchbase/sync_gateway/master/examples/startup_config/basic.json`
+
+For older versions:
+
+`$ docker run -p 4984:4984 -d couchbase/sync-gateway https://raw.githubusercontent.com/couchbase/sync_gateway/release/2.8.3/examples/serviceconfig.json`
 
 # Running with a Couchbase Server container
 

--- a/enterprise/sync-gateway/2.7.3/README.md
+++ b/enterprise/sync-gateway/2.7.3/README.md
@@ -80,10 +80,19 @@ $ curl http://localhost:4985
 
 **Step - 1 :** Prepare the Sync Gateway configuration file on your local machine:
 
+For versions 3.0.0 and newer:
 ```
 $ cd /tmp
-$ wget https://raw.githubusercontent.com/couchbase/sync_gateway/master/examples/basic-walrus-bucket.json
-$ mv basic-walrus-bucket.json my-sg-config.json
+$ wget https://raw.githubusercontent.com/couchbase/sync_gateway/master/examples/startup_config/basic.json
+$ mv basic.json my-sg-config.json
+$ vi my-sg-config.json  # make edits
+```
+
+For older versions:
+```
+$ cd /tmp
+$ wget https://raw.githubusercontent.com/couchbase/sync_gateway/master/examples/release/2.8.3/examples/serviceconfig.json
+$ mv serviceconfig.json my-sg-config.json
 $ vi my-sg-config.json  # make edits
 ```
 
@@ -99,7 +108,13 @@ Sync Gateway can also load its configuration directly from a public URL.
 
 **Step - 2 :** Then start Sync Gateway and give it the URL to the raw JSON data:
 
-`$ docker run -p 4984:4984 -d couchbase/sync-gateway https://raw.githubusercontent.com/couchbase/sync_gateway/master/examples/basic-walrus-bucket.json`
+For versions 3.0.0 and newer:
+
+`$ docker run -p 4984:4984 -d couchbase/sync-gateway https://raw.githubusercontent.com/couchbase/sync_gateway/master/examples/startup_config/basic.json`
+
+For older versions:
+
+`$ docker run -p 4984:4984 -d couchbase/sync-gateway https://raw.githubusercontent.com/couchbase/sync_gateway/release/2.8.3/examples/serviceconfig.json`
 
 # Running with a Couchbase Server container
 

--- a/enterprise/sync-gateway/2.7.4/README.md
+++ b/enterprise/sync-gateway/2.7.4/README.md
@@ -80,10 +80,19 @@ $ curl http://localhost:4985
 
 **Step - 1 :** Prepare the Sync Gateway configuration file on your local machine:
 
+For versions 3.0.0 and newer:
 ```
 $ cd /tmp
-$ wget https://raw.githubusercontent.com/couchbase/sync_gateway/master/examples/basic-walrus-bucket.json
-$ mv basic-walrus-bucket.json my-sg-config.json
+$ wget https://raw.githubusercontent.com/couchbase/sync_gateway/master/examples/startup_config/basic.json
+$ mv basic.json my-sg-config.json
+$ vi my-sg-config.json  # make edits
+```
+
+For older versions:
+```
+$ cd /tmp
+$ wget https://raw.githubusercontent.com/couchbase/sync_gateway/master/examples/release/2.8.3/examples/serviceconfig.json
+$ mv serviceconfig.json my-sg-config.json
 $ vi my-sg-config.json  # make edits
 ```
 
@@ -99,7 +108,13 @@ Sync Gateway can also load its configuration directly from a public URL.
 
 **Step - 2 :** Then start Sync Gateway and give it the URL to the raw JSON data:
 
-`$ docker run -p 4984:4984 -d couchbase/sync-gateway https://raw.githubusercontent.com/couchbase/sync_gateway/master/examples/basic-walrus-bucket.json`
+For versions 3.0.0 and newer:
+
+`$ docker run -p 4984:4984 -d couchbase/sync-gateway https://raw.githubusercontent.com/couchbase/sync_gateway/master/examples/startup_config/basic.json`
+
+For older versions:
+
+`$ docker run -p 4984:4984 -d couchbase/sync-gateway https://raw.githubusercontent.com/couchbase/sync_gateway/release/2.8.3/examples/serviceconfig.json`
 
 # Running with a Couchbase Server container
 

--- a/enterprise/sync-gateway/2.8.0/README.md
+++ b/enterprise/sync-gateway/2.8.0/README.md
@@ -80,10 +80,19 @@ $ curl http://localhost:4985
 
 **Step - 1 :** Prepare the Sync Gateway configuration file on your local machine:
 
+For versions 3.0.0 and newer:
 ```
 $ cd /tmp
-$ wget https://raw.githubusercontent.com/couchbase/sync_gateway/master/examples/basic-walrus-bucket.json
-$ mv basic-walrus-bucket.json my-sg-config.json
+$ wget https://raw.githubusercontent.com/couchbase/sync_gateway/master/examples/startup_config/basic.json
+$ mv basic.json my-sg-config.json
+$ vi my-sg-config.json  # make edits
+```
+
+For older versions:
+```
+$ cd /tmp
+$ wget https://raw.githubusercontent.com/couchbase/sync_gateway/master/examples/release/2.8.3/examples/serviceconfig.json
+$ mv serviceconfig.json my-sg-config.json
 $ vi my-sg-config.json  # make edits
 ```
 
@@ -99,7 +108,13 @@ Sync Gateway can also load its configuration directly from a public URL.
 
 **Step - 2 :** Then start Sync Gateway and give it the URL to the raw JSON data:
 
-`$ docker run -p 4984:4984 -d couchbase/sync-gateway https://raw.githubusercontent.com/couchbase/sync_gateway/master/examples/basic-walrus-bucket.json`
+For versions 3.0.0 and newer:
+
+`$ docker run -p 4984:4984 -d couchbase/sync-gateway https://raw.githubusercontent.com/couchbase/sync_gateway/master/examples/startup_config/basic.json`
+
+For older versions:
+
+`$ docker run -p 4984:4984 -d couchbase/sync-gateway https://raw.githubusercontent.com/couchbase/sync_gateway/release/2.8.3/examples/serviceconfig.json`
 
 # Running with a Couchbase Server container
 

--- a/enterprise/sync-gateway/2.8.2/README.md
+++ b/enterprise/sync-gateway/2.8.2/README.md
@@ -80,10 +80,19 @@ $ curl http://localhost:4985
 
 **Step - 1 :** Prepare the Sync Gateway configuration file on your local machine:
 
+For versions 3.0.0 and newer:
 ```
 $ cd /tmp
-$ wget https://raw.githubusercontent.com/couchbase/sync_gateway/master/examples/basic-walrus-bucket.json
-$ mv basic-walrus-bucket.json my-sg-config.json
+$ wget https://raw.githubusercontent.com/couchbase/sync_gateway/master/examples/startup_config/basic.json
+$ mv basic.json my-sg-config.json
+$ vi my-sg-config.json  # make edits
+```
+
+For older versions:
+```
+$ cd /tmp
+$ wget https://raw.githubusercontent.com/couchbase/sync_gateway/master/examples/release/2.8.3/examples/serviceconfig.json
+$ mv serviceconfig.json my-sg-config.json
 $ vi my-sg-config.json  # make edits
 ```
 
@@ -99,7 +108,13 @@ Sync Gateway can also load its configuration directly from a public URL.
 
 **Step - 2 :** Then start Sync Gateway and give it the URL to the raw JSON data:
 
-`$ docker run -p 4984:4984 -d couchbase/sync-gateway https://raw.githubusercontent.com/couchbase/sync_gateway/master/examples/basic-walrus-bucket.json`
+For versions 3.0.0 and newer:
+
+`$ docker run -p 4984:4984 -d couchbase/sync-gateway https://raw.githubusercontent.com/couchbase/sync_gateway/master/examples/startup_config/basic.json`
+
+For older versions:
+
+`$ docker run -p 4984:4984 -d couchbase/sync-gateway https://raw.githubusercontent.com/couchbase/sync_gateway/release/2.8.3/examples/serviceconfig.json`
 
 # Running with a Couchbase Server container
 

--- a/enterprise/sync-gateway/2.8.3/README.md
+++ b/enterprise/sync-gateway/2.8.3/README.md
@@ -80,10 +80,19 @@ $ curl http://localhost:4985
 
 **Step - 1 :** Prepare the Sync Gateway configuration file on your local machine:
 
+For versions 3.0.0 and newer:
 ```
 $ cd /tmp
-$ wget https://raw.githubusercontent.com/couchbase/sync_gateway/master/examples/basic-walrus-bucket.json
-$ mv basic-walrus-bucket.json my-sg-config.json
+$ wget https://raw.githubusercontent.com/couchbase/sync_gateway/master/examples/startup_config/basic.json
+$ mv basic.json my-sg-config.json
+$ vi my-sg-config.json  # make edits
+```
+
+For older versions:
+```
+$ cd /tmp
+$ wget https://raw.githubusercontent.com/couchbase/sync_gateway/master/examples/release/2.8.3/examples/serviceconfig.json
+$ mv serviceconfig.json my-sg-config.json
 $ vi my-sg-config.json  # make edits
 ```
 
@@ -99,7 +108,13 @@ Sync Gateway can also load its configuration directly from a public URL.
 
 **Step - 2 :** Then start Sync Gateway and give it the URL to the raw JSON data:
 
-`$ docker run -p 4984:4984 -d couchbase/sync-gateway https://raw.githubusercontent.com/couchbase/sync_gateway/master/examples/basic-walrus-bucket.json`
+For versions 3.0.0 and newer:
+
+`$ docker run -p 4984:4984 -d couchbase/sync-gateway https://raw.githubusercontent.com/couchbase/sync_gateway/master/examples/startup_config/basic.json`
+
+For older versions:
+
+`$ docker run -p 4984:4984 -d couchbase/sync-gateway https://raw.githubusercontent.com/couchbase/sync_gateway/release/2.8.3/examples/serviceconfig.json`
 
 # Running with a Couchbase Server container
 

--- a/enterprise/sync-gateway/3.0.0-beta01/README.md
+++ b/enterprise/sync-gateway/3.0.0-beta01/README.md
@@ -80,10 +80,19 @@ $ curl http://localhost:4985
 
 **Step - 1 :** Prepare the Sync Gateway configuration file on your local machine:
 
+For versions 3.0.0 and newer:
 ```
 $ cd /tmp
-$ wget https://raw.githubusercontent.com/couchbase/sync_gateway/master/examples/basic-walrus-bucket.json
-$ mv basic-walrus-bucket.json my-sg-config.json
+$ wget https://raw.githubusercontent.com/couchbase/sync_gateway/master/examples/startup_config/basic.json
+$ mv basic.json my-sg-config.json
+$ vi my-sg-config.json  # make edits
+```
+
+For older versions:
+```
+$ cd /tmp
+$ wget https://raw.githubusercontent.com/couchbase/sync_gateway/master/examples/release/2.8.3/examples/serviceconfig.json
+$ mv serviceconfig.json my-sg-config.json
 $ vi my-sg-config.json  # make edits
 ```
 
@@ -99,7 +108,13 @@ Sync Gateway can also load its configuration directly from a public URL.
 
 **Step - 2 :** Then start Sync Gateway and give it the URL to the raw JSON data:
 
-`$ docker run -p 4984:4984 -d couchbase/sync-gateway https://raw.githubusercontent.com/couchbase/sync_gateway/master/examples/basic-walrus-bucket.json`
+For versions 3.0.0 and newer:
+
+`$ docker run -p 4984:4984 -d couchbase/sync-gateway https://raw.githubusercontent.com/couchbase/sync_gateway/master/examples/startup_config/basic.json`
+
+For older versions:
+
+`$ docker run -p 4984:4984 -d couchbase/sync-gateway https://raw.githubusercontent.com/couchbase/sync_gateway/release/2.8.3/examples/serviceconfig.json`
 
 # Running with a Couchbase Server container
 

--- a/enterprise/sync-gateway/3.0.0-beta02/README.md
+++ b/enterprise/sync-gateway/3.0.0-beta02/README.md
@@ -80,10 +80,19 @@ $ curl http://localhost:4985
 
 **Step - 1 :** Prepare the Sync Gateway configuration file on your local machine:
 
+For versions 3.0.0 and newer:
 ```
 $ cd /tmp
-$ wget https://raw.githubusercontent.com/couchbase/sync_gateway/master/examples/basic-walrus-bucket.json
-$ mv basic-walrus-bucket.json my-sg-config.json
+$ wget https://raw.githubusercontent.com/couchbase/sync_gateway/master/examples/startup_config/basic.json
+$ mv basic.json my-sg-config.json
+$ vi my-sg-config.json  # make edits
+```
+
+For older versions:
+```
+$ cd /tmp
+$ wget https://raw.githubusercontent.com/couchbase/sync_gateway/master/examples/release/2.8.3/examples/serviceconfig.json
+$ mv serviceconfig.json my-sg-config.json
 $ vi my-sg-config.json  # make edits
 ```
 
@@ -99,7 +108,13 @@ Sync Gateway can also load its configuration directly from a public URL.
 
 **Step - 2 :** Then start Sync Gateway and give it the URL to the raw JSON data:
 
-`$ docker run -p 4984:4984 -d couchbase/sync-gateway https://raw.githubusercontent.com/couchbase/sync_gateway/master/examples/basic-walrus-bucket.json`
+For versions 3.0.0 and newer:
+
+`$ docker run -p 4984:4984 -d couchbase/sync-gateway https://raw.githubusercontent.com/couchbase/sync_gateway/master/examples/startup_config/basic.json`
+
+For older versions:
+
+`$ docker run -p 4984:4984 -d couchbase/sync-gateway https://raw.githubusercontent.com/couchbase/sync_gateway/release/2.8.3/examples/serviceconfig.json`
 
 # Running with a Couchbase Server container
 

--- a/enterprise/sync-gateway/3.0.0/README.md
+++ b/enterprise/sync-gateway/3.0.0/README.md
@@ -80,10 +80,19 @@ $ curl http://localhost:4985
 
 **Step - 1 :** Prepare the Sync Gateway configuration file on your local machine:
 
+For versions 3.0.0 and newer:
 ```
 $ cd /tmp
-$ wget https://raw.githubusercontent.com/couchbase/sync_gateway/master/examples/basic-walrus-bucket.json
-$ mv basic-walrus-bucket.json my-sg-config.json
+$ wget https://raw.githubusercontent.com/couchbase/sync_gateway/master/examples/startup_config/basic.json
+$ mv basic.json my-sg-config.json
+$ vi my-sg-config.json  # make edits
+```
+
+For older versions:
+```
+$ cd /tmp
+$ wget https://raw.githubusercontent.com/couchbase/sync_gateway/master/examples/release/2.8.3/examples/serviceconfig.json
+$ mv serviceconfig.json my-sg-config.json
 $ vi my-sg-config.json  # make edits
 ```
 
@@ -99,7 +108,13 @@ Sync Gateway can also load its configuration directly from a public URL.
 
 **Step - 2 :** Then start Sync Gateway and give it the URL to the raw JSON data:
 
-`$ docker run -p 4984:4984 -d couchbase/sync-gateway https://raw.githubusercontent.com/couchbase/sync_gateway/master/examples/basic-walrus-bucket.json`
+For versions 3.0.0 and newer:
+
+`$ docker run -p 4984:4984 -d couchbase/sync-gateway https://raw.githubusercontent.com/couchbase/sync_gateway/master/examples/startup_config/basic.json`
+
+For older versions:
+
+`$ docker run -p 4984:4984 -d couchbase/sync-gateway https://raw.githubusercontent.com/couchbase/sync_gateway/release/2.8.3/examples/serviceconfig.json`
 
 # Running with a Couchbase Server container
 

--- a/generate/resources/couchbase-server/README.md
+++ b/generate/resources/couchbase-server/README.md
@@ -26,20 +26,20 @@ Here is how to get a single node Couchbase Server cluster running on Docker cont
 
 **Step - 2 :** Next, visit `http://localhost:8091` on the host machine to see the Web Console to start Couchbase Server setup.
 
-![Setup splash screen](https://d774lla4im6mk.cloudfront.net/6.6.2/setup-initial.jpg)
+![Setup splash screen](https://d774lla4im6mk.cloudfront.net/setup-initial.jpg)
 
 Walk through the Setup wizard and accept the default values.
 
 -	Note: You may need to lower the RAM allocated to various services to fit within the bounds of the resource of the containers.
 -	Enable the beer-sample bucket to load some sample data.
 
-![Creating a cluster](https://d774lla4im6mk.cloudfront.net/6.6.2/cluster-creation.jpg)
+![Creating a cluster](https://d774lla4im6mk.cloudfront.net/cluster-creation.jpg)
 
-![Completing the wizard](https://d774lla4im6mk.cloudfront.net/6.6.2/finish-wizard.jpg)
+![Completing the wizard](https://d774lla4im6mk.cloudfront.net/finish-wizard.jpg)
 
-![UI home](https://d774lla4im6mk.cloudfront.net/6.6.2/ui-home.jpg)
+![UI home](https://d774lla4im6mk.cloudfront.net/ui-home.jpg)
 
-![Loading sample data](https://d774lla4im6mk.cloudfront.net/6.6.2/load-sample-data.jpg)
+![Loading sample data](https://d774lla4im6mk.cloudfront.net/load-sample-data.jpg)
 
 **Note :** For detailed information on configuring the Server, see [Deployment Guidelines](https://docs.couchbase.com/server/current/install/install-production-deployment.html).
 

--- a/generate/screenshots/docker-compose.yml
+++ b/generate/screenshots/docker-compose.yml
@@ -8,6 +8,6 @@ services:
     environment:
       - TAG=\${TAG}
     volumes:
-      - ./output/${TAG}:/output
+      - ./output:/output
     depends_on:
       - couchbase

--- a/generate/screenshots/robot/src/app.js
+++ b/generate/screenshots/robot/src/app.js
@@ -78,7 +78,7 @@ const playwright = require('playwright');
         height: 400,
     });
     await page.waitForNavigation()
-    await page.click('css=[for="setup-sample-beer-sample"]')
+    await page.click('css=[for="bucketbeer-sample"]')
     await page.screenshot({
         path: `/output/load-sample-data.jpg`,
         quality: 85,


### PR DESCRIPTION
This change is quite noisy because I've re-run the generator. The important part is what's happening in the generate directory:

- Updated the readme template to reference images as url/foo.jpg, rather than url/version/foo.jpg - so we can update the images in place without a pull request to docker-library/docs going forward
- Changed the css text being targeted from `setup-sample-beer-sample` to `bucketbeer-sample` so that the field can be selected correctly - the name has changed since 6.6.2 when the screenshot generator was last run
- Updated the compose file to drop the version number from the output folder - the idea being we'll just overwrite images in the root of the target bucket to update them in future