### PR TITLE
updating exec command

### DIFF
--- a/enterprise/couchbase-server/6.6.3/scripts/entrypoint.sh
+++ b/enterprise/couchbase-server/6.6.3/scripts/entrypoint.sh
@@ -53,7 +53,7 @@ overridePort "ssl_proxy_upstream_port"
     fi
     echo "Starting Couchbase Server -- Web UI available at http://<ip>:$restPortValue"
     echo "and logs available in /opt/couchbase/var/lib/couchbase/logs"
-    exec /usr/sbin/runsvdir-start
+    exec runsvdir -P /etc/service 'log: ...........................................................................................................................................................................................................................................................................................................................................................................................................'
 }
 
 exec "$@"


### PR DESCRIPTION
After updating to ubuntu:20.04 this was throwing error "/entrypoint.sh: line 56: /usr/sbin/runsvdir-start: No such file or directory" so correcting it.
It is still working on ubuntu:16.04 but after using 20.04 as a base image this entrypoint command needs to be updated