### PR TITLE
CBD-5188: Update EXPOSE ports and descriptions

### DIFF
--- a/generate/templates/couchbase-server/Dockerfile.template
+++ b/generate/templates/couchbase-server/Dockerfile.template
@@ -115,20 +115,41 @@ COPY scripts/entrypoint.sh /
 ENTRYPOINT ["/entrypoint.sh"]
 CMD ["couchbase-server"]
 
-# 8091: Couchbase Web console, REST/HTTP interface
-# 8092: Views, queries, XDCR
-# 8093: Query services (4.0+)
-# 8094: Full-text Search (4.5+)
-# 8095: Analytics (5.5+)
-# 8096: Eventing (5.5+)
-# 11207: Smart client library data node access (SSL)
-# 11210: Smart client library/moxi data node access
-# 11211: Legacy non-smart client library data node access
-# 18091: Couchbase Web console, REST/HTTP interface (SSL)
-# 18092: Views, query, XDCR (SSL)
-# 18093: Query services (SSL) (4.0+)
-# 18094: Full-text Search (SSL) (4.5+)
-# 18095: Analytics (SSL) (5.5+)
-# 18096: Eventing (SSL) (5.5+)
-EXPOSE 8091 8092 8093 8094 8095 8096 11207 11210 11211 18091 18092 18093 18094 18095 18096
+# 8091: Cluster administration REST/HTTP traffic, including Couchbase Web Console
+# 8092: Views and XDCR access
+# 8093: Query service REST/HTTP traffic
+# 8094: Search Service REST/HTTP traffic
+# 8095: Analytics service REST/HTTP traffic
+# 8096: Eventing service REST/HTTP traffic
+# 8097: Backup service REST/HTTP traffic
+# 9123: Analytics prometheus
+# 11207: Data Service (SSL)
+# 11210: Data Service
+# 11280: Data Service prometheus
+# 18091: Cluster administration REST/HTTP traffic, including Couchbase Web Console (SSL)
+# 18092: Views and XDCR access (SSL)
+# 18093: Query service REST/HTTP traffic (SSL)
+# 18094: Search Service REST/HTTP traffic (SSL)
+# 18095: Analytics service REST/HTTP traffic (SSL)
+# 18096: Eventing service REST/HTTP traffic (SSL)
+# 18097: Backup service REST/HTTP traffic (SSL)
+EXPOSE 8091 \
+       8092 \
+       8093 \
+       8094 \
+       8095 \
+       8096 \
+       8097 \
+       9123 \
+       11207 \
+       11210 \
+       11280 \
+       18091 \
+       18092 \
+       18093 \
+       18094 \
+       18095 \
+       18096 \
+       18097
+
 VOLUME /opt/couchbase/var


### PR DESCRIPTION
This change:
- Adds some missing ports to our EXPOSE list
- Updates port descriptions to match [the current docs](https://docs.couchbase.com/server/current/install/install-ports.html) 
- Removes version info (which was all related to versions which are now EOL)
