### PR TITLE
CBD-5330, update README for SGW, change config for 3.x.

### DIFF
--- a/generate/templates/sync-gateway/Dockerfile.ubuntu.template
+++ b/generate/templates/sync-gateway/Dockerfile.ubuntu.template
@@ -9,6 +9,7 @@ ENV PATH $PATH:/opt/couchbase-sync-gateway/bin
 RUN set -x \
     && apt update \
     && apt install -y \
+           curl \
            lsb-release \
            systemctl \
            wget \
@@ -30,7 +31,7 @@ RUN mkdir /opt/couchbase-sync-gateway/data
 
 # Copy sample service config as the initial config
 RUN mkdir /etc/sync_gateway \
-    && cp /opt/couchbase-sync-gateway/examples/serviceconfig.json /etc/sync_gateway/config.json \
+    && cp /opt/couchbase-sync-gateway/examples/startup_config/basic.json /etc/sync_gateway/config.json \
     && chown -R sync_gateway:sync_gateway /etc/sync_gateway
 
 # Create log dir


### PR DESCRIPTION
Update README to reflect the latest SGW.  I moved "Admin Port" below "Running with a Couchbase Server container" since SGW needs to be bootstrapped with couchbase server first starting from 3.0.
Switch to use startup_config/basic.json for 3.x docker images.

-Ming