### PR TITLE
Chore: reduce attack surface and size for Docker image

### DIFF
--- a/generate/templates/couchbase-server/Dockerfile.template
+++ b/generate/templates/couchbase-server/Dockerfile.template
@@ -22,7 +22,7 @@ ARG CLEANUP_COMMAND="rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*"
 #  numactl: numactl
 RUN set -x \
     && ${UPDATE_COMMAND} \
-    && {{ .PKG_COMMAND }} install -y -q wget tzdata \
+    && {{ .PKG_COMMAND }} install -y -q --no-install-recommends wget tzdata \
       lsof lshw sysstat net-tools numactl {{ .CB_EXTRA_DEPS }} \
     && ${CLEANUP_COMMAND}
 


### PR DESCRIPTION
Hi,

This pull request includes a small improvement for the Dockerfile, which should help improve the security of container and reduce the risk of potential attacks.

In detail:
- I added `--no-install-recommends` to remove unnecessary `apt` packages, that were not needed for the container's functionality. Not only can this change trim your image size but it also can also reduce the attack surface.

As quoted from [CIS Docker Benchmark v1.5.0](https://www.cisecurity.org/benchmark/docker):
>**4.3 Ensure that unnecessary packages are not installed in the container**
>**Description:**
>Containers should have as small a footprint as possible, and should not contain unnecessary software packages which could increase their attack surface.
>**Rationale:**
>Unnecessary software should not be installed into containers, as doing so increases their attack surface. Only packages strictly necessary for the correct operation of the application being deployed should be installed.

I generated Dockerfiles from the new template file, and I selected one of them (`enterprise/couchbase-server/6.0.5/Dockerfile`) for testing the improvement impact on process.
The differences between two builds are summarized in the below table:

||Before improvement|After improvement|
|-----------------------|-------|-------|
|Newly intalled packages| 48   |  38  |
|Image size             | 921MB | 913MB |
|Build time             | 110s  | 97s  |

- Removed unnecessary packages after the improvement:
```
libkmod2 pciutils usbutils libmagic-mgc publicsuffix libusb-1.0-0 file libpci3 cron libmagic1
```

I hope that you find them useful. Please let me know if you have any concerns.

Thank you.