### PR TITLE
CBG-3613 run sync gateway in writeable directory

### DIFF
--- a/generate/templates/sync-gateway/Dockerfile.ubuntu.template
+++ b/generate/templates/sync-gateway/Dockerfile.ubuntu.template
@@ -47,6 +47,7 @@ ENTRYPOINT ["/entrypoint.sh"]
 CMD ["/etc/sync_gateway/config.json"]
 
 USER sync_gateway
+WORKDIR /home/sync_gateway
 
 # Expose ports
 #  port 4984: public port


### PR DESCRIPTION
Ideally, sync gateway won't write any files here, but sometimes this happens. This behavior matches that of the systemd setup.