### PR TITLE
CBD-5850: Improve warnings when failing to chown files/dirs at startup

### DIFF
--- a/generate/resources/couchbase-server/scripts/run
+++ b/generate/resources/couchbase-server/scripts/run
@@ -20,7 +20,8 @@ mkdir -p var/lib/couchbase \
 # Ensure everything in var is owned and writable to Server.
 # Skip "inbox" as it may contain readonly-mounted things like k8s certs.
 find var -path var/lib/couchbase/inbox -prune -o -print0 | \
-  xargs -0 chown --no-dereference couchbase:couchbase
+  xargs -0 -I {} sh -c 'chown --no-dereference couchbase:couchbase {} >/dev/null 2>&1 ||
+    echo "Warning: could not ensure '\''couchbase'\'' user owns $(pwd)/{}; this may cause issues" >&2;'
 
 if [ "$(whoami)" = "couchbase" ]; then
   exec /opt/couchbase/bin/couchbase-server -- -kernel global_enable_tracing false -noinput

--- a/generate/resources/couchbase-server/scripts/run
+++ b/generate/resources/couchbase-server/scripts/run
@@ -20,8 +20,8 @@ mkdir -p var/lib/couchbase \
 # Ensure everything in var is owned and writable to Server.
 # Skip "inbox" as it may contain readonly-mounted things like k8s certs.
 find var -path var/lib/couchbase/inbox -prune -o -print0 | \
-  xargs -0 -I {} sh -c 'chown --no-dereference couchbase:couchbase {} >/dev/null 2>&1 ||
-    echo "Warning: could not ensure '\''couchbase'\'' user owns $(pwd)/{}; this may cause issues" >&2;'
+  xargs -0 -I {} sh -c 'chown --no-dereference couchbase:couchbase "{}" >/dev/null 2>&1 ||
+    echo "Warning: could not ensure '\''couchbase'\'' user owns '\''$(pwd)/{}'\''; this may cause issues" >&2;'
 
 if [ "$(whoami)" = "couchbase" ]; then
   exec /opt/couchbase/bin/couchbase-server -- -kernel global_enable_tracing false -noinput

--- a/generate/screenshots/robot/Dockerfile
+++ b/generate/screenshots/robot/Dockerfile
@@ -1,9 +1,9 @@
-FROM mcr.microsoft.com/playwright:bionic
+FROM playwright/chrome:playwright-1.42.1
 
 # Uncomment this to show playwright debug output
 # ENV DEBUG=pw:api
 
-COPY src /src
+COPY --chown=pwuser:pwuser src /src
 COPY entrypoint.sh /
 
 WORKDIR /src


### PR DESCRIPTION
Currently we attempt to chown the contents of /opt/couchbase/var without intercepting issues, which can result in chown failure messages appearing as-is on mounted volumes where ownership is not directly modifiable:

> Starting Couchbase Server -- Web UI available at http://<ip>:8091
> and logs available in /opt/couchbase/var/lib/couchbase/logs
> chown: changing ownership of 'var/lib/couchbase': Operation not permitted

This change aims to intercept such failures and provide a more informative warning, and also fixes some issues with the dockerhub screenshot generator.