### PR TITLE
CBD-5850: Test contents of var are writable when running as non-root

### DIFF
--- a/generate/resources/couchbase-server/scripts/run
+++ b/generate/resources/couchbase-server/scripts/run
@@ -21,13 +21,15 @@ mkdir -p var/lib/couchbase \
 # owned by the 'couchbase' user. If running as 'couchbase', don't attempt to
 # claim ownership, but instead warn when encountering unwritable paths.
 # Skip "inbox" as it may contain readonly-mounted things like k8s certs.
-find var -path var/lib/couchbase/inbox -prune -o -print0 | \
-  xargs -0 -I {} sh -c '
-    if [ "$(whoami)" = "root" ]; then
-      chown --no-dereference couchbase:couchbase "{}"
-    elif ! test -w "{}"; then
-      echo "Warning: '\''$(pwd)/{}'\'' is not writable by user '\''$(whoami)'\''" >&2;
-    fi'
+container_user=$(whoami)
+if [ "${container_user}" = "root" ]; then
+    find var -path var/lib/couchbase/inbox -prune -o -print0 | \
+      xargs -0 chown --no-dereference couchbase:couchbase
+else
+    find var -path var/lib/couchbase/inbox -prune -o \! -writable -print0 | \
+      xargs -0 -I {} echo "Warning: '/opt/couchbase/{}' is not writable by user '${container_user}'"
+fi
+unset container_user
 
 if [ "$(whoami)" = "couchbase" ]; then
   exec /opt/couchbase/bin/couchbase-server -- -kernel global_enable_tracing false -noinput

--- a/generate/resources/couchbase-server/scripts/run
+++ b/generate/resources/couchbase-server/scripts/run
@@ -17,11 +17,14 @@ mkdir -p var/lib/couchbase \
          var/lib/couchbase/logs \
          var/lib/moxi
 
-# Ensure everything in var is owned and writable to Server.
+# Ensure everything in var is writable by the 'couchbase' user, and warn when
+# encountering files or directories which aren't.
 # Skip "inbox" as it may contain readonly-mounted things like k8s certs.
 find var -path var/lib/couchbase/inbox -prune -o -print0 | \
-  xargs -0 -I {} sh -c 'chown --no-dereference couchbase:couchbase "{}" >/dev/null 2>&1 ||
-    echo "Warning: could not ensure '\''couchbase'\'' user owns '\''$(pwd)/{}'\''; this may cause issues" >&2;'
+  xargs -0 -I {} sh -c '
+    if ! test -w "{}"; then
+      echo "Warning: '\''$(pwd)/{}'\'' is not writable by user '\''couchbase'\''; this may result in issues" >&2;
+    fi'
 
 if [ "$(whoami)" = "couchbase" ]; then
   exec /opt/couchbase/bin/couchbase-server -- -kernel global_enable_tracing false -noinput

--- a/generate/resources/couchbase-server/scripts/run
+++ b/generate/resources/couchbase-server/scripts/run
@@ -17,13 +17,16 @@ mkdir -p var/lib/couchbase \
          var/lib/couchbase/logs \
          var/lib/moxi
 
-# Ensure everything in var is writable by the 'couchbase' user, and warn when
-# encountering files or directories which aren't.
+# If container is running as root, ensure contents of /opt/couchbase/var are
+# owned by the 'couchbase' user. If running as 'couchbase', don't attempt to
+# claim ownership, but instead warn when encountering unwritable paths.
 # Skip "inbox" as it may contain readonly-mounted things like k8s certs.
 find var -path var/lib/couchbase/inbox -prune -o -print0 | \
   xargs -0 -I {} sh -c '
-    if ! test -w "{}"; then
-      echo "Warning: '\''$(pwd)/{}'\'' is not writable by user '\''couchbase'\''; this may result in issues" >&2;
+    if [ "$(whoami)" = "root" ]; then
+      chown --no-dereference couchbase:couchbase "{}"
+    elif ! test -w "{}"; then
+      echo "Warning: '\''$(pwd)/{}'\'' is not writable by user '\''$(whoami)'\''" >&2;
     fi'
 
 if [ "$(whoami)" = "couchbase" ]; then


### PR DESCRIPTION
To avoid confusion on e.g. mounted volumes where the ownership of the volume cannot be modified (but the directory is writable) this change aims to replace the blanket chown approach with a test for writability when running as 'couchbase' user.