### PR TITLE
CBG-3819 declare log file directory to be a volume

### DIFF
--- a/generate/templates/sync-gateway/Dockerfile.ubuntu.template
+++ b/generate/templates/sync-gateway/Dockerfile.ubuntu.template
@@ -49,6 +49,7 @@ CMD ["/etc/sync_gateway/config.json"]
 USER sync_gateway
 WORKDIR /home/sync_gateway
 
+VOLUME /var/log/sync_gateway
 # Expose ports
 #  port 4984: public port
 EXPOSE 4984


### PR DESCRIPTION
Sync gateway writes files to this location, so this should be a volume instead of writing into the container.