### PR TITLE
reconfigure default ubuntu version to 22.0.4 for couchbase-server and couchbase-columnar

### DIFF
--- a/generate/generator/generate.go
+++ b/generate/generator/generate.go
@@ -622,7 +622,7 @@ func (variant DockerfileVariant) ubuntuVersion() string {
 	case ProductSyncGw:
 		return "22.04"
         case ProductColumnar:
-                return "20.04"
+                return "22.04"
         case ProductServer:
 		version4, err := version.NewConstraint(">= 4.0, < 5.0")
 		if err != nil {
@@ -649,7 +649,7 @@ func (variant DockerfileVariant) ubuntuVersion() string {
                 } else if version6Dot6Dot2To7Dot6Dot2.Check(v1) {
                         return "20.04"
 		}
-		return "20.04"
+		return "22.04"
 	}
 	return ""
 }


### PR DESCRIPTION
Failure of python-httplib2 mentioned in https://github.com/couchbase/docker/pull/216 was due to cb-docker-tool landing on an inaccurate couchbase-server version.  This was a special use case for creating toy columnar container.  I have modified the jenkins job to use couchbase-columnar template.  It is safe to use 22.0.4 as default now.

-Ming