### PR TITLE
MB-65496: Fix PROFILE handling for couchbase-columnar

### DIFF
--- a/generate/resources/couchbase-server/scripts/entrypoint.sh
+++ b/generate/resources/couchbase-server/scripts/entrypoint.sh
@@ -51,6 +51,13 @@ overridePort "ssl_proxy_upstream_port"
             exit 1
         fi
     fi
+
+    # Ensure running on sufficient hardware
+    if [ -e /opt/couchbase/bin/validate-cpu-microarchitecture.sh ]; then
+        source /opt/couchbase/bin/validate-cpu-microarchitecture.sh
+        validate_cpu_microarchitecture
+    fi
+
     echo "Starting Couchbase Server -- Web UI available at http://<ip>:$restPortValue"
     echo "and logs available in /opt/couchbase/var/lib/couchbase/logs"
     exec runsvdir -P /etc/service

--- a/generate/resources/enterprise-analytics/scripts/entrypoint.sh
+++ b/generate/resources/enterprise-analytics/scripts/entrypoint.sh
@@ -51,6 +51,13 @@ overridePort "ssl_proxy_upstream_port"
             exit 1
         fi
     fi
+
+    # Ensure running on sufficient hardware
+    if [ -e /opt/couchbase/bin/validate-cpu-microarchitecture.sh ]; then
+        source /opt/couchbase/bin/validate-cpu-microarchitecture.sh
+        validate_cpu_microarchitecture
+    fi
+
     echo "Starting Couchbase Server -- Web UI available at http://<ip>:$restPortValue"
     echo "and logs available in /opt/enterprise-analytics/var/lib/couchbase/logs"
     exec runsvdir -P /etc/service


### PR DESCRIPTION
Columnar builds >= 1.2.0 do not want `/etc/couchbase.d/config_profile` in the image, but < 1.2.0 still requires that file to exist with the contents `columnar`.

Switch the Dockerfile.template handling to match couchbase-server, where PROFILE is a template argument that creates the block to create that file only when the argument is set. Modify the generator to set PROFILE=columnar for couchbase-columnar builds when the version is < 1.2.0.