### PR TITLE
CBD-6354: Upgrade ubuntu:20.04 base images to most current supported LTS

### DIFF
--- a/generate/generator/generate.go
+++ b/generate/generator/generate.go
@@ -342,19 +342,19 @@ func generateDockerfile(variant DockerfileVariant) error {
 		// template parameters
 		params = map[string]any{
 			"CB_VERSION":        variant.VersionWithSubstitutions(),
-			"CB_PACKAGE":         variant.columnarPackageFile(Archgeneric),
-			"CB_RELEASE_URL":     variant.releaseURL(),
+			"CB_PACKAGE":        variant.columnarPackageFile(Archgeneric),
+			"CB_RELEASE_URL":    variant.releaseURL(),
 			"DOCKER_BASE_IMAGE": variant.dockerBaseImage(),
 			"CB_MULTIARCH":      len(variant.Arches) > 1,
 		}
-        } else if variant.Product == ProductEdgeServer {
-                // template parameters
-                params = map[string]any{
-			"CB_RELEASE_URL":      variant.releaseURL(),
-			"CB_PACKAGE_NAME":     variant.edgeServerPackageFile(Archgeneric),
-			"DOCKER_BASE_IMAGE":   variant.dockerBaseImage(),
-                }
-        }
+	} else if variant.Product == ProductEdgeServer {
+		// template parameters
+		params = map[string]any{
+			"CB_RELEASE_URL":    variant.releaseURL(),
+			"CB_PACKAGE_NAME":   variant.edgeServerPackageFile(Archgeneric),
+			"DOCKER_BASE_IMAGE": variant.dockerBaseImage(),
+		}
+	}
 
 	// Apply any user-requested template overrides
 	for key, value := range variant.TemplateOverrides {
@@ -576,8 +576,8 @@ func (variant DockerfileVariant) dockerBaseImage() string {
 		} else {
 			return fmt.Sprintf("ubuntu:%s", variant.ubuntuVersion())
 		}
-        case ProductEdgeServer:
-                return fmt.Sprintf("ubuntu:%s", variant.ubuntuVersion())
+	case ProductEdgeServer:
+		return fmt.Sprintf("ubuntu:%s", variant.ubuntuVersion())
 	case ProductServer:
 		return fmt.Sprintf("ubuntu:%s", variant.ubuntuVersion())
 	case ProductSandbox:
@@ -634,11 +634,11 @@ func (variant DockerfileVariant) ubuntuVersion() string {
 	switch variant.Product {
 	case ProductSyncGw:
 		return "22.04"
-        case ProductEdgeServer:
-                return "22.04"
-        case ProductColumnar:
-                return "22.04"
-        case ProductServer:
+	case ProductEdgeServer:
+		return "22.04"
+	case ProductColumnar:
+		return "22.04"
+	case ProductServer:
 		version4, err := version.NewConstraint(">= 4.0, < 5.0")
 		if err != nil {
 			log.Fatalf("Error creating version constraint 4.x: %v", err)
@@ -651,9 +651,13 @@ func (variant DockerfileVariant) ubuntuVersion() string {
 		if err != nil {
 			log.Fatalf("Error creating version constraint 6.0.1--6.6.1: %v", err)
 		}
-		version6Dot6Dot2To7Dot6Dot2, err := version.NewConstraint(">= 6.6.2, <= 7.6.2")
+		version6Dot6Dot2To7Dot1Dot6, err := version.NewConstraint(">= 6.6.2, <= 7.1.6")
 		if err != nil {
-			log.Fatalf("Error creating version constraint 6.6.2--7.6.2: %v", err)
+			log.Fatalf("Error creating version constraint 6.6.2--7.1.6: %v", err)
+		}
+		version7Dot2Dot0To7Dot2Dot5, err := version.NewConstraint(">= 7.2.0, <= 7.2.5")
+		if err != nil {
+			log.Fatalf("Error creating version constraint 7.2.0--7.2.5: %v", err)
 		}
 		if version4.Check(v1) {
 			return "14.04"
@@ -661,10 +665,12 @@ func (variant DockerfileVariant) ubuntuVersion() string {
 			return "16.04"
 		} else if version6Dot0Dot1To6Dot6Dot1.Check(v1) {
 			return "18.04"
-                } else if version6Dot6Dot2To7Dot6Dot2.Check(v1) {
-                        return "20.04"
+		} else if version6Dot6Dot2To7Dot1Dot6.Check(v1) {
+			return "20.04"
+		} else if version7Dot2Dot0To7Dot2Dot5.Check(v1) {
+			return "22.04"
 		}
-		return "22.04"
+		return "24.04"
 	}
 	return ""
 }

--- a/generate/templates/couchbase-server/Dockerfile.template
+++ b/generate/templates/couchbase-server/Dockerfile.template
@@ -51,8 +51,8 @@ ARG CB_PACKAGE_NAME={{ .CB_PACKAGE_NAME }}
 {{- end }}
 ENV PATH=$PATH:/opt/couchbase/bin:/opt/couchbase/bin/tools:/opt/couchbase/bin/install
 
-# Create Couchbase user with UID 1000 (necessary to match default
-# boot2docker UID)
+# Create couchbase user/group with fixed UID/GID 1000 for consistency across environments
+# (modifies existing user/group in images which already have UID/GID 1000 - e.g. ubuntu:24.04)
 RUN set -x \
     && if getent group 1000 >/dev/null; then \
           existing_group=$(getent group 1000 | cut -d: -f1); \

--- a/generate/templates/couchbase-server/Dockerfile.template
+++ b/generate/templates/couchbase-server/Dockerfile.template
@@ -53,7 +53,19 @@ ENV PATH=$PATH:/opt/couchbase/bin:/opt/couchbase/bin/tools:/opt/couchbase/bin/in
 
 # Create Couchbase user with UID 1000 (necessary to match default
 # boot2docker UID)
-RUN groupadd -g 1000 couchbase && useradd couchbase -u 1000 -g couchbase -M
+RUN set -x \
+    && if getent group 1000 >/dev/null; then \
+          existing_group=$(getent group 1000 | cut -d: -f1); \
+          groupmod --new-name couchbase "${existing_group}"; \
+       else \
+          groupadd -g 1000 couchbase; \
+       fi \
+    && if getent passwd 1000 >/dev/null; then \
+          existing_user=$(getent passwd 1000 | cut -d: -f1); \
+          usermod --login couchbase -d /home/couchbase -m -g couchbase -s /bin/sh "${existing_user}"; \
+       else \
+          useradd couchbase -u 1000 -g couchbase -M -s /bin/sh; \
+       fi
 
 # Install couchbase
 {{- if .SYSTEMD_WORKAROUND }}
@@ -166,7 +178,7 @@ RUN set -x \
 # 18094: Search Service REST/HTTP traffic (SSL)
 # 18095: Analytics service REST/HTTP traffic (SSL)
 # 18096: Eventing service REST/HTTP traffic (SSL)
-# 18097: Backup service REST/HTTP traffic (SSL)
+# 18097: Backup service REST/HTTP traffic (SSL)
 EXPOSE 8091 \
        8092 \
        8093 \


### PR DESCRIPTION
This change updates the generator to upgrade 7.2.x+7.6.x versions currently on ubuntu20 to highest supported LTS version (ubuntu22/24)

The dockerfile is also adapted to modify uid/gid 1000 should it already exist (ubuntu 24.04 introduced an "ubuntu" user and group with those IDs)