### PR TITLE
CBD-6297: Check for x86_64-v3 at container startup

### DIFF
--- a/generate/resources/couchbase-server/scripts/entrypoint.sh
+++ b/generate/resources/couchbase-server/scripts/entrypoint.sh
@@ -51,6 +51,13 @@ overridePort "ssl_proxy_upstream_port"
             exit 1
         fi
     fi
+
+    # Ensure running on sufficient hardware
+    if [ -e /opt/couchbase/bin/validate-cpu-microarchitecture.sh ]; then
+        source /opt/couchbase/bin/validate-cpu-microarchitecture.sh
+        validate_cpu_microarchitecture
+    fi
+
     echo "Starting Couchbase Server -- Web UI available at http://<ip>:$restPortValue"
     echo "and logs available in /opt/couchbase/var/lib/couchbase/logs"
     exec runsvdir -P /etc/service

--- a/generate/resources/enterprise-analytics/scripts/entrypoint.sh
+++ b/generate/resources/enterprise-analytics/scripts/entrypoint.sh
@@ -51,6 +51,13 @@ overridePort "ssl_proxy_upstream_port"
             exit 1
         fi
     fi
+
+    # Ensure running on sufficient hardware
+    if [ -e /opt/enterprise-analytics/bin/validate-cpu-microarchitecture.sh ]; then
+        source /opt/enterprise-analytics/bin/validate-cpu-microarchitecture.sh
+        validate_cpu_microarchitecture
+    fi
+
     echo "Starting Couchbase Server -- Web UI available at http://<ip>:$restPortValue"
     echo "and logs available in /opt/enterprise-analytics/var/lib/couchbase/logs"
     exec runsvdir -P /etc/service


### PR DESCRIPTION
This check is only performed when the file `validate-cpu-microarchitecture.sh` exists, which it will in any releases that are compiled with x86_64-v3.