### PR TITLE
MB-67729: Use 'enterprise-analytics' as process name for EA

### DIFF
--- a/generate/resources/enterprise-analytics/scripts/entrypoint.sh
+++ b/generate/resources/enterprise-analytics/scripts/entrypoint.sh
@@ -47,7 +47,7 @@ overridePort "ssl_proxy_upstream_port"
         if [ ! -w /opt/enterprise-analytics/var -o \
             $(find /opt/enterprise-analytics/var -maxdepth 0 -printf '%u') != "couchbase" ]; then
             echo "/opt/enterprise-analytics/var is not owned and writable by UID 1000"
-            echo "Aborting as Couchbase Server will likely not run"
+            echo "Aborting as Enterprise Analytics will likely not run"
             exit 1
         fi
     fi
@@ -58,7 +58,7 @@ overridePort "ssl_proxy_upstream_port"
         validate_cpu_microarchitecture
     fi
 
-    echo "Starting Couchbase Server -- Web UI available at http://<ip>:$restPortValue"
+    echo "Starting Enterprise Analytics -- Web UI available at http://<ip>:$restPortValue"
     echo "and logs available in /opt/enterprise-analytics/var/lib/couchbase/logs"
     exec runsvdir -P /etc/service
 }

--- a/generate/resources/enterprise-analytics/scripts/run
+++ b/generate/resources/enterprise-analytics/scripts/run
@@ -2,7 +2,7 @@
 
 # If HOME is set, Erlang requires that it be a writable directory.
 # We can't guarantee that as it depends on which UID the container
-# is started as. The enterprise-analytics script will handle it being
+# is started as. The couchbase-server script will handle it being
 # unset, though, so do that for safety.
 unset HOME
 
@@ -32,7 +32,7 @@ fi
 unset container_user
 
 if [ "$(whoami)" = "couchbase" ]; then
-  exec /opt/enterprise-analytics/bin/enterprise-analytics -- -kernel global_enable_tracing false -noinput
+  exec /opt/enterprise-analytics/bin/couchbase-server -- -kernel global_enable_tracing false -noinput
 else
-  exec chpst -ucouchbase  /opt/enterprise-analytics/bin/enterprise-analytics -- -kernel global_enable_tracing false -noinput
+  exec chpst -ucouchbase  /opt/enterprise-analytics/bin/couchbase-server -- -kernel global_enable_tracing false -noinput
 fi

--- a/generate/resources/enterprise-analytics/scripts/run
+++ b/generate/resources/enterprise-analytics/scripts/run
@@ -2,7 +2,7 @@
 
 # If HOME is set, Erlang requires that it be a writable directory.
 # We can't guarantee that as it depends on which UID the container
-# is started as. The couchbase-server script will handle it being
+# is started as. The enterprise-analytics script will handle it being
 # unset, though, so do that for safety.
 unset HOME
 
@@ -32,7 +32,7 @@ fi
 unset container_user
 
 if [ "$(whoami)" = "couchbase" ]; then
-  exec /opt/enterprise-analytics/bin/couchbase-server -- -kernel global_enable_tracing false -noinput
+  exec /opt/enterprise-analytics/bin/enterprise-analytics -- -kernel global_enable_tracing false -noinput
 else
-  exec chpst -ucouchbase  /opt/enterprise-analytics/bin/couchbase-server -- -kernel global_enable_tracing false -noinput
+  exec chpst -ucouchbase  /opt/enterprise-analytics/bin/enterprise-analytics -- -kernel global_enable_tracing false -noinput
 fi

--- a/generate/templates/enterprise-analytics/Dockerfile.template
+++ b/generate/templates/enterprise-analytics/Dockerfile.template
@@ -114,7 +114,6 @@ CMD ["enterprise-analytics"]
 # 11210: Data Service
 # 11280: Data Service prometheus
 # 18091: Cluster administration REST/HTTP traffic, including Web Console (SSL)
-# 18092: Views and XDCR access (SSL)
 # 18095: Enterprise Analytics service REST/HTTP traffic (SSL)
 EXPOSE 8091 \
        8095 \

--- a/generate/templates/enterprise-analytics/Dockerfile.template
+++ b/generate/templates/enterprise-analytics/Dockerfile.template
@@ -107,41 +107,22 @@ COPY scripts/entrypoint.sh /
 ENTRYPOINT ["/entrypoint.sh"]
 CMD ["enterprise-analytics"]
 
-# 8091: Cluster administration REST/HTTP traffic, including Couchbase Web Console
-# 8092: Views and XDCR access
-# 8093: Query service REST/HTTP traffic
-# 8094: Search Service REST/HTTP traffic
-# 8095: Analytics service REST/HTTP traffic
-# 8096: Eventing service REST/HTTP traffic
-# 8097: Backup service REST/HTTP traffic
-# 9123: Analytics prometheus
+# 8091: Cluster administration REST/HTTP traffic, including Web Console
+# 8095: Enterprise Analytics service REST/HTTP traffic
+# 9123: Enterprise Analytics prometheus
 # 11207: Data Service (SSL)
 # 11210: Data Service
 # 11280: Data Service prometheus
-# 18091: Cluster administration REST/HTTP traffic, including Couchbase Web Console (SSL)
+# 18091: Cluster administration REST/HTTP traffic, including Web Console (SSL)
 # 18092: Views and XDCR access (SSL)
-# 18093: Query service REST/HTTP traffic (SSL)
-# 18094: Search Service REST/HTTP traffic (SSL)
-# 18095: Analytics service REST/HTTP traffic (SSL)
-# 18096: Eventing service REST/HTTP traffic (SSL)
-# 18097: Backup service REST/HTTP traffic (SSL)
+# 18095: Enterprise Analytics service REST/HTTP traffic (SSL)
 EXPOSE 8091 \
-       8092 \
-       8093 \
-       8094 \
        8095 \
-       8096 \
-       8097 \
        9123 \
        11207 \
        11210 \
        11280 \
        18091 \
-       18092 \
-       18093 \
-       18094 \
-       18095 \
-       18096 \
-       18097
+       18095
 
 VOLUME /opt/enterprise-analytics/var


### PR DESCRIPTION
- also prune unused ports
- update some logging to be EA branded