### PR TITLE
CBD-6467: Add support for read-only root filesystem

### DIFF
--- a/generate/resources/couchbase-server/scripts/entrypoint.sh
+++ b/generate/resources/couchbase-server/scripts/entrypoint.sh
@@ -41,6 +41,10 @@ overridePort "ssl_proxy_upstream_port"
 
 [[ "$1" == "couchbase-server" ]] && {
 
+    # Create the supervise directory in /run for runit
+    mkdir -p /run/couchbase-server/supervise
+    chown -R couchbase:couchbase /run/couchbase-server
+
     if [ "$(whoami)" = "couchbase" ]; then
         # Ensure that /opt/couchbase/var is owned by user 'couchbase' and
         # is writable

--- a/generate/resources/couchbase-server/scripts/run
+++ b/generate/resources/couchbase-server/scripts/run
@@ -9,25 +9,23 @@ unset HOME
 exec 2>&1
 
 # Create directories where couchbase stores its data
-cd /opt/couchbase
-mkdir -p var/lib/couchbase \
-         var/lib/couchbase/config \
-         var/lib/couchbase/data \
-         var/lib/couchbase/stats \
-         var/lib/couchbase/logs \
-         var/lib/moxi
+cd /opt/couchbase/var/lib/couchbase
+mkdir -p config \
+         data \
+         stats \
+         logs
 
-# If container is running as root, ensure contents of /opt/couchbase/var are
+# If container is running as root, ensure contents of the data directory are
 # owned by the 'couchbase' user. If running as 'couchbase', don't attempt to
 # claim ownership, but instead warn when encountering unwritable paths.
 # Skip "inbox" as it may contain readonly-mounted things like k8s certs.
 container_user=$(whoami)
 if [ "${container_user}" = "root" ]; then
-    find var -path var/lib/couchbase/inbox -prune -o -print0 | \
+    find . -path ./inbox -prune -o -print0 | \
       xargs -0 chown --no-dereference couchbase:couchbase
 else
-    find var -path var/lib/couchbase/inbox -prune -o \! -writable -print0 | \
-      xargs -0 -I {} echo "Warning: '/opt/couchbase/{}' is not writable by user '${container_user}'"
+    find . -path ./inbox -prune -o \! -writable -print0 | \
+      xargs -0 -I {} echo "Warning: '/opt/couchbase/var/lib/couchbase/{}' is not writable by user '${container_user}'"
 fi
 unset container_user
 

--- a/generate/resources/enterprise-analytics/scripts/entrypoint.sh
+++ b/generate/resources/enterprise-analytics/scripts/entrypoint.sh
@@ -41,6 +41,10 @@ overridePort "ssl_proxy_upstream_port"
 
 [[ "$1" == "enterprise-analytics" ]] && {
 
+    # Create the supervise directory in /run for runit
+    mkdir -p /run/enterprise-analytics/supervise
+    chown -R couchbase:couchbase /run/enterprise-analytics
+
     if [ "$(whoami)" = "couchbase" ]; then
         # Ensure that /opt/enterprise-analytics/var is owned by user 'couchbase' and
         # is writable

--- a/generate/resources/enterprise-analytics/scripts/run
+++ b/generate/resources/enterprise-analytics/scripts/run
@@ -9,25 +9,23 @@ unset HOME
 exec 2>&1
 
 # Create directories where couchbase stores its data
-cd /opt/enterprise-analytics
-mkdir -p var/lib/couchbase \
-         var/lib/couchbase/config \
-         var/lib/couchbase/data \
-         var/lib/couchbase/stats \
-         var/lib/couchbase/logs \
-         var/lib/moxi
+cd /opt/enterprise-analytics/var/lib/couchbase
+mkdir -p config \
+         data \
+         stats \
+         logs
 
-# If container is running as root, ensure contents of /opt/enterprise-analytics/var are
+# If container is running as root, ensure contents of the data directory are
 # owned by the 'couchbase' user. If running as 'couchbase', don't attempt to
 # claim ownership, but instead warn when encountering unwritable paths.
 # Skip "inbox" as it may contain readonly-mounted things like k8s certs.
 container_user=$(whoami)
 if [ "${container_user}" = "root" ]; then
-    find var -path var/lib/couchbase/inbox -prune -o -print0 | \
+    find . -path ./inbox -prune -o -print0 | \
       xargs -0 chown --no-dereference couchbase:couchbase
 else
-    find var -path var/lib/couchbase/inbox -prune -o \! -writable -print0 | \
-      xargs -0 -I {} echo "Warning: '/opt/enterprise-analytics/{}' is not writable by user '${container_user}'"
+    find . -path ./inbox -prune -o \! -writable -print0 | \
+      xargs -0 -I {} echo "Warning: '/opt/enterprise-analytics/var/lib/couchbase/{}' is not writable by user '${container_user}'"
 fi
 unset container_user
 

--- a/generate/templates/couchbase-server/Dockerfile.template
+++ b/generate/templates/couchbase-server/Dockerfile.template
@@ -119,12 +119,11 @@ RUN \
 RUN sed -i -e '1 s/$/\/docker/' /opt/couchbase/VARIANT.txt
 
 # Add runit service script for couchbase-server
+# Note: the supervise directory is symlinked to /run to support read-only root filesystems
 COPY scripts/run /etc/service/couchbase-server/run
 RUN set -x \
-    && mkdir -p /etc/service/couchbase-server/supervise \
-    && chown -R couchbase:couchbase \
-                /etc/service \
-                /etc/service/couchbase-server/supervise
+    && ln -s /run/couchbase-server/supervise /etc/service/couchbase-server/supervise \
+    && chown -R couchbase:couchbase /etc/service
 
 # Add dummy script for commands invoked by cbcollect_info that
 # make no sense in a Docker container
@@ -198,4 +197,5 @@ EXPOSE 8091 \
        18096 \
        18097
 
-VOLUME /opt/couchbase/var
+# Data directories
+VOLUME /opt/couchbase/etc /opt/couchbase/var/lib/couchbase

--- a/generate/templates/enterprise-analytics/Dockerfile.template
+++ b/generate/templates/enterprise-analytics/Dockerfile.template
@@ -86,12 +86,11 @@ RUN \
 RUN sed -i -e '1 s/$/\/docker/' /opt/enterprise-analytics/VARIANT.txt
 
 # Add runit service script for enterprise-analytics
+# Note: the supervise directory is symlinked to /run to support read-only root filesystems
 COPY scripts/run /etc/service/enterprise-analytics/run
 RUN set -x \
-    && mkdir -p /etc/service/enterprise-analytics/supervise \
-    && chown -R couchbase:couchbase \
-                /etc/service \
-                /etc/service/enterprise-analytics/supervise
+    && ln -s /run/enterprise-analytics/supervise /etc/service/enterprise-analytics/supervise \
+    && chown -R couchbase:couchbase /etc/service
 
 # Add dummy script for commands invoked by cbcollect_info that
 # make no sense in a Docker container
@@ -124,4 +123,5 @@ EXPOSE 8091 \
        18091 \
        18095
 
-VOLUME /opt/enterprise-analytics/var
+# Data directories
+VOLUME /opt/enterprise-analytics/etc /opt/enterprise-analytics/var/lib/couchbase


### PR DESCRIPTION
Relocate runit supervise directory to /run and declare volumes for /opt/couchbase/etc and /opt/couchbase/var/lib/couchbase, enabling containers to run with --read-only --tmpfs /run --tmpfs /tmp.