### PR TITLE
CBD-6606: Ensure generator treats 0.0.0 as the highest version

### DIFF
--- a/generate/generator/generate.go
+++ b/generate/generator/generate.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"io/ioutil"
 	"log"
+	"math"
 	"net/http"
 	"os"
 	"path"
@@ -623,6 +624,11 @@ func (variant DockerfileVariant) systemdWorkaround() bool {
 
 func intVer(v string) (int64, error) {
 	baseVer := strings.Split(v, "-")[0]
+
+	if baseVer == "0.0.0" {
+		return math.MaxInt64, nil
+	}
+
 	sections := strings.Split(baseVer, ".")
 	intVerSection := func(n int) string {
 		return fmt.Sprintf("%02s", sections[n])


### PR DESCRIPTION
Currently we do a version comparison and install python-httplib2 If the version of server is older than mad hatter, bzip2 if it is newer, however this does not account for 0.0.0 being a *high* version number, so master builds get the wrong package.