### PR TITLE
CBG-5062 Sync Gateway: switch to use in memory based backing store

### DIFF
--- a/generate/generator/generate.go
+++ b/generate/generator/generate.go
@@ -330,6 +330,7 @@ func generateDockerfile(variant DockerfileVariant) error {
 			"SYNC_GATEWAY_PACKAGE_URL":      variant.sgPackageUrl(),
 			"SYNC_GATEWAY_PACKAGE_FILENAME": variant.sgPackageFilename(),
 			"DOCKER_BASE_IMAGE":             variant.dockerBaseImage(),
+			"SYNC_GATEWAY_CONFIG":           variant.sgDefaultConfig(),
 		}
 
 	} else if variant.Product == ProductSandbox {
@@ -809,6 +810,20 @@ func (variant DockerfileVariant) releaseURL() string {
 			return "https://packages.couchbase.com/releases/" + string(variant.Product) + "/" + variant.Version
 		}
 	}
+}
+
+// sgDefaultConfig returns the config to use as the image's initial config,
+// relative to the examples directory installed by the Sync Gateway package.
+// serviceconfig.json is the config the packaged service starts with; since
+// 3.2.0 it bootstraps from a rosmar in-memory bucket store, so the container
+// runs standalone. Older versions fall back to the Couchbase Server example,
+// as their serviceconfig.json is still in the legacy format.
+func (variant DockerfileVariant) sgDefaultConfig() string {
+	productVer, _ := intVer(variant.Version)
+	if productVer >= 30200 {
+		return "serviceconfig.json"
+	}
+	return "startup_config/basic.json"
 }
 
 // Find the package URL for this Sync Gateway version

--- a/generate/templates/sync-gateway/Dockerfile.ubuntu.template
+++ b/generate/templates/sync-gateway/Dockerfile.ubuntu.template
@@ -31,7 +31,7 @@ RUN mkdir /opt/couchbase-sync-gateway/data
 
 # Copy sample service config as the initial config
 RUN mkdir /etc/sync_gateway \
-    && cp /opt/couchbase-sync-gateway/examples/startup_config/basic.json /etc/sync_gateway/config.json \
+    && cp /opt/couchbase-sync-gateway/examples/{{ .SYNC_GATEWAY_CONFIG }} /etc/sync_gateway/config.json \
     && chown -R sync_gateway:sync_gateway /etc/sync_gateway
 
 # Create log dir


### PR DESCRIPTION
CBG-5062 sgw: switch to use in memory based backing store

Use a config file for Sync Gateway that allows the base docker image to start up.

The default sync_gateway config file used by deb packages is examples/serviceconfig.json which loads an in memory (rosmar) copy of Sync Gateway.

The existing configuration file used is from examples/startup_config/basic.json which shows an example of how to connect to couchbase server but can't be used without a couchbase server instance. In a docker container couchbases://localhost is never going to be a path to a Couchbase Server instance.

Note:

I'm not at all attached to the mechanics of this implemenation. This file is only valid for Sync Gateway 3.2+ so I put an if statement to use the original file. I'm fine with not regenerating the older images - it seems `go generate` only creates new files for versions that don't exist anyway.